### PR TITLE
Help parsing refactor

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -516,7 +516,18 @@ class App:
         try:
             # Special flags (help/version) get bubbled up to the root app.
             # The root ``help_print`` will then traverse the meta app linked list.
-            if any(flag in tokens for flag in self.help_flags):
+
+            # The Help Flag is allowed to be anywhere in the token stream.
+            help_flag_index = None
+            for help_flag in self.help_flags:
+                try:
+                    help_flag_index = tokens.index(help_flag)
+                    break
+                except ValueError:
+                    pass
+
+            if help_flag_index is not None:
+                tokens.pop(help_flag_index)
                 command = self.help_print
                 while meta_parent := meta_parent._meta_parent:
                     command = meta_parent.help_print

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -40,9 +40,9 @@ from cyclopts.group import Group, to_group_converter
 from cyclopts.group_extractors import groups_from_app, inverse_groups_from_app
 from cyclopts.help import (
     HelpPanel,
-    format_command_rows,
+    create_parameter_help_panel,
+    format_command_entries,
     format_doc,
-    format_group_parameters,
     format_usage,
 )
 from cyclopts.parameter import Parameter, validate_command
@@ -657,7 +657,7 @@ class App:
                     if not group.show:
                         continue
                     cparams = [command.iparam_to_cparam[x] for x in iparams]
-                    console.print(format_group_parameters(group, iparams, cparams))
+                    console.print(create_parameter_help_panel(group, iparams, cparams))
 
             # Print command groups
             # We need to deduplicate groups from meta-app.
@@ -676,7 +676,7 @@ class App:
                 if group.help:
                     command_panel.description = group.help
 
-                command_panel.entries.extend(format_command_rows(elements))
+                command_panel.entries.extend(format_command_entries(elements))
 
         for _, help_panel in sorted(command_panels.items()):
             if not help_panel.entries:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -40,7 +40,6 @@ from cyclopts.group import Group, to_group_converter
 from cyclopts.group_extractors import groups_from_app, inverse_groups_from_app
 from cyclopts.help import (
     HelpPanel,
-    create_panel_table_commands,
     format_command_rows,
     format_doc,
     format_group_parameters,
@@ -669,7 +668,10 @@ class App:
                 try:
                     command_panel = command_panels[group.name]
                 except KeyError:
-                    command_panels[group.name] = command_panel = HelpPanel(title=group.name)
+                    command_panels[group.name] = command_panel = HelpPanel(
+                        format="command",
+                        title=group.name,
+                    )
 
                 if group.help:
                     command_panel.description = group.help

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -171,7 +171,7 @@ def _get_choices(type_: Type) -> str:
     return choices
 
 
-def format_group_parameters(group: "Group", iparams, cparams: List[Parameter]) -> HelpPanel:
+def create_parameter_help_panel(group: "Group", iparams, cparams: List[Parameter]) -> HelpPanel:
     icparams = [(ip, cp) for ip, cp in zip(iparams, cparams) if cp.show]
     iparams, cparams = (list(x) for x in zip(*icparams))
 
@@ -240,7 +240,7 @@ def format_group_parameters(group: "Group", iparams, cparams: List[Parameter]) -
     return help_panel
 
 
-def format_command_rows(elements) -> List:
+def format_command_entries(elements) -> List:
     entries = []
     for element in elements:
         entry = HelpEntry(

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -16,9 +16,9 @@ from cyclopts import App, Group, Parameter
 from cyclopts.help import (
     HelpEntry,
     HelpPanel,
-    format_command_rows,
+    create_parameter_help_panel,
+    format_command_entries,
     format_doc,
-    format_group_parameters,
     format_usage,
 )
 from cyclopts.resolve import ResolvedCommand
@@ -125,7 +125,7 @@ def test_format_commands_docstring(app, console):
         pass
 
     panel = HelpPanel(title="Commands", format="command")
-    panel.entries.extend(format_command_rows((app["foo"],)))
+    panel.entries.extend(format_command_entries((app["foo"],)))
     with console.capture() as capture:
         console.print(panel)
 
@@ -144,7 +144,7 @@ def test_format_commands_explicit_help(app, console):
         pass
 
     panel = HelpPanel(title="Commands", format="command")
-    panel.entries.extend(format_command_rows((app["foo"],)))
+    panel.entries.extend(format_command_entries((app["foo"],)))
     with console.capture() as capture:
         console.print(panel)
 
@@ -166,7 +166,7 @@ def test_format_commands_explicit_name(app, console):
         pass
 
     panel = HelpPanel(title="Commands", format="command")
-    panel.entries.extend(format_command_rows((app["bar"],)))
+    panel.entries.extend(format_command_entries((app["bar"],)))
     with console.capture() as capture:
         console.print(panel)
 
@@ -195,7 +195,7 @@ def capture_format_group_parameters(console, default_function_groups):
         with console.capture() as capture:
             group, iparams = command.groups_iparams[0]
             cparams = [command.iparam_to_cparam[x] for x in iparams]
-            console.print(format_group_parameters(group, iparams, cparams))
+            console.print(create_parameter_help_panel(group, iparams, cparams))
 
         return capture.get()
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -14,7 +14,8 @@ else:
 
 from cyclopts import App, Group, Parameter
 from cyclopts.help import (
-    create_panel_table_commands,
+    HelpEntry,
+    HelpPanel,
     format_command_rows,
     format_doc,
     format_group_parameters,
@@ -123,10 +124,9 @@ def test_format_commands_docstring(app, console):
         """
         pass
 
-    panel, table, text = create_panel_table_commands(title="Commands")
+    panel = HelpPanel(title="Commands", format="command")
+    panel.entries.extend(format_command_rows((app["foo"],)))
     with console.capture() as capture:
-        for row in format_command_rows((app["foo"],)):
-            table.add_row(*row)
         console.print(panel)
 
     actual = capture.get()
@@ -143,10 +143,9 @@ def test_format_commands_explicit_help(app, console):
         """Should not be shown."""
         pass
 
-    panel, table, text = create_panel_table_commands(title="Commands")
+    panel = HelpPanel(title="Commands", format="command")
+    panel.entries.extend(format_command_rows((app["foo"],)))
     with console.capture() as capture:
-        for row in format_command_rows((app["foo"],)):
-            table.add_row(*row)
         console.print(panel)
 
     actual = capture.get()
@@ -166,10 +165,9 @@ def test_format_commands_explicit_name(app, console):
         """
         pass
 
-    panel, table, text = create_panel_table_commands(title="Commands")
+    panel = HelpPanel(title="Commands", format="command")
+    panel.entries.extend(format_command_rows((app["bar"],)))
     with console.capture() as capture:
-        for row in format_command_rows((app["bar"],)):
-            table.add_row(*row)
         console.print(panel)
 
     actual = capture.get()


### PR DESCRIPTION
Refactors help logic to separate rendering from gathering data.

Also fixes a bug where bubbling up the `help_print` would fail if the help_flags differ across the app stack.