### PR TITLE
Allow specifying a Rich console in App.__init__

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -562,6 +562,9 @@ class App:
         tokens: Union[None, str, Iterable[str]]
             Either a string, or a list of strings to launch a command.
             Defaults to ``sys.argv[1:]``.
+        console: rich.console.Console
+            Console to print help and runtime Cyclopts errors.
+            If not provided, follows the resolution order defined in :attr:`App.console`.
         print_error: bool
             Print a rich-formatted error on error.
             Defaults to ``True``.
@@ -648,6 +651,9 @@ class App:
         tokens : Union[None, str, Iterable[str]]
             Either a string, or a list of strings to launch a command.
             Defaults to ``sys.argv[1:]``.
+        console: rich.console.Console
+            Console to print help and runtime Cyclopts errors.
+            If not provided, follows the resolution order defined in :attr:`App.console`.
         print_error: bool
             Print a rich-formatted error on error.
             Defaults to ``True``.
@@ -706,6 +712,9 @@ class App:
         tokens: Union[None, str, Iterable[str]]
             Tokens to interpret for traversing the application command structure.
             If not provided, defaults to ``sys.argv``.
+        console: rich.console.Console
+            Console to print help and runtime Cyclopts errors.
+            If not provided, follows the resolution order defined in :attr:`App.console`.
         """
         tokens = normalize_tokens(tokens)
 

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -2,8 +2,9 @@ import difflib
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
 
-from attrs import define
+from attrs import define, field
 from rich import box
+from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
@@ -92,6 +93,11 @@ class CycloptsError(Exception):
     app: Optional["App"] = None
     """
     The Cyclopts application itself.
+    """
+
+    console: Optional[Console] = field(default=None, kw_only=True)
+    """
+    Rich console to display runtime errors.
     """
 
     def __str__(self):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -76,6 +76,12 @@ API
       Defaults to ``["--version"]``.
       Cannot be changed after instantiating the app.
 
+   .. attribute:: console
+      :type: rich.Console
+      :value: None
+
+      Default :class:`rich.Console` to use when displaying runtime errors.
+
    .. attribute:: default_parameter
       :type: Parameter
       :value: None

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -81,6 +81,13 @@ API
       :value: None
 
       Default :class:`rich.console.Console` to use when displaying runtime errors.
+      Cyclopts console resolution is as follows:
+
+      #. Any explicitly passed in console to methods like :meth:`App.__call__`, :meth:`App.parse_args`, etc.
+      #. The relevant subcommand's :attr:`App.console` attribute, if not ``None``.
+      #. The parenting :attr:`App.console` (and so on), if not ``None``.
+      #. If all values are ``None``, then the default :class:`~rich.console.Console` is used.
+
 
    .. attribute:: default_parameter
       :type: Parameter

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -77,10 +77,10 @@ API
       Cannot be changed after instantiating the app.
 
    .. attribute:: console
-      :type: rich.Console
+      :type: rich.console.Console
       :value: None
 
-      Default :class:`rich.Console` to use when displaying runtime errors.
+      Default :class:`rich.console.Console` to use when displaying runtime errors.
 
    .. attribute:: default_parameter
       :type: Parameter

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,9 +69,10 @@ myst_enable_extensions = [
 
 # Intersphinx
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
-    "typing_extensions": ("https://typing-extensions.readthedocs.io/en/latest/", None),
     "pydantic": ("https://docs.pydantic.dev/latest/", None),
+    "python": ("https://docs.python.org/3", None),
+    "rich": ("https://rich.readthedocs.io/en/stable/", None),
+    "typing_extensions": ("https://typing-extensions.readthedocs.io/en/latest/", None),
 }
 
 # Napoleon settings

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,60 @@
+from contextlib import suppress
+
+import pytest
+
+from cyclopts import App, CycloptsError
+
+
+@pytest.fixture
+def subapp(app):
+    app.command(subapp := App(name="foo"))
+    return subapp
+
+
+@pytest.mark.parametrize("cmd", ["foo --help", "foo invalid-command"])
+def test_root_console(app, mocker, cmd):
+    app.console = mocker.MagicMock()
+
+    with suppress(CycloptsError):
+        app(cmd, exit_on_error=False)
+
+    app.console.print.assert_called()
+
+
+@pytest.mark.parametrize("cmd", ["foo --help", "foo invalid-command"])
+def test_root_console_subapp(app, subapp, mocker, cmd):
+    """Check if root console is properly resolved (subapp.console not specified)."""
+    app.console = mocker.MagicMock()
+
+    with suppress(CycloptsError):
+        app(cmd, exit_on_error=False)
+
+    app.console.print.assert_called()
+
+
+@pytest.mark.parametrize("cmd", ["foo --help", "foo invalid-command"])
+def test_root_subapp_console(app, subapp, mocker, cmd):
+    """Check if subapp console is properly resolved (NOT app.console)."""
+    app.console = mocker.MagicMock()
+    subapp.console = mocker.MagicMock()
+
+    with suppress(CycloptsError):
+        app(cmd, exit_on_error=False)
+
+    app.console.print.assert_not_called()
+    subapp.console.print.assert_called()
+
+
+@pytest.mark.parametrize("cmd", ["foo --help", "foo invalid-command"])
+def test_root_subapp_arg_console(app, subapp, mocker, cmd):
+    """Explicitly provided console should be used."""
+    console = mocker.MagicMock()
+    app.console = mocker.MagicMock()
+    subapp.console = mocker.MagicMock()
+
+    with suppress(CycloptsError):
+        app(cmd, console=console, exit_on_error=False)
+
+    console.print.assert_called()
+    app.console.print.assert_not_called()
+    subapp.console.print.assert_not_called()


### PR DESCRIPTION
Allows a `rich.Console` to be passed to `cyclopts.App`. I.e. `app = App(console=Console())`. The rich console is primarily used to display runtime errors, and help pages. The resolution of the console is as follows:

1. Any explicitly passed in console to methods like `App.__call__`, `App.parse_args`, etc.
2. The relevant subcommand's `App.console` attribute, if not `None`.
3. The parent's `App.console` (and so on) of the subcommand, if not `None`.
4. If all values are `None`, then the fallback default `Console()` is used.

Resolves #96

### TODO

- [x] Add unit tests.