### PR TITLE
move subcommands to it's own documentation subsection

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -2,10 +2,10 @@
 Commands
 ========
 
-There are 2 primary function registering decorators:
+There are 2 function-registering decorators:
 
 1. :meth:`@app.default <cyclopts.App.default>` -
-   Registers an action for when no valid command is provided by the CLI.
+   Registers an action for when no registered command is provided.
    This was previously demonstrated in :ref:`Getting Started`.
 
    A sub-app **cannot** be registered with :meth:`@app.default <cyclopts.App.default>`.
@@ -21,22 +21,48 @@ This section will detail how to use the :meth:`@app.command <cyclopts.App.comman
 Registering a Command
 ---------------------
 The :meth:`@app.command <cyclopts.App.command>` decorator adds a command to a Cyclopts application.
-The registered command can either be a function, or another Cyclopts :class:`.App`.
-
 
 .. code-block:: python
 
    from cyclopts import App
 
    app = App()
-   sub_app = App(name="foo")
-   app.command(sub_app)  # Registers sub_app to command "foo"
-   # Or, as a one-liner:  app.command(sub_app := App(name="foo"))
 
 
    @app.command
    def fizz(n: int):
        print(f"FIZZ: {n}")
+
+
+   @app.command
+   def buzz(n: int):
+       print(f"BUZZ: {n}")
+
+
+   app()
+
+.. code-block:: console
+
+   $ my-script fizz 3
+   FIZZ: 3
+
+   $ my-script buzz 4
+   BUZZ: 4
+
+------------------------
+Registering a SubCommand
+------------------------
+The :meth:`@app.command <cyclopts.App.command>` method can also register another Cyclopts :class:`.App` as a command.
+
+.. code-block:: python
+
+   from cyclopts import App
+
+   app = App()
+   sub_app = App(name="foo")  # "foo" would be a better variable name than "sub_app".
+   # "sub_app" in this example emphasizes the name comes from name="foo".
+   app.command(sub_app)  # Registers sub_app to command "foo"
+   # Or, as a one-liner:  app.command(sub_app := App(name="foo"))
 
 
    @sub_app.command
@@ -52,16 +78,17 @@ The registered command can either be a function, or another Cyclopts :class:`.Ap
 
    app()
 
+
 .. code-block:: console
 
-   $ my-script fizz 3
-   FIZZ: 3
+   $ my-script foo bar 3
+   BAR: 3
 
    $ my-script foo bar 4
-   BAR: 4
+   BAZ: 4
 
-   $ my-script foo baz 5
-   BAZ: 5
+The subcommand may have it's own registered ``default`` action.
+Cyclopts's command structure is fully recursive.
 
 .. _Changing Name:
 
@@ -94,7 +121,7 @@ There are a few ways to adding a help string to a command:
    used as the help string for the command.
    This is generally the preferred method.
 
-2. If the registered command is a sub app, the sub app's ``help`` field
+2. If the registered command is a sub app, the sub app's :attr:`help <cyclopts.App.help>` field
    will be used.
 
    .. code-block:: python

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,3 +1,5 @@
+.. _Commands:
+
 ========
 Commands
 ========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,12 @@ Cyclopts
 .. include:: ../../README.md
    :parser: myst_parser.sphinx_
 
+
+---
+API
+---
+For extensive documentation on all the features Cyclopts has to offer, checkout the :ref:`API` page.
+
 .. toctree::
    :maxdepth: 1
    :caption: Usage

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,12 @@ Cyclopts
 
 .. toctree::
    :maxdepth: 2
+   :caption: Migration
+
+   migration/typer.rst
+
+.. toctree::
+   :maxdepth: 2
    :caption: Alternative Libraries
 
    vs_typer/README.rst

--- a/docs/source/migration/typer.rst
+++ b/docs/source/migration/typer.rst
@@ -1,0 +1,101 @@
+====================
+Migrating From Typer
+====================
+Much of Cyclopts's syntax is `Typer`_-inspired. Migrating from Typer should be pretty straightforward; it is recommended to first read the :ref:`Getting Started` and :ref:`Commands` sections. The below table offers a jumping off point for translating the various portions of the APIs. The :ref:`Typer Comparison` page also provides many examples comparing the APIs.
+
+.. list-table:: Typer-to-Cyclopts API Reference
+   :widths: 30 30 40
+   :header-rows: 1
+
+   * - Typer
+     - Cyclopts
+     - Notes
+
+   * - :class:`typer.Typer()`
+     - :class:`cyclopts.App()`
+     - Same/similar fields:
+         + :attr:`.App.name` - Optional name of application or sub-command.
+       Cyclopts has more user-friendly default features:
+         + Equivalent ``no_args_is_help=True``.
+         + Equivalent ``pretty_exceptions_enable=False``.
+
+   * - :meth:`@app.command()`
+     - :meth:`@app.command() <.App.command>`
+     - In Cyclopts, ``@app.command`` :ref:`always results in a command. <Typer Default Command>` To define an action when no command is provided, see :meth:`@app.default <.App.default>`.
+
+   * - :meth:`@app.add_typer`
+     - :meth:`@app.command`
+     - Sub applications and commands are registered the same way in Cyclopts.
+
+   * - :meth:`@app.callback()`
+     - :meth:`@app.default() <.App.default>`
+
+       :meth:`@app.meta.default() <.App.default>`
+     - Typer's callback always executes before executing an app.
+       If used to provide functionality when no command was specified from the CLI, then use :meth:`@app.default() <.App.default>`.
+       Otherwise, checkout Cyclopt's :ref:`Meta App`.
+
+   * - :class:`Annotated[..., typer.Argument(...)]`
+
+       :class:`Annotated[..., typer.Option(...)]`
+     - :class:`Annotated[..., cyclopts.Parameter(...)] <.Parameter>`
+     - In Cyclopts, Positional/Keyword arguments :ref:`are determined from the function signature. <Typer Argument vs Option>`
+       Some of Typer's validation fields, like ``exists`` for :class:`~pathlib.Path` types are handled in Cyclopts :ref:`by explicit validators. <Parameter Validators>`
+
+Cyclopts and Typer mostly handle type-hints the same way, but there are a few notable exceptions:
+
+.. list-table:: Typer-to-Cyclopts Type-Hints
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Type Annotation
+     - Notes
+
+   * - :class:`~enum.Enum`
+     - Compared to Typer, Cyclopts handles :class:`~enum.Enum` lookups :ref:`in the reverse direction. <Typer Choices>`
+       Frequently, :obj:`~typing.Literal` :ref:`offers a more terse, intuitive choice option. <Coercion Rules - Literal>`
+
+   * - :obj:`~typing.Union`
+     - Typer does **not** support type unions. :ref:`Cyclopts does. <Coercion Rules - Union>`
+
+   * - ``Optional[List] = None``
+     - When no CLI argument is specified, Typer passes in an empty list ``[]``.
+       :ref:`Cyclopts will not bind an argument, <Typer Optional Lists>` resulting in the default ``None``.
+
+-------------
+General Steps
+-------------
+#. Add the following import: ``from cyclopts import App, Parameter``.
+#. Change ``app = Typer(...)`` to just ``app = App()``. Revisit more advanced configuration later.
+#. Remove all ``@app.callback`` stuff. Cyclopts already provides a good ``--version`` handler for you.
+#. Replace all ``Annotated[..., Argument/Option]`` type-hints with :class:`Annotated[..., Parameter()] <.Parameter>`.
+   If only supplying a :attr:`~.Parameter.help` string, :ref:`it's better to supply it via docstring. <Typer Docstring Parsing>`
+#. Cyclopts has similar boolean-flag handling as Typer, :ref:`but has different configuration parameters. <Typer Flag Negation>`
+
+   .. code-block:: python
+
+      #########
+      # Typer #
+      #########
+      # Overriding the name results in no "False" flag generation.
+      my_flag: Annotated[bool, Option("--my-custom-flag")]
+      # However, it can be custom specified:
+      my_flag: Annotated[bool, Option("--my-custom-flag/--disable-my-custom-flag")]
+
+      ############
+      # Cyclopts #
+      ############
+      # Overriding the name still results in "False" flag generation:
+      #    --my-custom-flag --no-my-custom-flag
+      my_flag: Annotated[bool, Parameter("--my-custom-flag")]
+      # Negative flag generation can be disabled:
+      #    --my-custom-flag
+      my_flag: Annotated[bool, Parameter("--my-custom-flag", negative="")]
+      # Or the prefix can be changed:
+      #    --my-custom-flag --disable-my-custom-flag
+      my_flag: Annotated[bool, Parameter("--my-custom-flag", negative_bool="--disable-")]
+
+After the basic migration is done, it is recommended to read through the rest of Cyclopts's documentation to learn about some of the better functionality it has, which could result in cleaner, terser code.
+
+.. _Typer: https://typer.tiangolo.com
+.. _always results in a command.: https://github.com/tiangolo/typer/issues/315

--- a/docs/source/parameter_validators.rst
+++ b/docs/source/parameter_validators.rst
@@ -1,3 +1,5 @@
+.. _Parameter Validators:
+
 ====================
 Parameter Validators
 ====================

--- a/docs/source/vs_typer/README.rst
+++ b/docs/source/vs_typer/README.rst
@@ -9,7 +9,7 @@ Despite it's popularity, Typer has some traits that I (and others) find less tha
 Part of this stems from Typer's age, with it's first release in late 2019, soon after Python 3.8's release.
 Because of this, most of it's API was initially designed around assigning proxy default values to function parameters.
 This made the decorated command functions difficult to use outside of Typer.
-With the introduction of ``Annotated`` in python3.9, type-hints were able to be directly annotated, allowing for the removal of these proxy defaults.
+With the introduction of :obj:`~.typing.Annotated` in python3.9, type-hints were able to be directly annotated, allowing for the removal of these proxy defaults.
 
 Additionally, Typer is built on top of `Click`_.
 This makes it difficult for newcomers to figure out which elements are Typer-related and which elements are click-related.

--- a/docs/source/vs_typer/argument_vs_option/README.rst
+++ b/docs/source/vs_typer/argument_vs_option/README.rst
@@ -1,3 +1,5 @@
+.. _Typer Argument vs Option:
+
 ==================
 Argument vs Option
 ==================

--- a/docs/source/vs_typer/choices/README.rst
+++ b/docs/source/vs_typer/choices/README.rst
@@ -8,7 +8,7 @@ Choices
 Enum
 ----
 Frequently, a CLI will want to limit values provided to a parameter to a specific set of choices.
-With Typer, this is accomplished via declaring an enum.
+With Typer, this is accomplished via declaring an :class:`~enum.Enum`.
 
 .. code-block:: python
 
@@ -54,9 +54,9 @@ Literal
 -------
 Enums don't work well with everyone's workflow.
 Many people prefer to directly use strings for their functions' options.
-The much more intuitive, convenient method of doing this is with the ``Literal`` type annotation.
+The much more intuitive, convenient method of doing this is with the :obj:`~typing.Literal` type annotation.
 Unfortuneately, Typer has not provided support, despite `a feature request dating back to early 2020`_
-Cyclopts has builtin support for ``Literal``, see :ref:`Coercion Rules - Literal <Coercion Rules - Literal>`.
+Cyclopts has builtin support for :obj:`~typing.Literal`, see :ref:`Coercion Rules - Literal <Coercion Rules - Literal>`.
 
 .. code-block:: python
 

--- a/docs/source/vs_typer/choices/README.rst
+++ b/docs/source/vs_typer/choices/README.rst
@@ -1,3 +1,5 @@
+.. _Typer Choices:
+
 =======
 Choices
 =======

--- a/docs/source/vs_typer/default_command/README.rst
+++ b/docs/source/vs_typer/default_command/README.rst
@@ -4,7 +4,6 @@
 Default Command
 ===============
 Typer has an annoying design quirk where if you register a single command, it **won't** expect you to provide the command name in the CLI.
-
 For example:
 
 
@@ -51,8 +50,8 @@ Github user `ajlive's callback solution`_ is copied below.
 
 To avoid this confusion, Cyclopts has two ways of registering a function:
 
-1. ``app.command`` - Register a function as a command.
-2. ``app.default`` - Invoked if no registered command can be parsed from the CLI.
+1. :meth:`@app.command <.App.command>` - Register a function as a command.
+2. :meth:`@app.default <.App.default>` - Invoked if no registered command can be parsed from the CLI.
 
 .. code-block:: python
 

--- a/docs/source/vs_typer/docstring/README.rst
+++ b/docs/source/vs_typer/docstring/README.rst
@@ -1,3 +1,5 @@
+.. _Typer Docstring Parsing:
+
 =================
 Docstring Parsing
 =================

--- a/docs/source/vs_typer/flag_negation/README.rst
+++ b/docs/source/vs_typer/flag_negation/README.rst
@@ -50,7 +50,7 @@ To use a different negative flag, you can supply the name after a slash in your 
    typer_app(["--your-flag"], standalone_mode=False)
    # my_flag=False
 
-Cyclopts's :class:`Parameter <cyclopts.Parameter>` takes in an optional ``negative`` flag.
+Cyclopts's :class:`Parameter <cyclopts.Parameter>` takes in an optional :attr:`~.Parameter.negative` flag.
 To suppress the negative-flag generation, set this argument to either an empty string or list.
 
 .. code-block:: python
@@ -85,4 +85,19 @@ To define your own custom negative flag, just provide it as a string or list of 
    cyclopts_app(["--my-flag"])
    # my_flag=True
    cyclopts_app(["--your-flag"])
+   # my_flag=False
+
+The default ``--no-`` negation prefix can also be customized with :attr:`~.Parameter.negative_bool`.
+
+.. code-block:: python
+
+   @cyclopts_app.default
+   def foo(my_flag: Annotated[bool, cyclopts.Parameter(negative_bool="--disable-")] = False):
+       print(f"{my_flag=}")
+
+
+   print("Cyclopts:")
+   cyclopts_app(["--my-flag"])
+   # my_flag=True
+   cyclopts_app(["--disable-my-flag"])
    # my_flag=False

--- a/docs/source/vs_typer/flag_negation/README.rst
+++ b/docs/source/vs_typer/flag_negation/README.rst
@@ -1,3 +1,5 @@
+.. _Typer Flag Negation:
+
 =============
 Flag Negation
 =============

--- a/docs/source/vs_typer/optional_list/README.rst
+++ b/docs/source/vs_typer/optional_list/README.rst
@@ -34,7 +34,8 @@ However, Typer supplies an empty list instead of ``None``.
 
 Cyclopts has a more intuitive solution.
 If no CLI option is specified, no argument is bound, so the parameter's default value ``None`` is used.
-If we wish to pass an empty iterable (``set``, ``list``), cyclopts provides an ``--empty-*`` flag for each iterable parameter.
+If we wish to pass an empty iterable (e.g. :class:`set` or :class:`list`), Cyclopts provides an ``--empty-*`` flag for each iterable parameter.
+This feature is configurable via :attr:`.Parameter.negative_iterable`.
 
 .. code-block:: python
 

--- a/docs/source/vs_typer/optional_list/README.rst
+++ b/docs/source/vs_typer/optional_list/README.rst
@@ -1,3 +1,5 @@
+.. _Typer Optional Lists:
+
 ==============
 Optional Lists
 ==============

--- a/docs/source/vs_typer/union_support/README.rst
+++ b/docs/source/vs_typer/union_support/README.rst
@@ -2,7 +2,7 @@
 Union/Optional Support
 ======================
 
-Currently, Typer does not support ``Union`` type annotations.
+Currently, Typer does not support :obj:`~typing.Union` type annotations.
 
 .. code-block:: python
 
@@ -18,7 +18,7 @@ Currently, Typer does not support ``Union`` type annotations.
    # AssertionError: Typer Currently doesn't support Union types
 
 
-Cyclopts fully supports ``Union`` annotations.
+Cyclopts fully supports :obj:`~typing.Union` annotations.
 Cyclopt's :ref:`Coercion Rules <Coercion Rules - Union>` iterate left-to-right over the unioned types until a coercion can be performed without error.
 
 .. code-block:: python
@@ -37,4 +37,4 @@ Cyclopt's :ref:`Coercion Rules <Coercion Rules - Union>` iterate left-to-right o
    cyclopts_app(["bar"])
    # type(value)=<class 'str'> value='bar'
 
-Naturally, Cyclopts also supports ``Optional`` types, since ``Optional`` is syntactic sugar for ``Union[..., None]``.
+Naturally, Cyclopts also supports :obj:`~typing.Optional` types, since :obj:`~typing.Optional` is syntactic sugar for ``Union[..., None]``.

--- a/docs/source/vs_typer/validation/README.rst
+++ b/docs/source/vs_typer/validation/README.rst
@@ -71,7 +71,7 @@ The ``typer.Argument`` signature has a ridiculous number of fields that only app
    ) -> Any:
        ...
 
-Cyclopts has an explicit ``validator`` field that accepts a function:
+Cyclopts has an explicit :attr:`~.Parameter.validator` field that accepts a function:
 
 .. code-block:: python
 

--- a/docs/source/vs_typer/version_flag/README.rst
+++ b/docs/source/vs_typer/version_flag/README.rst
@@ -51,7 +51,7 @@ When does ``version_callback`` get called?
 What is ``value``?
 
 With Cyclopts, the version is automatically detected by checking the version of the package instantiating :class:`App <cyclopts.App>`.
-If you prefer explicitness, ``version`` can also be explicitly supplied to :class:`App <cyclopts.App>`.
+If you prefer explicitness, :attr:`~.App.version` can also be explicitly supplied to :class:`App <cyclopts.App>`.
 
 
 .. code-block:: python


### PR DESCRIPTION
Addresses #76. Hopefully this makes it quicker to find subcommand documentation.