### PR TITLE
Predefined Annotated Types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@ repos:
       - id: check-ast
       - id: check-builtin-literals
       - id: check-case-conflict
-      - id: check-docstring-first
       - id: check-shebang-scripts-are-executable
       - id: check-merge-conflict
       - id: check-json

--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -14,11 +14,12 @@ __all__ = [
     "Parameter",
     "UnusedCliTokensError",
     "ValidationError",
-    "coerce",
+    "convert",
+    "types",
     "validators",
 ]
 
-from cyclopts.coercion import coerce
+from cyclopts._convert import convert
 from cyclopts.core import App
 from cyclopts.exceptions import (
     CoercionError,
@@ -34,4 +35,4 @@ from cyclopts.group import Group
 from cyclopts.parameter import Parameter
 from cyclopts.protocols import Dispatcher
 
-from . import validators
+from . import types, validators

--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -264,10 +264,10 @@ def convert(type_: Type, *args: str, converter: Optional[Callable] = None):
                 raise ValueError("A tuple must have 0 or 1 inner-types.")
 
             if inner_token_count == 1:
-                out = tuple(_convert(inner_type, x) for x in args)
+                out = tuple(_convert(inner_type, x, converter=converter) for x in args)
             else:
                 out = tuple(
-                    _convert(inner_type, args[i : i + inner_token_count])
+                    _convert(inner_type, args[i : i + inner_token_count], converter=converter)
                     for i in range(0, len(args), inner_token_count)
                 )
             return out
@@ -281,14 +281,14 @@ def convert(type_: Type, *args: str, converter: Optional[Callable] = None):
             it = iter(args)
             batched = [[next(it) for _ in range(size)] for size in args_per_convert]
             batched = [elem[0] if len(elem) == 1 else elem for elem in batched]
-            out = tuple(_convert(inner_type, arg) for inner_type, arg in zip(inner_types, batched))
+            out = tuple(_convert(inner_type, arg, converter=converter) for inner_type, arg in zip(inner_types, batched))
         return out
     elif (origin_type or type_) in _iterable_types or origin_type is collections.abc.Iterable:
-        return _convert(type_, args)
+        return _convert(type_, args, converter=converter)
     elif len(args) == 1:
-        return _convert(type_, args[0])
+        return _convert(type_, args[0], converter=converter)
     else:
-        return [_convert(type_, item) for item in args]
+        return [_convert(type_, item, converter=converter) for item in args]
 
 
 def token_count(type_: Union[Type, inspect.Parameter]) -> Tuple[int, bool]:

--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -5,7 +5,7 @@ import shlex
 import sys
 from typing import Any, Dict, Iterable, List, Tuple, Union, get_origin
 
-from cyclopts.coercion import token_count
+from cyclopts._convert import token_count
 from cyclopts.exceptions import (
     CoercionError,
     CycloptsError,

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -26,8 +26,8 @@ else:  # pragma: no cover
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as importlib_metadata_version
 
+from cyclopts._convert import optional_to_tuple_converter, to_list_converter, to_tuple_converter
 from cyclopts.bind import create_bound_arguments, normalize_tokens
-from cyclopts.coercion import optional_to_tuple_converter, to_list_converter, to_tuple_converter
 from cyclopts.exceptions import (
     CommandCollisionError,
     CycloptsError,

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -225,7 +225,7 @@ class MissingArgumentError(CycloptsError):
     """
 
     def __str__(self):
-        from cyclopts.coercion import token_count
+        from cyclopts._convert import token_count
 
         count, _ = token_count(self.parameter)
         if count == 0:

--- a/cyclopts/group.py
+++ b/cyclopts/group.py
@@ -8,7 +8,7 @@ from cyclopts.utils import Sentinel, is_iterable
 if TYPE_CHECKING:
     from cyclopts.parameter import Parameter
 
-from cyclopts.coercion import to_tuple_converter
+from cyclopts._convert import to_tuple_converter
 from cyclopts.utils import resolve_callables
 
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -4,9 +4,9 @@ from typing import Any, Callable, Optional, Tuple, Type, Union, cast, get_args, 
 import attrs
 from attrs import field, frozen
 
-from cyclopts.coercion import (
+from cyclopts._convert import (
     AnnotatedType,
-    coerce,
+    convert,
     get_origin_and_validate,
     optional_to_tuple_converter,
     resolve,
@@ -48,7 +48,7 @@ class Parameter:
         converter=lambda x: cast(Tuple[str, ...], to_tuple_converter(x)),
     )
 
-    converter: Callable = field(default=None, converter=attrs.converters.default_if_none(coerce))
+    converter: Callable = field(default=None, converter=attrs.converters.default_if_none(convert))
 
     validator: Tuple[Callable, ...] = field(
         default=(),

--- a/cyclopts/types.py
+++ b/cyclopts/types.py
@@ -41,17 +41,31 @@ def _path_resolve_converter(type_, *args):
     return convert(type_, *args, converter=lambda _, x: Path(x).resolve())
 
 
-Directory = Annotated[Path, Parameter(validator=validators.Path(file_okay=False))]
-File = Annotated[Path, Parameter(validator=validators.Path(dir_okay=False))]
 ExistingPath = Annotated[Path, Parameter(validator=validators.Path(exists=True))]
-ExistingDirectory = Annotated[Path, Parameter(validator=validators.Path(exists=True, file_okay=False))]
-ExistingFile = Annotated[Path, Parameter(validator=validators.Path(exists=True, dir_okay=False))]
+"A :class:`~pathlib.Path` file or directory that **must** exist."
 
-ResolvedDirectory = Annotated[Directory, Parameter(converter=_path_resolve_converter)]
-ResolvedFile = Annotated[File, Parameter(converter=_path_resolve_converter)]
+ResolvedPath = Annotated[Path, Parameter(converter=_path_resolve_converter)]
+"A :class:`~pathlib.Path` file or directory. :meth:`~pathlib.Path.resolve` is invoked prior to returning the path."
 ResolvedExistingPath = Annotated[ExistingPath, Parameter(converter=_path_resolve_converter)]
+"A :class:`~pathlib.Path` file or directory that **must** exist. :meth:`~pathlib.Path.resolve` is invoked prior to returning the path."
+
+Directory = Annotated[Path, Parameter(validator=validators.Path(file_okay=False))]
+"A :class:`~pathlib.Path` that **must** be a directory (or not exist)."
+ExistingDirectory = Annotated[Path, Parameter(validator=validators.Path(exists=True, file_okay=False))]
+"A :class:`~pathlib.Path` directory that **must** exist."
+ResolvedDirectory = Annotated[Directory, Parameter(converter=_path_resolve_converter)]
+"A :class:`~pathlib.Path` directory. :meth:`~pathlib.Path.resolve` is invoked prior to returning the path."
 ResolvedExistingDirectory = Annotated[ExistingDirectory, Parameter(converter=_path_resolve_converter)]
+"A :class:`~pathlib.Path` directory that **must** exist. :meth:`~pathlib.Path.resolve` is invoked prior to returning the path."
+
+File = Annotated[Path, Parameter(validator=validators.Path(dir_okay=False))]
+"A :class:`~pathlib.File` that **must** be a file (or not exist)."
+ExistingFile = Annotated[Path, Parameter(validator=validators.Path(exists=True, dir_okay=False))]
+"A :class:`~pathlib.Path` file that **must** exist."
+ResolvedFile = Annotated[File, Parameter(converter=_path_resolve_converter)]
+"A :class:`~pathlib.Path` file. :meth:`~pathlib.Path.resolve` is invoked prior to returning the path."
 ResolvedExistingFile = Annotated[ExistingFile, Parameter(converter=_path_resolve_converter)]
+"A :class:`~pathlib.Path` file that **must** exist. :meth:`~pathlib.Path.resolve` is invoked prior to returning the path."
 
 
 ##########
@@ -59,11 +73,19 @@ ResolvedExistingFile = Annotated[ExistingFile, Parameter(converter=_path_resolve
 ##########
 # foo
 PositiveFloat = Annotated[float, Parameter(validator=validators.Number(gt=0))]
+"A float that **must** be ``>0``."
 NonNegativeFloat = Annotated[float, Parameter(validator=validators.Number(gte=0))]
+"A float that **must** be ``>=0``."
 NegativeFloat = Annotated[float, Parameter(validator=validators.Number(lt=0))]
+"A float that **must** be ``<0``."
 NonPositiveFloat = Annotated[float, Parameter(validator=validators.Number(lte=0))]
+"A float that **must** be ``<=0``."
 
 PositiveInt = Annotated[int, Parameter(validator=validators.Number(gt=0))]
+"An int that **must** be ``>0``."
 NonNegativeInt = Annotated[int, Parameter(validator=validators.Number(gte=0))]
+"An int that **must** be ``>=0``."
 NegativeInt = Annotated[int, Parameter(validator=validators.Number(lt=0))]
+"An int that **must** be ``<0``."
 NonPositiveInt = Annotated[int, Parameter(validator=validators.Number(lte=0))]
+"An int that **must** be ``<=0``."

--- a/cyclopts/types.py
+++ b/cyclopts/types.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+from cyclopts import Parameter, validators
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated  # pragma: no cover
+else:
+    from typing import Annotated  # pragma: no cover
+
+__all__ = [
+    # Path
+    "ExistingPath",
+    "ExistingFile",
+    "ExistingDirectory",
+    "Directory",
+    "File",
+    # Number
+    "PositiveFloat",
+    "NonNegativeFloat",
+    "NegativeFloat",
+    "NonPositiveFloat",
+    "PositiveInt",
+    "NonNegativeInt",
+    "NegativeInt",
+    "NonPositiveInt",
+]
+
+
+########
+# Path #
+########
+def _resolve_converter(type_, *args):
+    pass
+
+
+Directory = Annotated[Path, Parameter(validator=validators.Path(file_okay=False))]
+File = Annotated[Path, Parameter(validator=validators.Path(dir_okay=False))]
+ExistingPath = Annotated[Path, Parameter(validator=validators.Path(exists=True))]
+ExistingDirectory = Annotated[Path, Parameter(validator=validators.Path(exists=True, file_okay=False))]
+ExistingFile = Annotated[Path, Parameter(validator=validators.Path(exists=True, dir_okay=False))]
+
+
+##########
+# Number #
+##########
+# foo
+PositiveFloat = Annotated[float, Parameter(validator=validators.Number(gt=0))]
+NonNegativeFloat = Annotated[float, Parameter(validator=validators.Number(gte=0))]
+NegativeFloat = Annotated[float, Parameter(validator=validators.Number(lt=0))]
+NonPositiveFloat = Annotated[float, Parameter(validator=validators.Number(lte=0))]
+
+PositiveInt = Annotated[int, Parameter(validator=validators.Number(gt=0))]
+NonNegativeInt = Annotated[int, Parameter(validator=validators.Number(gte=0))]
+NegativeInt = Annotated[int, Parameter(validator=validators.Number(lt=0))]
+NonPositiveInt = Annotated[int, Parameter(validator=validators.Number(lte=0))]

--- a/cyclopts/types.py
+++ b/cyclopts/types.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
-from cyclopts import Parameter, validators
+from cyclopts import validators
+from cyclopts._convert import convert
+from cyclopts.parameter import Parameter
 
 if sys.version_info < (3, 9):
     from typing_extensions import Annotated  # pragma: no cover
@@ -15,6 +17,11 @@ __all__ = [
     "ExistingDirectory",
     "Directory",
     "File",
+    "ResolvedExistingPath",
+    "ResolvedExistingFile",
+    "ResolvedExistingDirectory",
+    "ResolvedDirectory",
+    "ResolvedFile",
     # Number
     "PositiveFloat",
     "NonNegativeFloat",
@@ -30,8 +37,8 @@ __all__ = [
 ########
 # Path #
 ########
-def _resolve_converter(type_, *args):
-    pass
+def _path_resolve_converter(type_, *args):
+    return convert(type_, *args, converter=lambda _, x: Path(x).resolve())
 
 
 Directory = Annotated[Path, Parameter(validator=validators.Path(file_okay=False))]
@@ -39,6 +46,12 @@ File = Annotated[Path, Parameter(validator=validators.Path(dir_okay=False))]
 ExistingPath = Annotated[Path, Parameter(validator=validators.Path(exists=True))]
 ExistingDirectory = Annotated[Path, Parameter(validator=validators.Path(exists=True, file_okay=False))]
 ExistingFile = Annotated[Path, Parameter(validator=validators.Path(exists=True, dir_okay=False))]
+
+ResolvedDirectory = Annotated[Directory, Parameter(converter=_path_resolve_converter)]
+ResolvedFile = Annotated[File, Parameter(converter=_path_resolve_converter)]
+ResolvedExistingPath = Annotated[ExistingPath, Parameter(converter=_path_resolve_converter)]
+ResolvedExistingDirectory = Annotated[ExistingDirectory, Parameter(converter=_path_resolve_converter)]
+ResolvedExistingFile = Annotated[ExistingFile, Parameter(converter=_path_resolve_converter)]
 
 
 ##########

--- a/cyclopts/validators/_path.py
+++ b/cyclopts/validators/_path.py
@@ -9,7 +9,7 @@ class Path:
     """Assertions on properties of :class:`pathlib.Path`."""
 
     exists: bool = False
-    """If ``True``, specified path must exist. Defaults to ``False``."""
+    """If ``True``, specified path **must** exist. Defaults to ``False``."""
 
     file_okay: bool = True
     """
@@ -33,11 +33,11 @@ class Path:
         if not isinstance(path, pathlib.Path):
             raise TypeError
 
-        if self.exists and not path.exists():
+        if path.exists():
+            if not self.file_okay and path.is_file():
+                raise ValueError(f"Only directory input is allowed but {path} is a file.")
+
+            if not self.dir_okay and path.is_dir():
+                raise ValueError(f"Only file input is allowed but {path} is a directory.")
+        elif self.exists:
             raise ValueError(f"{path} does not exist.")
-
-        if not self.file_okay and path.is_file():
-            raise ValueError(f"Only directory input is allowed but {path} is a file.")
-
-        if not self.dir_okay and path.is_dir():
-            raise ValueError(f"Only file input is allowed but {path} is a directory.")

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -469,14 +469,44 @@ Cyclopts has several builtin validators for common CLI inputs.
    :members:
 
 
+.. _Annotated Types:
+
 -----
 Types
 -----
 Cyclopts has builtin pre-defined annotated-types for common validation configurations.
+All definitions in this section are just predefined annotations for convenience:
+
+.. code-block:: python
+
+   Annotated[..., Parameter(...)]
+
+Due to Cyclopts's advanced :class:`.Parameter` resolution engine, these annotations can themselves be annotated. E.g:
+
+.. code-block::
+
+   Annotated[PositiveInt, Parameter(...)]
+
+.. _Annotated Path Types:
+
+^^^^
+Path
+^^^^
+:class:`~pathlib.Path` annotated types for checking existence, type, and performing path-resolution.
 
 .. automodule:: cyclopts.types
-   :members:
-   :undoc-members:
+   :members: ExistingPath, ResolvedPath, ResolvedExistingPath, Directory, ExistingDirectory, ResolvedDirectory, ResolvedExistingDirectory, File, ExistingFile, ResolvedFile, ResolvedExistingFile
+
+.. _Annotated Number Types:
+
+^^^^^^
+Number
+^^^^^^
+Annotated types for checking common int/float value constraints.
+
+.. automodule:: cyclopts.types
+   :noindex:
+   :members: PositiveFloat, NonNegativeFloat, NegativeFloat, NonPositiveFloat, PositiveInt, NonNegativeInt, NegativeInt, NonPositiveInt
 
 ----------
 Exceptions

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -449,7 +449,7 @@ API
          ╰─────────────────────────────────────────────────────────╯
 
 
-.. autofunction:: cyclopts.coerce
+.. autofunction:: cyclopts.convert
 
 
 .. _API Validators:
@@ -468,6 +468,15 @@ Cyclopts has several builtin validators for common CLI inputs.
 .. autoclass:: cyclopts.validators.Path
    :members:
 
+
+-----
+Types
+-----
+Cyclopts has builtin pre-defined annotated-types for common validation configurations.
+
+.. automodule:: cyclopts.types
+   :members:
+   :undoc-members:
 
 ----------
 Exceptions

--- a/docs/source/parameter_validators.rst
+++ b/docs/source/parameter_validators.rst
@@ -52,6 +52,20 @@ The :class:`.Number` validator can set minimum and maximum input values.
    │ Invalid value for --n. Must be < 16                              │
    ╰──────────────────────────────────────────────────────────────────╯
 
+The following pre-defined annotated types are available in :mod:`cyclopts.types`:
+
+.. code-block::
+
+   PositiveFloat = Annotated[float, Parameter(validator=validators.Number(gt=0))]
+   NonNegativeFloat = Annotated[float, Parameter(validator=validators.Number(gte=0))]
+   NegativeFloat = Annotated[float, Parameter(validator=validators.Number(lt=0))]
+   NonPositiveFloat = Annotated[float, Parameter(validator=validators.Number(lte=0))]
+
+   PositiveInt = Annotated[int, Parameter(validator=validators.Number(gt=0))]
+   NonNegativeInt = Annotated[int, Parameter(validator=validators.Number(gte=0))]
+   NegativeInt = Annotated[int, Parameter(validator=validators.Number(lt=0))]
+   NonPositiveInt = Annotated[int, Parameter(validator=validators.Number(lte=0))]
+
 ----
 Path
 ----
@@ -86,3 +100,13 @@ of the parsed :class:`pathlib.Path` object, such as asserting the file must exis
    ╭─ Error ─────────────────────────────────────────────────────────────────╮
    │ Invalid value for --path. this_file_does_not_exist.txt does not exist.  │
    ╰─────────────────────────────────────────────────────────────────────────╯
+
+The following pre-defined annotated types are available in :mod:`cyclopts.types`:
+
+.. code-block::
+
+   Directory = Annotated[Path, Parameter(validator=validators.Path(file_okay=False))]
+   File = Annotated[Path, Parameter(validator=validators.Path(dir_okay=False))]
+   ExistingPath = Annotated[Path, Parameter(validator=validators.Path(exists=True))]
+   ExistingDirectory = Annotated[Path, Parameter(validator=validators.Path(exists=True, file_okay=False))]
+   ExistingFile = Annotated[Path, Parameter(validator=validators.Path(exists=True, dir_okay=False))]

--- a/docs/source/parameter_validators.rst
+++ b/docs/source/parameter_validators.rst
@@ -19,53 +19,6 @@ More than one validator can be supplied as a list to the ``validator`` field.
 
 Cyclopts has some builtin common validators in the :ref:`cyclopts.validators <API Validators>` module.
 
-------
-Number
-------
-The :class:`.Number` validator can set minimum and maximum input values.
-
-.. code-block:: python
-
-   from cyclopts import App, Parameter, validators
-   from typing import Annotated
-
-   app = App()
-
-
-   @app.default()
-   def foo(n: Annotated[int, Parameter(validator=validators.Number(gte=0, lt=16))]):
-       print(f"Your number in hex is {str(hex(n))[2]}.")
-
-
-   app()
-
-.. code-block:: console
-
-   $ my-script 0
-   Your number in hex is 0.
-
-   $ my-script 15
-   Your number in hex is f.
-
-   $ my-script 16
-   ╭─ Error ──────────────────────────────────────────────────────────╮
-   │ Invalid value for --n. Must be < 16                              │
-   ╰──────────────────────────────────────────────────────────────────╯
-
-The following pre-defined annotated types are available in :mod:`cyclopts.types`:
-
-.. code-block::
-
-   PositiveFloat = Annotated[float, Parameter(validator=validators.Number(gt=0))]
-   NonNegativeFloat = Annotated[float, Parameter(validator=validators.Number(gte=0))]
-   NegativeFloat = Annotated[float, Parameter(validator=validators.Number(lt=0))]
-   NonPositiveFloat = Annotated[float, Parameter(validator=validators.Number(lte=0))]
-
-   PositiveInt = Annotated[int, Parameter(validator=validators.Number(gt=0))]
-   NonNegativeInt = Annotated[int, Parameter(validator=validators.Number(gte=0))]
-   NegativeInt = Annotated[int, Parameter(validator=validators.Number(lt=0))]
-   NonPositiveInt = Annotated[int, Parameter(validator=validators.Number(lte=0))]
-
 ----
 Path
 ----
@@ -101,12 +54,39 @@ of the parsed :class:`pathlib.Path` object, such as asserting the file must exis
    │ Invalid value for --path. this_file_does_not_exist.txt does not exist.  │
    ╰─────────────────────────────────────────────────────────────────────────╯
 
-The following pre-defined annotated types are available in :mod:`cyclopts.types`:
+See :ref:`Annotated Path Types <Annotated Path Types>` for Annotated-Type equivalents of common Path converter/validators.
 
-.. code-block::
+------
+Number
+------
+The :class:`.Number` validator can set minimum and maximum input values.
 
-   Directory = Annotated[Path, Parameter(validator=validators.Path(file_okay=False))]
-   File = Annotated[Path, Parameter(validator=validators.Path(dir_okay=False))]
-   ExistingPath = Annotated[Path, Parameter(validator=validators.Path(exists=True))]
-   ExistingDirectory = Annotated[Path, Parameter(validator=validators.Path(exists=True, file_okay=False))]
-   ExistingFile = Annotated[Path, Parameter(validator=validators.Path(exists=True, dir_okay=False))]
+.. code-block:: python
+
+   from cyclopts import App, Parameter, validators
+   from typing import Annotated
+
+   app = App()
+
+
+   @app.default()
+   def foo(n: Annotated[int, Parameter(validator=validators.Number(gte=0, lt=16))]):
+       print(f"Your number in hex is {str(hex(n))[2]}.")
+
+
+   app()
+
+.. code-block:: console
+
+   $ my-script 0
+   Your number in hex is 0.
+
+   $ my-script 15
+   Your number in hex is f.
+
+   $ my-script 16
+   ╭─ Error ──────────────────────────────────────────────────────────╮
+   │ Invalid value for --n. Must be < 16                              │
+   ╰──────────────────────────────────────────────────────────────────╯
+
+See :ref:`Annotated Number Types <Annotated Number Types>` for Annotated-Type equivalents of common Number converter/validators.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import inspect
+from pathlib import Path
 
 import pytest
 from rich.console import Console
@@ -60,6 +61,9 @@ def convert(app):
         if n_times_called:
             raise pytest.UsageError("convert fixture can only be called once per test.")
         n_times_called += 1
+
+        if isinstance(cmd, Path):
+            cmd = cmd.as_posix()
 
         @app.default
         def target(arg1: type_):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,27 @@ def assert_parse_args_partial(app):
         assert actual_bind == expected_bind
 
     return inner
+
+
+@pytest.fixture
+def convert(app):
+    """Function that performs a conversion for a given type/cmd pair.
+
+    Goes through the whole app stack.
+    Can only be called once per test.
+    """
+    n_times_called = 0
+
+    def inner(type_, cmd):
+        nonlocal n_times_called
+        if n_times_called:
+            raise pytest.UsageError("convert fixture can only be called once per test.")
+        n_times_called += 1
+
+        @app.default
+        def target(arg1: type_):
+            return arg1
+
+        return app(cmd, exit_on_error=False)
+
+    return inner

--- a/tests/test_bind_custom_type.py
+++ b/tests/test_bind_custom_type.py
@@ -9,7 +9,7 @@ if sys.version_info < (3, 9):
 else:
     from typing import Annotated
 
-from cyclopts import Parameter, coerce
+from cyclopts import Parameter, convert
 
 
 @frozen

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -12,7 +12,7 @@ else:
     from typing import Annotated
 
 from cyclopts import CoercionError
-from cyclopts.coercion import coerce, resolve, token_count
+from cyclopts._convert import convert, resolve, token_count
 
 
 def _assert_tuple(expected, actual):
@@ -83,46 +83,46 @@ def test_token_count_iterable():
 
 
 def test_coerce_bool():
-    assert True is coerce(bool, "true")
-    assert False is coerce(bool, "false")
+    assert True is convert(bool, "true")
+    assert False is convert(bool, "false")
 
 
 def test_coerce_error():
     with pytest.raises(CoercionError):
-        coerce(bool, "foo")
+        convert(bool, "foo")
 
 
 def test_coerce_int():
-    assert 123 == coerce(int, "123")
+    assert 123 == convert(int, "123")
 
 
 def test_coerce_annotated_int():
-    assert [123, 456] == coerce(Annotated[int, "foo"], "123", "456")
-    assert [123, 456] == coerce(Annotated[List[int], "foo"], "123", "456")
+    assert [123, 456] == convert(Annotated[int, "foo"], "123", "456")
+    assert [123, 456] == convert(Annotated[List[int], "foo"], "123", "456")
 
 
 def test_coerce_optional_annotated_int():
-    assert [123, 456] == coerce(Optional[Annotated[int, "foo"]], "123", "456")
-    assert [123, 456] == coerce(Optional[Annotated[List[int], "foo"]], "123", "456")
+    assert [123, 456] == convert(Optional[Annotated[int, "foo"]], "123", "456")
+    assert [123, 456] == convert(Optional[Annotated[List[int], "foo"]], "123", "456")
 
 
 def test_coerce_annotated_union_str_secondary_choice():
-    assert 123 == coerce(Union[None, int, str], "123")
-    assert "foo" == coerce(Union[None, int, str], "foo")
+    assert 123 == convert(Union[None, int, str], "123")
+    assert "foo" == convert(Union[None, int, str], "foo")
 
     with pytest.raises(CoercionError):
-        coerce(Union[None, int, float], "invalid-choice")
+        convert(Union[None, int, float], "invalid-choice")
 
 
 def test_coerce_annotated_nested_union_str_secondary_choice():
-    assert 123 == coerce(Union[None, Union[int, str]], "123")
-    assert "foo" == coerce(Union[None, Union[int, str]], "foo")
+    assert 123 == convert(Union[None, Union[int, str]], "123")
+    assert "foo" == convert(Union[None, Union[int, str]], "foo")
 
 
 def test_coerce_annotated_union_int():
-    assert 123 == coerce(Annotated[Union[None, int, float], "foo"], "123")
-    assert [123, 456] == coerce(Annotated[int, "foo"], "123", "456")
-    assert [123, 456] == coerce(Annotated[Union[None, int, float], "foo"], "123", "456")
+    assert 123 == convert(Annotated[Union[None, int, float], "foo"], "123")
+    assert [123, 456] == convert(Annotated[int, "foo"], "123", "456")
+    assert [123, 456] == convert(Annotated[Union[None, int, float], "foo"], "123", "456")
 
 
 def test_coerce_enum():
@@ -132,119 +132,119 @@ def test_coerce_enum():
         PROD = auto()
         _PROD_OLD = auto()
 
-    assert SoftwareEnvironment.STAGING == coerce(SoftwareEnvironment, "staging")
-    assert SoftwareEnvironment._PROD_OLD == coerce(SoftwareEnvironment, "prod_old")
-    assert SoftwareEnvironment._PROD_OLD == coerce(SoftwareEnvironment, "prod-old")
+    assert SoftwareEnvironment.STAGING == convert(SoftwareEnvironment, "staging")
+    assert SoftwareEnvironment._PROD_OLD == convert(SoftwareEnvironment, "prod_old")
+    assert SoftwareEnvironment._PROD_OLD == convert(SoftwareEnvironment, "prod-old")
 
     with pytest.raises(CoercionError):
-        coerce(SoftwareEnvironment, "invalid-choice")
+        convert(SoftwareEnvironment, "invalid-choice")
 
 
 def test_coerce_dict_error():
     with pytest.raises(TypeError):
-        coerce(dict, "this-doesnt-matter")
+        convert(dict, "this-doesnt-matter")
 
     with pytest.raises(TypeError):
-        coerce(Dict, "this-doesnt-matter")
+        convert(Dict, "this-doesnt-matter")
 
     with pytest.raises(TypeError):
-        coerce(Annotated[dict, "foo"], "this-doesnt-matter")
+        convert(Annotated[dict, "foo"], "this-doesnt-matter")
 
 
 def test_coerce_tuple_basic_single():
-    _assert_tuple((1,), coerce(Tuple[int], "1"))
+    _assert_tuple((1,), convert(Tuple[int], "1"))
 
 
 def test_coerce_tuple_basic_double():
-    _assert_tuple((1, 2.0), coerce(Tuple[int, Union[None, float, int]], "1", "2"))
+    _assert_tuple((1, 2.0), convert(Tuple[int, Union[None, float, int]], "1", "2"))
 
 
 def test_coerce_tuple_no_inner_types():
-    _assert_tuple(("1", "2"), coerce(Tuple, "1", "2"))
+    _assert_tuple(("1", "2"), convert(Tuple, "1", "2"))
 
 
 def test_coerce_tuple_nested():
     _assert_tuple(
         (1, (2.0, "foo")),
-        coerce(Tuple[int, Tuple[float, Union[None, str, int]]], "1", "2", "foo"),
+        convert(Tuple[int, Tuple[float, Union[None, str, int]]], "1", "2", "foo"),
     )
 
 
 def test_coerce_tuple_len_mismatch_underflow():
     with pytest.raises(CoercionError):
-        coerce(Tuple[int, int], "1")
+        convert(Tuple[int, int], "1")
 
 
 def test_coerce_tuple_len_mismatch_overflow():
     with pytest.raises(CoercionError):
-        coerce(Tuple[int, int], "1", "2", "3")
+        convert(Tuple[int, int], "1", "2", "3")
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Typing")
 def test_coerce_tuple_ellipsis_too_many_inner_types():
     with pytest.raises(ValueError):  # This is a ValueError because it happens prior to runtime.
         # Only 1 inner type annotation allowed
-        coerce(Tuple[int, int, ...], "1", "2")  # pyright: ignore
+        convert(Tuple[int, int, ...], "1", "2")  # pyright: ignore
 
 
 def test_coerce_tuple_ellipsis_non_divisible():
     with pytest.raises(CoercionError):
-        coerce(Tuple[Tuple[int, int], ...], "1", "2", "3")
+        convert(Tuple[Tuple[int, int], ...], "1", "2", "3")
 
 
 def test_coerce_list():
-    assert [123, 456] == coerce(int, "123", "456")
-    assert [123, 456] == coerce(List[int], "123", "456")
-    assert [123] == coerce(List[int], "123")
+    assert [123, 456] == convert(int, "123", "456")
+    assert [123, 456] == convert(List[int], "123", "456")
+    assert [123] == convert(List[int], "123")
 
 
 def test_coerce_bare_list():
     # Implicit element type: str
-    assert ["123", "456"] == coerce(list, "123", "456")
+    assert ["123", "456"] == convert(list, "123", "456")
 
 
 def test_coerce_iterable():
-    assert [123, 456] == coerce(Iterable[int], "123", "456")
-    assert [123] == coerce(Iterable[int], "123")
+    assert [123, 456] == convert(Iterable[int], "123", "456")
+    assert [123] == convert(Iterable[int], "123")
 
 
 def test_coerce_set():
-    assert {"123", "456"} == coerce(Set[str], "123", "456")
-    assert {123, 456} == coerce(Set[Union[int, str]], "123", "456")
+    assert {"123", "456"} == convert(Set[str], "123", "456")
+    assert {123, 456} == convert(Set[Union[int, str]], "123", "456")
 
 
 def test_coerce_literal():
-    assert "foo" == coerce(Literal["foo", "bar", 3], "foo")
-    assert "bar" == coerce(Literal["foo", "bar", 3], "bar")
-    assert 3 == coerce(Literal["foo", "bar", 3], "3")
+    assert "foo" == convert(Literal["foo", "bar", 3], "foo")
+    assert "bar" == convert(Literal["foo", "bar", 3], "bar")
+    assert 3 == convert(Literal["foo", "bar", 3], "3")
 
     with pytest.raises(CoercionError):
-        coerce(Literal["foo", "bar", 3], "invalid-choice")
+        convert(Literal["foo", "bar", 3], "invalid-choice")
 
 
 def test_coerce_path():
-    assert Path("foo") == coerce(Path, "foo")
+    assert Path("foo") == convert(Path, "foo")
 
 
 def test_coerce_any():
-    assert "foo" == coerce(Any, "foo")
+    assert "foo" == convert(Any, "foo")
 
 
 def test_coerce_bytes():
-    assert b"foo" == coerce(bytes, "foo")
-    assert [b"foo", b"bar"] == coerce(bytes, "foo", "bar")
+    assert b"foo" == convert(bytes, "foo")
+    assert [b"foo", b"bar"] == convert(bytes, "foo", "bar")
 
 
 def test_coerce_bytearray():
-    res = coerce(bytearray, "foo")
+    res = convert(bytearray, "foo")
     assert isinstance(res, bytearray)
     assert bytearray(b"foo") == res
 
-    assert [bytearray(b"foo"), bytearray(b"bar")] == coerce(bytearray, "foo", "bar")
+    assert [bytearray(b"foo"), bytearray(b"bar")] == convert(bytearray, "foo", "bar")
 
 
 def test_coerce_empty():
-    assert "foo" == coerce(inspect.Parameter.empty, "foo")
+    assert "foo" == convert(inspect.Parameter.empty, "foo")
 
 
 def test_resolve_annotated():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -61,7 +61,6 @@ def test_exceptions_coercion_error_verbose(app, console):
         """\
         ╭─ Error ────────────────────────────────────────────────────────────╮
         │ CoercionError                                                      │
-        │ Function defined in file                                           │
         """
     )
     assert actual.startswith(expected)

--- a/tests/types/test_types_path.py
+++ b/tests/types/test_types_path.py
@@ -16,52 +16,52 @@ def tmp_file(tmp_path):
 
 # ExistingPath
 def test_types_existing_path(convert, tmp_file):
-    assert tmp_file == convert(ct.ExistingPath, str(tmp_file))
+    assert tmp_file == convert(ct.ExistingPath, tmp_file)
 
 
 def test_types_existing_path_validation_error(convert, tmp_path):
     with pytest.raises(ValidationError):
-        convert(ct.ExistingPath, str(tmp_path / "foo"))
+        convert(ct.ExistingPath, tmp_path / "foo")
 
 
 # ExistingFile
 def test_types_existing_file(convert, tmp_file):
-    assert tmp_file == convert(ct.ExistingFile, str(tmp_file))
+    assert tmp_file == convert(ct.ExistingFile, tmp_file)
 
 
 def test_types_existing_file_validation_error(convert, tmp_path):
     with pytest.raises(ValidationError):
-        convert(ct.ExistingFile, str(tmp_path))
+        convert(ct.ExistingFile, tmp_path)
 
 
 # ExistingDirectory
 def test_types_existing_directory(convert, tmp_path):
-    assert tmp_path == convert(ct.ExistingDirectory, str(tmp_path))
+    assert tmp_path == convert(ct.ExistingDirectory, tmp_path)
 
 
 def test_types_existing_directory_validation_error(convert, tmp_file):
     with pytest.raises(ValidationError):
-        convert(ct.ExistingDirectory, str(tmp_file))
+        convert(ct.ExistingDirectory, tmp_file)
 
 
 # Directory
 def test_types_directory(convert, tmp_path):
-    assert tmp_path == convert(ct.Directory, str(tmp_path))
+    assert tmp_path == convert(ct.Directory, tmp_path)
 
 
 def test_types_directory_validation_error(convert, tmp_file):
     with pytest.raises(ValidationError):
-        convert(ct.Directory, str(tmp_file))
+        convert(ct.Directory, tmp_file)
 
 
 # File
 def test_types_file(convert, tmp_file):
-    assert tmp_file == convert(ct.File, str(tmp_file))
+    assert tmp_file == convert(ct.File, tmp_file)
 
 
 def test_types_file_validation_error(convert, tmp_path):
     with pytest.raises(ValidationError):
-        convert(ct.File, str(tmp_path))
+        convert(ct.File, tmp_path)
 
 
 # ResolvedExistingPath
@@ -69,60 +69,60 @@ def test_types_file_validation_error(convert, tmp_path):
 def test_types_resolved_existing_path(convert, tmp_path, action):
     src = tmp_path / ".." / tmp_path.name / "foo"
     getattr(src, action)()
-    assert src.resolve() == convert(ct.ResolvedExistingPath, str(src))
+    assert src.resolve() == convert(ct.ResolvedExistingPath, src)
 
 
 def test_types_resolved_existing_path_validation_error(convert, tmp_path):
     with pytest.raises(ValidationError):
-        convert(ct.ResolvedExistingPath, str(tmp_path / "foo"))
+        convert(ct.ResolvedExistingPath, tmp_path / "foo")
 
 
 # ResolvedExistingFile
 def test_types_resolved_existing_file(convert, tmp_path):
     src = tmp_path / ".." / tmp_path.name / "foo"
     src.touch()
-    assert src.resolve() == convert(ct.ResolvedExistingFile, str(src))
+    assert src.resolve() == convert(ct.ResolvedExistingFile, src)
 
 
 def test_types_resolved_existing_file_validation_error(convert, tmp_path):
     with pytest.raises(ValidationError):
-        convert(ct.ResolvedExistingFile, str(tmp_path / "foo"))
+        convert(ct.ResolvedExistingFile, tmp_path / "foo")
 
 
 # ResolvedExistingDirectory
 def test_types_resolved_existing_directory(convert, tmp_path):
     src = tmp_path / ".." / tmp_path.name / "foo"
     src.mkdir()
-    assert src.resolve() == convert(ct.ResolvedExistingDirectory, str(src))
+    assert src.resolve() == convert(ct.ResolvedExistingDirectory, src)
 
 
 def test_types_resolved_existing_directory_validation_error(convert, tmp_path):
     src = tmp_path / ".." / tmp_path.name / "foo"
 
     with pytest.raises(ValidationError):
-        convert(ct.ResolvedExistingDirectory, str(src))
+        convert(ct.ResolvedExistingDirectory, src)
 
 
 # ResolvedDirectory
-def test_types_resolved_directory(convert):
-    assert Path("/bar") == convert(ct.ResolvedDirectory, "/foo/../bar/")
+def test_types_resolved_directory(convert, tmp_path):
+    assert tmp_path == convert(ct.ResolvedDirectory, tmp_path / "foo" / "..")
 
 
 def test_types_resolved_directory_validation_error(convert, tmp_file):
     with pytest.raises(ValidationError):
-        convert(ct.ResolvedDirectory, str(tmp_file))
+        convert(ct.ResolvedDirectory, tmp_file)
 
 
 # ResolvedFile
 def test_types_resolved_file(convert, tmp_path):
     src = tmp_path / ".." / tmp_path.name / "foo"
     src.touch()
-    assert src.resolve() == convert(ct.ResolvedFile, str(src))
+    assert src.resolve() == convert(ct.ResolvedFile, src)
 
 
 def test_types_resolved_file_validation_error(convert, tmp_path):
     with pytest.raises(ValidationError):
-        convert(ct.ResolvedFile, str(tmp_path))
+        convert(ct.ResolvedFile, tmp_path)
 
 
 # Misc
@@ -134,4 +134,6 @@ def test_types_path_resolve_converter(convert, tmp_path):
     dir1.mkdir()
     dir2.mkdir()
 
-    assert (dir1, dir2) == convert(Tuple[ct.ResolvedDirectory, ct.ResolvedDirectory], [str(dir1), str(dir2)])
+    assert (dir1, dir2) == convert(
+        Tuple[ct.ResolvedDirectory, ct.ResolvedDirectory], [dir1.as_posix(), dir2.as_posix()]
+    )

--- a/tests/types/test_types_path.py
+++ b/tests/types/test_types_path.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from cyclopts import types as ct
+from cyclopts.exceptions import ValidationError
+
+
+@pytest.fixture
+def tmp_file(tmp_path):
+    file_path = tmp_path / "file.bin"
+    file_path.touch()
+    return file_path
+
+
+# ExistingPath
+def test_types_existing_path(convert, tmp_file):
+    assert tmp_file == convert(ct.ExistingPath, str(tmp_file))
+
+
+def test_types_existing_path_validation_error(convert, tmp_path):
+    with pytest.raises(ValidationError):
+        convert(ct.ExistingPath, str(tmp_path / "foo"))
+
+
+# ExistingFile
+def test_types_existing_file(convert, tmp_file):
+    assert tmp_file == convert(ct.ExistingFile, str(tmp_file))
+
+
+def test_types_existing_file_validation_error(convert, tmp_path):
+    with pytest.raises(ValidationError):
+        convert(ct.ExistingFile, str(tmp_path))
+
+
+# ExistingDirectory
+def test_types_existing_directory(convert, tmp_path):
+    assert tmp_path == convert(ct.ExistingDirectory, str(tmp_path))
+
+
+def test_types_existing_directory_validation_error(convert, tmp_file):
+    with pytest.raises(ValidationError):
+        convert(ct.ExistingDirectory, str(tmp_file))
+
+
+# Directory
+def test_types_directory(convert, tmp_path):
+    assert tmp_path == convert(ct.Directory, str(tmp_path))
+
+
+def test_types_directory_validation_error(convert, tmp_file):
+    with pytest.raises(ValidationError):
+        convert(ct.Directory, str(tmp_file))
+
+
+# File
+def test_types_file(convert, tmp_file):
+    assert tmp_file == convert(ct.File, str(tmp_file))
+
+
+def test_types_file_validation_error(convert, tmp_path):
+    with pytest.raises(ValidationError):
+        convert(ct.File, str(tmp_path))
+
+
+# ResolvedExistingPath
+@pytest.mark.parametrize("action", ["touch", "mkdir"])
+def test_types_resolved_existing_path(convert, tmp_path, action):
+    src = tmp_path / ".." / tmp_path.name / "foo"
+    getattr(src, action)()
+    assert src.resolve() == convert(ct.ResolvedExistingPath, str(src))
+
+
+def test_types_resolved_existing_path_validation_error(convert, tmp_path):
+    with pytest.raises(ValidationError):
+        convert(ct.ResolvedExistingPath, str(tmp_path / "foo"))
+
+
+# ResolvedExistingFile
+def test_types_resolved_existing_file(convert, tmp_path):
+    src = tmp_path / ".." / tmp_path.name / "foo"
+    src.touch()
+    assert src.resolve() == convert(ct.ResolvedExistingFile, str(src))
+
+
+def test_types_resolved_existing_file_validation_error(convert, tmp_path):
+    with pytest.raises(ValidationError):
+        convert(ct.ResolvedExistingFile, str(tmp_path / "foo"))
+
+
+# ResolvedExistingDirectory
+def test_types_resolved_existing_directory(convert, tmp_path):
+    src = tmp_path / ".." / tmp_path.name / "foo"
+    src.mkdir()
+    assert src.resolve() == convert(ct.ResolvedExistingDirectory, str(src))
+
+
+def test_types_resolved_existing_directory_validation_error(convert, tmp_path):
+    src = tmp_path / ".." / tmp_path.name / "foo"
+
+    with pytest.raises(ValidationError):
+        convert(ct.ResolvedExistingDirectory, str(src))
+
+
+# ResolvedDirectory
+def test_types_resolved_directory(convert):
+    assert Path("/bar") == convert(ct.ResolvedDirectory, "/foo/../bar/")
+
+
+def test_types_resolved_directory_validation_error(convert, tmp_file):
+    with pytest.raises(ValidationError):
+        convert(ct.ResolvedDirectory, str(tmp_file))
+
+
+# ResolvedFile
+def test_types_resolved_file(convert, tmp_path):
+    src = tmp_path / ".." / tmp_path.name / "foo"
+    src.touch()
+    assert src.resolve() == convert(ct.ResolvedFile, str(src))
+
+
+def test_types_resolved_file_validation_error(convert, tmp_path):
+    with pytest.raises(ValidationError):
+        convert(ct.ResolvedFile, str(tmp_path))
+
+
+# Misc
+def test_types_path_resolve_converter(convert, tmp_path):
+    """Tests that ``_path_resolve_converter`` handles things like tuples correctly."""
+    dir1 = tmp_path / "foo"
+    dir2 = tmp_path / "bar"
+
+    dir1.mkdir()
+    dir2.mkdir()
+
+    assert (dir1, dir2) == convert(Tuple[ct.ResolvedDirectory, ct.ResolvedDirectory], [str(dir1), str(dir2)])


### PR DESCRIPTION
Implements the pre-defined annotated types described: https://github.com/BrianPugh/cyclopts/issues/65#issuecomment-1891017348

Summary:
1. Renamed `cyclopts.coerce` to `cyclopts.convert` for naming consistency. It also takes a new optional keyword `converter`.
2. Introduce the following `Path` annotated types:
    ```
    ExistingPath, ResolvedPath, ResolvedExistingPath, Directory, ExistingDirectory, ResolvedDirectory, ResolvedExistingDirectory, File, ExistingFile, ResolvedFile, ResolvedExistingFile
    ```
3. Introduce the following `Number` annotated types:
    ```
    PositiveFloat, NonNegativeFloat, NegativeFloat, NonPositiveFloat, PositiveInt, NonNegativeInt, NegativeInt, NonPositiveInt
    ```
4. `Path` validator now only checks if the path is a file/directory **if it exists**. Previously it would always try to check.

@ravencentric, let me know what you think about this PR!