### PR TITLE
Add new App.usage field.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -38,6 +38,13 @@ API
       Defaults to ``["--help", "-h"]``.
       Cannot be changed after instantiating the app.
 
+   .. attribute:: usage
+      :type: Optional[str]
+      :value: None
+
+      Text to be displayed in lieue of the default ``Usage: app COMMAND ...`` at the beginning of the help-page.
+      Set to an empty-string ``""`` to disable showing the default usage.
+
    .. attribute:: show
       :type: bool
       :value: True

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -63,6 +63,47 @@ def test_help_default_action(app, console):
     assert actual == expected
 
 
+def test_help_custom_usage(app, console):
+    app.usage = "My custom usage."
+    with console.capture() as capture:
+        app([], console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        My custom usage.
+
+        App Help String Line 1.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ --help,-h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
+def test_help_custom_usage_subapp(app, console):
+    app.command(App(name="foo", usage="My custom usage."))
+
+    with console.capture() as capture:
+        app(["foo", "--help"], console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        My custom usage.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ --help,-h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
 def test_help_default_help_flags(console):
     """Standard help flags."""
     app = App(name="app", help="App Help String Line 1.")


### PR DESCRIPTION
Partially addresses #69.  Allows a manually specified `App.usage` string.

I'm postponing improving the auto-generated usage string for a minor v2.X release in a future PR; this is a relatively small-value feature improvement and I don't want to block v2 release on it.

@ravencentric please give this a look!