### PR TITLE
Feature: Add environment variable parsing.

### DIFF
--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -253,6 +253,10 @@ def format_parameters(app, title, show_special=True):
             if choices:
                 help_components.append(rf"[dim]\[choices: {choices}][/dim]")
 
+        if param.show_env_var in (None, True) and param.env_var:
+            env_vars = " ".join(param.env_var)
+            help_components.append(rf"[dim]\[env var: {env_vars}][/dim]")
+
         if not is_required(parameter) and (
             param.show_default or (param.show_default is None and parameter.default is not None)
         ):

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -145,9 +145,9 @@ class Parameter:
 
     env_var: Union[str, Iterable[str]] = field(default=[], converter=_str_to_tuple_converter)
     """
-    Attempt to use these environment variable values in the absence of a CLI-provided value.
-    If the environment variable is unset, Cyclopts will default to the function-signature default.
-    If multiple values are given, the left-most environment variable with a set-value will be used.
+    Fallback to environment variable(s) if CLI value not provided.
+    If multiple environment variables are given, the left-most environment variable with a set value will be used.
+    If no environment variable is set, Cyclopts will fallback to the function-signature default.
     """
 
     @property

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -137,6 +137,19 @@ class Parameter:
     If not specified, defaults to the docstring.
     """
 
+    show_env_var: Optional[bool] = field(default=None)
+    """
+    If a variable has ``env_var`` set, display the variable name in the help page.
+    Defaults to ``True``.
+    """
+
+    env_var: Union[str, Iterable[str]] = field(default=[], converter=_str_to_tuple_converter)
+    """
+    Attempt to use these environment variable values in the absence of a CLI-provided value.
+    If the environment variable is unset, Cyclopts will default to the function-signature default.
+    If multiple values are given, the left-most environment variable with a set-value will be used.
+    """
+
     @property
     def show_(self):
         if self.show is not None:

--- a/tests/test_bind_env_var.py
+++ b/tests/test_bind_env_var.py
@@ -1,9 +1,10 @@
 import inspect
 import os
 
+import pytest
 from typing_extensions import Annotated
 
-from cyclopts import Parameter
+from cyclopts import MissingArgumentError, Parameter
 
 
 def test_env_var_unset_use_signature_default(app):
@@ -34,6 +35,26 @@ def test_env_var_set_use_env_var(app):
     actual_command, actual_bind = app.parse_args([])
     assert actual_command == foo
     assert actual_bind == expected_bind
+
+
+def test_env_var_set_use_env_var_no_default(app):
+    @app.default
+    def foo(bar: Annotated[int, Parameter(env_var="BAR")]):
+        pass
+
+    os.environ["BAR"] = "456"
+
+    signature = inspect.signature(foo)
+    expected_bind = signature.bind(456)
+
+    actual_command, actual_bind = app.parse_args([])
+    assert actual_command == foo
+    assert actual_bind == expected_bind
+
+    os.environ.pop("BAR", None)
+
+    with pytest.raises(MissingArgumentError):
+        app.parse_args([], exit_on_error=False)
 
 
 def test_env_var_list_set_use_env_var(app):

--- a/tests/test_bind_env_var.py
+++ b/tests/test_bind_env_var.py
@@ -1,0 +1,68 @@
+import inspect
+import os
+
+from typing_extensions import Annotated
+
+from cyclopts import Parameter
+
+
+def test_env_var_unset_use_signature_default(app):
+    @app.default
+    def foo(bar: Annotated[int, Parameter(env_var="BAR")] = 123):
+        pass
+
+    os.environ.pop("BAR", None)
+
+    signature = inspect.signature(foo)
+    expected_bind = signature.bind()
+
+    actual_command, actual_bind = app.parse_args([])
+    assert actual_command == foo
+    assert actual_bind == expected_bind
+
+
+def test_env_var_set_use_env_var(app):
+    @app.default
+    def foo(bar: Annotated[int, Parameter(env_var="BAR")] = 123):
+        pass
+
+    os.environ["BAR"] = "456"
+
+    signature = inspect.signature(foo)
+    expected_bind = signature.bind(456)
+
+    actual_command, actual_bind = app.parse_args([])
+    assert actual_command == foo
+    assert actual_bind == expected_bind
+
+
+def test_env_var_list_set_use_env_var(app):
+    @app.default
+    def foo(bar: Annotated[int, Parameter(env_var=["BAR", "BAZ"])] = 123):
+        pass
+
+    os.environ.pop("BAR", None)
+    os.environ["BAZ"] = "456"
+
+    signature = inspect.signature(foo)
+    expected_bind = signature.bind(456)
+
+    actual_command, actual_bind = app.parse_args([])
+    assert actual_command == foo
+    assert actual_bind == expected_bind
+
+
+def test_env_var_unset_list_use_signature_default(app):
+    @app.default
+    def foo(bar: Annotated[int, Parameter(env_var=["BAR", "BAZ"])] = 123):
+        pass
+
+    os.environ.pop("BAR", None)
+    os.environ.pop("BAZ", None)
+
+    signature = inspect.signature(foo)
+    expected_bind = signature.bind()
+
+    actual_command, actual_bind = app.parse_args([])
+    assert actual_command == foo
+    assert actual_bind == expected_bind

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -415,6 +415,27 @@ def test_help_format_parameters_choices_enum(app, console):
     assert actual == expected
 
 
+def test_help_format_parameters_env_var(app, console):
+    @app.command
+    def cmd(
+        foo: Annotated[int, Parameter(env_var=["FOO", "BAR"], help="Docstring for foo.")] = 123,
+    ):
+        pass
+
+    with console.capture() as capture:
+        console.print(format_parameters(app["cmd"], app.help_title_parameters))
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO,--foo  Docstring for foo. [env var: FOO BAR] [default: 123]    │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
 def test_help_print_function(app, console):
     with console.capture() as capture:
         app.help_print(console=console)


### PR DESCRIPTION
Allows for environment variable parsing fallbacks:

```
@app.default
def foo(bar: Annotated[int, Parameter(env_var="BAR")] = 123):
    pass
```

The priority order is:
1. CLI-provided values
2. Values parsed from `Parameter.env_var`.
3. Default values from the function signature.

Addresses #18.