### PR TITLE
Add App.name_transform

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -161,6 +161,22 @@ API
 
       The raised error message will be presented to the user with python-variables prepended with "--" remapped to their CLI counterparts.
 
+   .. attribute:: name_transform
+      :type: Optional[Callable[[str], str]]
+      :value: None
+
+      A function that converts function names to their CLI command counterparts.
+
+      The function must have signature:
+
+      .. code-block:: python
+
+         def name_transform(s: str) -> str:
+             ...
+
+      If :obj:`None` (default value), uses :func:`cyclopts.default_name_transform`.
+      If a subapp, inherits from first non-:obj:`None` parent.
+
 .. autoclass:: cyclopts.Parameter
 
    Cyclopts configuration for individual function parameters.

--- a/tests/test_name_transform.py
+++ b/tests/test_name_transform.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cyclopts import default_name_transform
+from cyclopts import App, default_name_transform
 
 
 @pytest.mark.parametrize(
@@ -16,24 +16,62 @@ def test_default_name_transform(before, after):
     assert default_name_transform(before) == after
 
 
-@pytest.mark.skip(reason="TODO")
 def test_app_name_transform_default(app):
-    pass
+    @app.command
+    def _F_O_O_():  # noqa: N802
+        pass
+
+    assert "f-o-o" in app
 
 
-@pytest.mark.skip(reason="TODO")
 def test_app_name_transform_custom(app):
-    pass
+    def name_transform(s: str) -> str:
+        return "my-custom-name-transform"
+
+    app.name_transform = name_transform
+
+    @app.command
+    def foo():
+        pass
+
+    assert "my-custom-name-transform" in app
 
 
-@pytest.mark.skip(reason="TODO")
-def test_subapp_name_transform_override(app):
-    pass
-
-
-@pytest.mark.skip(reason="TODO")
 def test_subapp_name_transform_custom(app):
-    pass
+    """A subapp with an explicitly set ``name_transform`` should NOT inherit from parent."""
+
+    def name_transform_1(s: str) -> str:
+        return "my-custom-name-transform-1"
+
+    def name_transform_2(s: str) -> str:
+        return "my-custom-name-transform-2"
+
+    app.name_transform = name_transform_1
+
+    app.command(subapp := App(name="bar", name_transform=name_transform_2))
+
+    @subapp.command
+    def foo():
+        pass
+
+    assert "my-custom-name-transform-2" in subapp
+
+
+def test_subapp_name_transform_custom_inherited(app):
+    """A subapp without an explicitly set ``name_transform`` should inherit it from the first parent."""
+
+    def name_transform(s: str) -> str:
+        return "my-custom-name-transform"
+
+    app.name_transform = name_transform
+
+    app.command(subapp := App(name="bar"))
+
+    @subapp.command
+    def foo():
+        pass
+
+    assert "my-custom-name-transform" in subapp
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
Adds the `name_transform` attribute to `cyclopts.App`. This allows the user to supply a custom function (or even a "do nothing" function like `lambda s: s`) to infer CLI commands from python function names.

CLI names must be evaluated at-time-of-function-registration. When a subapp is registered to an app, and a `name_transform` is not explicitly set, it will inherit the parenting app's `name_transform` **at registration time**.