### PR TITLE
Added async functions support

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -685,7 +685,8 @@ class App:
         try:
             if inspect.iscoroutinefunction(command):
                 return asyncio.run(command(*bound.args, **bound.kwargs))
-            return command(*bound.args, **bound.kwargs)
+            else:
+                return command(*bound.args, **bound.kwargs)
         except Exception as e:
             if PydanticValidationError is not None and isinstance(e, PydanticValidationError):
                 if print_error:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import inspect
 import os
@@ -682,6 +683,8 @@ class App:
             verbose=verbose,
         )
         try:
+            if inspect.iscoroutinefunction(command):
+                return asyncio.run(command(*bound.args, **bound.kwargs))
             return command(*bound.args, **bound.kwargs)
         except Exception as e:
             if PydanticValidationError is not None and isinstance(e, PydanticValidationError):

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -158,18 +158,22 @@ There are a few ways to adding a help string to a command:
    │ --version  Display application version.                               │
    ╰───────────────────────────────────────────────────────────────────────╯
 
------------
+-----
 Async
------------
+-----
 Cyclopts works with async functions too, it will run async function with ``asyncio.run``
 
 .. code-block:: python
 
-    app = cyclopts.App()
+   app = cyclopts.App()
 
-    @app.command
-    async def foo():
-        await asyncio.sleep(10)
+
+   @app.command
+   async def foo():
+       await asyncio.sleep(10)
+
+
+   app()
 
 
 --------------------------

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -158,6 +158,20 @@ There are a few ways to adding a help string to a command:
    │ --version  Display application version.                               │
    ╰───────────────────────────────────────────────────────────────────────╯
 
+-----------
+Async
+-----------
+Cyclopts works with async functions too, it will run async function with ``asyncio.run``
+
+.. code-block:: python
+
+    app = cyclopts.App()
+
+    @app.command
+    async def foo():
+        await asyncio.sleep(10)
+
+
 --------------------------
 Decorated Function Details
 --------------------------

--- a/docs/source/meta_app.rst
+++ b/docs/source/meta_app.rst
@@ -109,7 +109,7 @@ Just like a standard application, the parsed ``command`` executes instead of ``d
 -------------------------
 Custom Command Invocation
 -------------------------
-The :meth:`App.__call__` method is really quite simple internally:
+The core logic of :meth:`App.__call__` method is the following:
 
 .. code-block:: python
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,34 @@
+from cyclopts import App
+
+
+def test_async_handler():
+    app = App()
+
+    @app.command(name="command")
+    async def async_handler():
+        return "Async handler works"
+
+    assert app("command") == "Async handler works"
+
+
+def test_async_handler_with_subcommand_works():
+    app = App()
+
+    sub_app = App(name="foo")
+    app.command(sub_app)
+
+    @sub_app.command(name="bar")
+    async def async_handler():
+        return "Async handler works"
+
+    assert app("foo bar") == "Async handler works"
+
+
+def test_handler():
+    app = App()
+
+    @app.command(name="command")
+    def sync_handler():
+        return "Sync handler works"
+
+    assert app("command") == "Sync handler works"


### PR DESCRIPTION
Hello!

Cyclopts is a beatiful cli library!

I just started use it and found it necessary to have async support, because a lot of cli-apps doing async work. 

Now we have an option to extract async code to function and call it with `asyncio.run`, it is not comfortable.

So, I propose to do it instead of user.