### PR TITLE
Expose `App.parse_commands`; provide cookbook example of using pyproject.toml

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -292,7 +292,26 @@ class App:
             self._meta._meta_parent = self
         return self._meta
 
-    def _parse_command_chain(self, tokens):
+    def parse_commands(self, tokens: Union[None, str, Iterable[str]] = None):
+        """Extract out the command tokens from a command.
+
+        Parameters
+        ----------
+        tokens: Union[None, str, Iterable[str]]
+            Either a string, or a list of strings to launch a command.
+            Defaults to ``sys.argv[1:]``
+
+        Returns
+        -------
+        List[str]
+            Tokens that are interpreted as a valid command chain.
+        List[App]
+            The associated :class:`App` object with each of those tokens.
+        List[str]
+            The remaining non-command tokens.
+        """
+        tokens = normalize_tokens(tokens)
+
         command_chain = []
         app = self
         apps = [app]
@@ -427,7 +446,7 @@ class App:
         """
         tokens = normalize_tokens(tokens)
 
-        command_chain, apps, unused_tokens = self._parse_command_chain(tokens)
+        command_chain, apps, unused_tokens = self.parse_commands(tokens)
         command_app = apps[-1]
 
         try:
@@ -653,7 +672,7 @@ class App:
         if console is None:
             console = Console()
 
-        command_chain, apps, _ = self._parse_command_chain(tokens)
+        command_chain, apps, _ = self.parse_commands(tokens)
         executing_app = apps[-1]
 
         # Print the:

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -177,10 +177,13 @@ def _get_choices(type_: Type) -> str:
 
 
 def create_parameter_help_panel(group: "Group", iparams, cparams: List[Parameter]) -> HelpPanel:
-    icparams = [(ip, cp) for ip, cp in zip(iparams, cparams) if cp.show]
-    iparams, cparams = (list(x) for x in zip(*icparams))
-
     help_panel = HelpPanel(format="parameter", title=group.name, description=group.help)
+    icparams = [(ip, cp) for ip, cp in zip(iparams, cparams) if cp.show]
+
+    if not icparams:
+        return help_panel
+
+    iparams, cparams = (list(x) for x in zip(*icparams))
 
     for iparam, cparam in icparams:
         assert cparam.name is not None

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,7 +5,7 @@ API
 ===
 
 .. autoclass:: cyclopts.App
-   :members: default, command, version_print, help_print, interactive_shell, parse_known_args, parse_args
+   :members: default, command, version_print, help_print, interactive_shell, parse_commands, parse_known_args, parse_args
    :special-members: __call__, __getitem__
 
    Cyclopts Application.

--- a/docs/source/cookbook/pyproject.rst
+++ b/docs/source/cookbook/pyproject.rst
@@ -1,0 +1,211 @@
+==========================
+Using ``pyproject.toml``
+==========================
+Let's create a CLI tool that is configurable via the user's ``pyproject.toml``. Think tools like Poetry_, Ruff_, and Codespell_.
+
+----------------
+Base Application
+----------------
+For this example, we'll be creating a simple CLI named ``compact`` that can compress data with either the ``zip`` or the ``lzma`` algorithm.
+
+.. code-block:: python
+
+   from cyclopts import App, Parameter
+   from cyclopts.types import ExistingFile, File
+   from typing import Annotated, Literal, Optional
+   import lzma
+   import zlib
+
+   app = App(name="compact", help="Data compression tool.")
+
+
+   @app.command
+   def compress(src: ExistingFile, dst: Optional[File] = None, *, method: Literal["lzma", "zip"] = "zip"):
+       """Compress a file."""
+       data = src.read_bytes()
+       if method == "lzma":
+           out = lzma.compress(data)
+       elif method == "zip":
+           out = zlib.compress(data)
+       else:
+           raise NotImplementedError
+       dst = dst or src.with_suffix(src.suffix + "." + method)
+       dst.write_bytes(out)
+
+
+   if __name__ == "__main__":
+       app()
+
+This application works as-is, but it may be useful for the caller to set the default ``method`` field from their ``pyproject.toml``.
+More precisely, we want to be able to use the following configuration:
+
+.. code-block:: toml
+
+   # pyproject.toml
+   [tool.compact.compress]
+   method = "lzma"
+
+------------------
+Customizing Launch
+------------------
+First, we need to hook into the application launch process. In Cyclopts, this is done with the :ref:`Meta App` (an app that launches an app). The most basic meta-app is:
+
+.. code-block:: python
+
+   @app.meta.default
+   def main(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+       app(tokens)
+
+
+   if __name__ == "__main__":
+       app.meta()  # Call app.meta() instead of app()
+
+For our purposes, we'll want to dive into the Cyclopts machinery a little further.
+
+.. code-block:: python
+
+   @app.meta.default
+   def main(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+       command, bound = app.parse_args(tokens)
+       return command(*bound.args, **bound.kwargs)
+
+``command`` is the actual python function to-be-executed.  ``bound`` is a :class:`~inspect.BoundArguments` object containing all the parsed & converted CLI arguments. It follows that ``command(*bound.args, **bound.kwargs)`` would execute the function with all of our supplied arguments.
+
+-----------------------------
+Reading in ``pyproject.toml``
+-----------------------------
+We now have an appropriate place to read ``pyproject.toml`` from the current working directory.
+Add the following to the beginning of the ``main`` meta-app function:
+
+.. code-block:: python
+
+   import tomli  # Or you can just use ``toml`` in Python >=3.11
+
+   try:
+       with open("pyproject.toml", "rb") as f:
+           config = tomli.load(f)["tool"]["compact"]  # Reads the [tool.compact] table.
+   except (FileNotFoundError, KeyError):
+       config = {}
+
+``config`` will be empty if ``pyproject.toml`` does not exist, or if it does not contain a ``[tool.compact]`` table.
+
+.. note::
+
+   Many applications search the current working directory for ``pyproject.toml``, and will fallback to searching parenting directories until a ``pyproject.toml`` is found. Here's a snippet for that:
+
+
+   .. code-block::
+
+      from pathlib import Path
+
+      def find_pyproject() -> Path:
+          """Searches current directory, then parenting directories until a pyproject.toml is found."""
+          for parent in Path("pyproject.toml").absolute().parents:
+              if (candidate := parent / path.name).exists():
+                  return candidate
+          raise FileNotFoundError("Cannot find a pyproject.toml")
+
+--------------------------
+Getting the command string
+--------------------------
+We want to dynamically parse what sub-table of the config we need to access based on the command being executed.
+The :meth:`~.App.parse_commands` method returns a bunch of data; the first returned element is a list of strings containing the parsed command names.
+
+.. code-block:: python
+
+    command_names, _, _ = app.parse_commands(tokens)
+
+If we invoked our program:
+
+.. code-block:: console
+
+   $ python compact.py compress foo.bin
+
+Then the resulting ``command_names`` would be ``["compress"]``.
+
+We can now access the config for this specific subcommand:
+
+.. code-block:: python
+
+    for command_name in command_names:
+        config = config.get(command_name, {})
+
+------------------------
+Updating bound arguments
+------------------------
+Finally, we need to set these values as defaults to the :attr:`bound.arguments <inspect.BoundArguments.arguments>` dictionary.
+We don't want to simply update the dictionary, as that would mean our toml-configured values would overwrite CLI-provided values. Using :meth:`dict.setdefault` will only set values for previously non-existent keys.
+
+.. code-block:: python
+
+    # Update the bound arguments for unset keys:
+    for key, value in config.items():
+        bound.arguments.setdefault(key, value)
+
+.. warning::
+
+   You are responsible to correctly interpreting/coercing data types from non-cli sources to the correct type.
+   E.g. A value from ``toml`` may be a string, but the function might be expecting a :class:`~pathlib.Path` object.
+
+----------
+Final Code
+----------
+Putting it all together, here's the complete copy/pastable example code:
+
+.. code-block:: python
+
+   from cyclopts import App, Parameter
+   from cyclopts.types import ExistingFile, File
+   from typing import Annotated, Literal, Optional
+   import tomli
+   import lzma
+   import zlib
+
+   app = App(name="compact", help="Data compression tool.")
+
+
+   @app.command
+   def compress(src: ExistingFile, dst: Optional[File] = None, *, method: Literal["lzma", "zip"] = "zip"):
+       """Compress a file."""
+       data = src.read_bytes()
+       if method == "lzma":
+           out = lzma.compress(data)
+       elif method == "zip":
+           out = zlib.compress(data)
+       else:
+           raise NotImplementedError
+       dst = dst or src.with_suffix(src.suffix + "." + method)
+       dst.write_bytes(out)
+
+
+   @app.meta.default
+   def main(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+       try:
+           with open("pyproject.toml", "rb") as f:
+               config = tomli.load(f)["tool"]["compact"]
+       except (FileNotFoundError, KeyError):
+           config = {}
+
+       # The main Cyclopts parsing/conversion
+       command, bound = app.parse_args(tokens)
+
+       # Get the config dictionary for the specified command.
+       command_names, _, _ = app.parse_commands(tokens)
+       for command_name in command_names:
+           config = config.get(command_name, {})
+
+       # Update the bound arguments for unset keys:
+       for key, value in config.items():
+           bound.arguments.setdefault(key, value)
+
+       # Actual function execution.
+       return command(*bound.args, **bound.kwargs)
+
+
+   if __name__ == "__main__":
+       app.meta()
+
+
+.. _Poetry: https://github.com/python-poetry/poetry
+.. _Ruff: https://github.com/astral-sh/ruff
+.. _Codespell: https://github.com/codespell-project/codespell

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ Cyclopts
 
    cookbook/app_upgrade.rst
    cookbook/interactive_help.rst
+   cookbook/pyproject.rst
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/meta_app.rst
+++ b/docs/source/meta_app.rst
@@ -23,13 +23,13 @@ To change how the primary app is run, you can use the meta-app feature of Cyclop
 
 .. code-block:: python
 
-   from cyclopts import App, Parameter
+   from cyclopts import App, Group, Parameter
    from typing_extensions import Annotated
 
-   app = App(
-       help_flags=[],  # Disable help & version flags since the meta-app
-       version_flags=[],  # will handle them.
-   )
+   app = App()
+   # Rename the meta's "Parameter" -> "Session Parameters".
+   # Set sort_key so it will be drawn higher up the help-page.
+   app.meta.group_parameters = Group("Session Parameters", sort_key=0)
 
 
    @app.command
@@ -66,14 +66,14 @@ be additionally scanned when generate help screens
    $ my-script --help
    Usage: my-script COMMAND
 
-   ╭─ Session Parameters ───────────────────────────────────────────────────╮
-   │ *  --user     [required]                                               │
-   │    --version  Display application version.                             │
-   │    --help,-h  Display this message and exit.                           │
-   ╰────────────────────────────────────────────────────────────────────────╯
-   ╭─ Commands ─────────────────────────────────────────────────────────────╮
-   │ foo                                                                    │
-   ╰────────────────────────────────────────────────────────────────────────╯
+   ╭─ Session Parameters ────────────────────────────────────────────────────╮
+   │ *  --user  [required]                                                   │
+   ╰─────────────────────────────────────────────────────────────────────────╯
+   ╭─ Commands ──────────────────────────────────────────────────────────────╮
+   │ foo                                                                     │
+   │ --help,-h  Display this message and exit.                               │
+   │ --version  Display application version.                                 │
+   ╰─────────────────────────────────────────────────────────────────────────╯
 
 -------------
 Meta Commands
@@ -94,15 +94,15 @@ If you want a command to circumvent ``my_app_launcher``, add it as you would any
    $ my-script --help
    Usage: my-script COMMAND
 
-   ╭─ Session Parameters ───────────────────────────────────────────────────╮
-   │ *  --user     [required]                                               │
-   │    --version  Display application version.                             │
-   │    --help,-h  Display this message and exit.                           │
-   ╰────────────────────────────────────────────────────────────────────────╯
-   ╭─ Commands ─────────────────────────────────────────────────────────────╮
-   │ foo                                                                    │
-   │ info                                                                   │
-   ╰────────────────────────────────────────────────────────────────────────╯
+   ╭─ Session Parameters ────────────────────────────────────────────────────╮
+   │ *  --user  [required]                                                   │
+   ╰─────────────────────────────────────────────────────────────────────────╯
+   ╭─ Commands ──────────────────────────────────────────────────────────────╮
+   │ foo                                                                     │
+   │ info                                                                    │
+   │ --help,-h  Display this message and exit.                               │
+   │ --version  Display application version.                                 │
+   ╰─────────────────────────────────────────────────────────────────────────╯
 
 Just like a standard application, the parsed ``command`` executes instead of ``default``.
 
@@ -145,7 +145,7 @@ This might be useful to share an expensive-to-create object amongst commands in 
 
 
    @app.meta.default
-   def launcher(*tokens: Annotated[str, Parameter(show=False)], user: str):
+   def launcher(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)], user: str):
        user_obj = User(user)
        command, bound = app.parse_args(tokens)
        return command(*bound.args, **bound.kwargs, user_obj=user_obj)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -273,6 +273,17 @@ def capture_format_group_parameters(console, default_function_groups):
     return inner
 
 
+def test_help_format_group_parameters_empty(capture_format_group_parameters):
+    def cmd(
+        foo: Annotated[str, Parameter(show=False)],
+    ):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = ""
+    assert actual == expected
+
+
 def test_help_format_group_parameters(capture_format_group_parameters):
     def cmd(
         foo: Annotated[str, Parameter(help="Docstring for foo.")],


### PR DESCRIPTION
* Expose `App.parse_commands` to public API.
* Fix crash when displaying help where the only parameter has `show=False`.
* Added a cookbook example of how to use `pyproject.toml` to the documentation.
* Fixed out-of-date meta-app documentation.