### PR TITLE
Handle mutable signature parameter defaults.

### DIFF
--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -7,6 +7,8 @@ from rich import box
 from rich.panel import Panel
 from rich.text import Text
 
+from cyclopts.utils import ParameterDict
+
 if TYPE_CHECKING:
     from cyclopts.core import App
 
@@ -77,7 +79,7 @@ class CycloptsError(Exception):
     Dictionary mapping CLI strings to python parameters.
     """
 
-    parameter2cli: Optional[Dict[inspect.Parameter, List[str]]] = None
+    parameter2cli: Optional[ParameterDict] = None
     """
     Dictionary mapping function parameters to possible CLI tokens.
     """

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -1,4 +1,7 @@
 import functools
+import inspect
+from collections.abc import MutableMapping
+from typing import Any, Iterator
 
 
 def record_init_kwargs(target: str):
@@ -17,3 +20,36 @@ def record_init_kwargs(target: str):
         return cls
 
     return decorator
+
+
+class ParameterDict(MutableMapping):
+    """A dictionary implementation that can handle ``inspect.Parameter`` as keys.
+
+    Traditional dictionaries don't always work because ``inspect.Parameter.default`` may be mutable.
+    """
+
+    def __init__(self):
+        self.store = {}
+
+    def _param_key(self, param: inspect.Parameter) -> tuple:
+        if not isinstance(param, inspect.Parameter):
+            raise TypeError("Key must be an inspect.Parameter")
+        return (param.name, param.kind, param.annotation)
+
+    def __getitem__(self, key: inspect.Parameter) -> Any:
+        return self.store[self._param_key(key)]
+
+    def __setitem__(self, key: inspect.Parameter, value: Any) -> None:
+        self.store[self._param_key(key)] = value
+
+    def __delitem__(self, key: inspect.Parameter) -> None:
+        del self.store[self._param_key(key)]
+
+    def __iter__(self) -> Iterator[inspect.Parameter]:
+        return iter(self.store)
+
+    def __len__(self) -> int:
+        return len(self.store)
+
+    def setdefault(self, key: inspect.Parameter, default: Any = None) -> Any:
+        return self.store.setdefault(self._param_key(key), default)

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 from collections.abc import MutableMapping
-from typing import Any, Iterator
+from typing import Any, Dict, Iterator, Optional
 
 
 def record_init_kwargs(target: str):
@@ -23,33 +23,46 @@ def record_init_kwargs(target: str):
 
 
 class ParameterDict(MutableMapping):
-    """A dictionary implementation that can handle ``inspect.Parameter`` as keys.
+    """A dictionary implementation that can handle mutable ``inspect.Parameter`` as keys."""
 
-    Traditional dictionaries don't always work because ``inspect.Parameter.default`` may be mutable.
-    """
-
-    def __init__(self):
+    def __init__(self, store: Optional[Dict[inspect.Parameter, Any]] = None):
         self.store = {}
+        self.reverse_mapping = {}
+        if store is not None:
+            for k, v in store.items():
+                self[k] = v
 
     def _param_key(self, param: inspect.Parameter) -> tuple:
         if not isinstance(param, inspect.Parameter):
-            raise TypeError("Key must be an inspect.Parameter")
+            raise TypeError(f"Key must be an inspect.Parameter; got {type(param)}.")
         return (param.name, param.kind, param.annotation)
 
     def __getitem__(self, key: inspect.Parameter) -> Any:
         return self.store[self._param_key(key)]
 
     def __setitem__(self, key: inspect.Parameter, value: Any) -> None:
-        self.store[self._param_key(key)] = value
+        processed_key = self._param_key(key)
+        self.store[processed_key] = value
+        self.reverse_mapping[processed_key] = key
 
     def __delitem__(self, key: inspect.Parameter) -> None:
-        del self.store[self._param_key(key)]
+        processed_key = self._param_key(key)
+        del self.store[processed_key]
+        del self.reverse_mapping[processed_key]
 
     def __iter__(self) -> Iterator[inspect.Parameter]:
-        return iter(self.store)
+        return iter(self.reverse_mapping.values())
 
     def __len__(self) -> int:
         return len(self.store)
 
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, inspect.Parameter):
+            raise TypeError(f"Key must be an inspect.Parameter; got {type(key)}.")
+        return self._param_key(key) in self.store
+
     def setdefault(self, key: inspect.Parameter, default: Any = None) -> Any:
-        return self.store.setdefault(self._param_key(key), default)
+        processed_key = self._param_key(key)
+        if processed_key not in self.store:
+            self.reverse_mapping[processed_key] = key
+        return self.store.setdefault(processed_key, default)

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -28,6 +28,25 @@ def test_keyword_list(app):
     assert actual_bind == expected_bind
 
 
+def test_keyword_list_mutable_default(app):
+    @app.command
+    def foo(a: List[int] = []):  # noqa: B006
+        pass
+
+    signature = inspect.signature(foo)
+    expected_bind = signature.bind([1, 2, 3])
+
+    actual_command, actual_bind = app.parse_args("foo --a=1 --a=2 --a 3")
+    assert actual_command == foo
+    assert actual_bind == expected_bind
+
+    expected_bind = signature.bind()
+
+    actual_command, actual_bind = app.parse_args("foo")
+    assert actual_command == foo
+    assert actual_bind == expected_bind
+
+
 def test_keyword_list_pos(app):
     @app.command
     def foo(a: List[int]):

--- a/tests/test_parameter2cli.py
+++ b/tests/test_parameter2cli.py
@@ -8,6 +8,7 @@ else:
 
 from cyclopts.bind import parameter2cli
 from cyclopts.parameter import Parameter
+from cyclopts.utils import ParameterDict
 
 
 def test_parameter2cli_positional_or_keyword():
@@ -16,7 +17,7 @@ def test_parameter2cli_positional_or_keyword():
 
     a_iparam = list(inspect.signature(foo).parameters.values())[0]
     actual = parameter2cli(foo)
-    assert actual == {a_iparam: ["--a"]}
+    assert actual == ParameterDict({a_iparam: ["--a"]})
 
 
 def test_parameter2cli_positional_only():
@@ -25,7 +26,7 @@ def test_parameter2cli_positional_only():
 
     a_iparam = list(inspect.signature(foo).parameters.values())[0]
     actual = parameter2cli(foo)
-    assert actual == {a_iparam: ["A"]}
+    assert actual == ParameterDict({a_iparam: ["A"]})
 
 
 def test_parameter2cli_keyword_only():
@@ -34,7 +35,7 @@ def test_parameter2cli_keyword_only():
 
     a_iparam = list(inspect.signature(foo).parameters.values())[0]
     actual = parameter2cli(foo)
-    assert actual == {a_iparam: ["--a"]}
+    assert actual == ParameterDict({a_iparam: ["--a"]})
 
 
 def test_parameter2cli_var_keyword():
@@ -43,7 +44,7 @@ def test_parameter2cli_var_keyword():
 
     a_iparam = list(inspect.signature(foo).parameters.values())[0]
     actual = parameter2cli(foo)
-    assert actual == {a_iparam: ["--a"]}
+    assert actual == ParameterDict({a_iparam: ["--a"]})
 
 
 def test_parameter2cli_var_positional():
@@ -52,4 +53,4 @@ def test_parameter2cli_var_positional():
 
     a_iparam = list(inspect.signature(foo).parameters.values())[0]
     actual = parameter2cli(foo)
-    assert actual == {a_iparam: ["A"]}
+    assert actual == ParameterDict({a_iparam: ["A"]})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+import inspect
+from typing import List
+
+from cyclopts.utils import ParameterDict
+
+
+def test_parameter_dict_immutable():
+    def foo(a: int, b: int = 3):
+        pass
+
+    parameter_dict = ParameterDict()
+    parameters = dict(inspect.signature(foo).parameters)
+
+    for name, parameter in parameters.items():
+        parameter_dict[parameter] = name
+
+    for name, parameter in parameters.items():
+        assert parameter_dict[parameter] == name
+
+
+def test_parameter_dict_mutable():
+    def foo(a: int, b: List[int] = []):  # noqa: B006
+        pass
+
+    parameter_dict = ParameterDict()
+    parameters = dict(inspect.signature(foo).parameters)
+
+    for name, parameter in parameters.items():
+        parameter_dict[parameter] = name
+
+    for name, parameter in parameters.items():
+        assert parameter_dict[parameter] == name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,10 @@ def test_parameter_dict_immutable():
     for name, parameter in parameters.items():
         assert parameter_dict[parameter] == name
 
+    # Test __contains__
+    assert parameters["a"] in parameter_dict
+    assert parameters["b"] in parameter_dict
+
 
 def test_parameter_dict_mutable():
     def foo(a: int, b: List[int] = []):  # noqa: B006
@@ -30,3 +34,7 @@ def test_parameter_dict_mutable():
 
     for name, parameter in parameters.items():
         assert parameter_dict[parameter] == name
+
+    # Test __contains__
+    assert parameters["a"] in parameter_dict
+    assert parameters["b"] in parameter_dict


### PR DESCRIPTION
While it's bad practice to set parameter defaults to mutable defaults, Cyclopts should be able to handle it:

```
@app.command
def foo(a: List[int] = []):  # noqa: B006
    pass
```

Previously Cyclopts was using a vanilla dictionary with `inspect.Parameter` as keys. `inspect.Parameter` is no longer hashable if `inspect.Parameter.default` is mutable, so we made our own custom dictionary `ParameterDict` that doesn't include the `default` when hashing.

Addresses the hashing issue bug-report in #31.