### PR TITLE
User customizable name_transform

### DIFF
--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "UnusedCliTokensError",
     "ValidationError",
     "convert",
+    "default_name_transform",
     "types",
     "validators",
 ]
@@ -36,5 +37,6 @@ from cyclopts.exceptions import (
 from cyclopts.group import Group
 from cyclopts.parameter import Parameter
 from cyclopts.protocols import Dispatcher
+from cyclopts.utils import default_name_transform
 
 from . import types, validators

--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -27,7 +27,7 @@ else:
 
 
 from cyclopts.exceptions import CoercionError
-from cyclopts.utils import is_union
+from cyclopts.utils import default_name_transform, is_union
 
 if TYPE_CHECKING:
     from cyclopts.parameter import Parameter
@@ -83,7 +83,13 @@ _converters = {
 }
 
 
-def _convert_tuple(type_: Type[Any], *args: str, converter: Optional[Callable] = None) -> Tuple:
+def _convert_tuple(
+    type_: Type[Any],
+    *args: str,
+    converter: Optional[Callable[[Type, str], Any]],
+    name_transform: Callable[[str], str],
+) -> Tuple:
+    convert = partial(_convert, converter=converter, name_transform=name_transform)
     inner_types = tuple(x for x in get_args(type_) if x is not ...)
     inner_token_count, consume_all = token_count(type_)
     if consume_all:
@@ -101,11 +107,10 @@ def _convert_tuple(type_: Type[Any], *args: str, converter: Optional[Callable] =
             raise ValueError("A tuple must have 0 or 1 inner-types.")
 
         if inner_token_count == 1:
-            out = tuple(_convert(inner_type, x, converter=converter) for x in args)
+            out = tuple(convert(inner_type, x) for x in args)
         else:
             out = tuple(
-                _convert(inner_type, args[i : i + inner_token_count], converter=converter)
-                for i in range(0, len(args), inner_token_count)
+                convert(inner_type, args[i : i + inner_token_count]) for i in range(0, len(args), inner_token_count)
             )
         return out
     else:
@@ -116,27 +121,41 @@ def _convert_tuple(type_: Type[Any], *args: str, converter: Optional[Callable] =
         it = iter(args)
         batched = [[next(it) for _ in range(size)] for size in args_per_convert]
         batched = [elem[0] if len(elem) == 1 else elem for elem in batched]
-        out = tuple(_convert(inner_type, arg, converter=converter) for inner_type, arg in zip(inner_types, batched))
+        out = tuple(convert(inner_type, arg) for inner_type, arg in zip(inner_types, batched))
     return out
 
 
-def _convert(type_, element, converter=None, name_transform=None):
-    pconvert = partial(_convert, converter=converter)
+def _convert(
+    type_,
+    element,
+    *,
+    converter: Optional[Callable[[Type, str], Any]],
+    name_transform: Callable[[str], str],
+):
+    """Inner recursive conversion function for public ``convert``.
+
+    Parameters
+    ----------
+    converter: Callable
+    name_transform: Callable
+    """
+    convert = partial(_convert, converter=converter, name_transform=name_transform)
+    convert_tuple = partial(_convert_tuple, converter=converter, name_transform=name_transform)
     origin_type = get_origin(type_)
     inner_types = [resolve(x) for x in get_args(type_)]
 
     if type_ in _implicit_iterable_type_mapping:
-        return pconvert(_implicit_iterable_type_mapping[type_], element)
+        return convert(_implicit_iterable_type_mapping[type_], element)
 
     if origin_type is collections.abc.Iterable:
         assert len(inner_types) == 1
-        return pconvert(List[inner_types[0]], element)  # pyright: ignore[reportGeneralTypeIssues]
+        return convert(List[inner_types[0]], element)  # pyright: ignore[reportGeneralTypeIssues]
     elif is_union(origin_type):
         for t in inner_types:
             if t is NoneType:
                 continue
             try:
-                return pconvert(t, element)
+                return convert(t, element)
             except Exception:
                 pass
         else:
@@ -144,7 +163,7 @@ def _convert(type_, element, converter=None, name_transform=None):
     elif origin_type is Literal:
         for choice in get_args(type_):
             try:
-                res = pconvert(type(choice), (element))
+                res = convert(type(choice), (element))
             except Exception:
                 continue
             if res == choice:
@@ -157,18 +176,18 @@ def _convert(type_, element, converter=None, name_transform=None):
             gen = zip(*[iter(element)] * count)
         else:
             gen = element
-        return origin_type(pconvert(inner_types[0], e) for e in gen)  # pyright: ignore[reportOptionalCall]
+        return origin_type(convert(inner_types[0], e) for e in gen)  # pyright: ignore[reportOptionalCall]
     elif origin_type is tuple:
         if isinstance(element, str):
             # E.g. Tuple[str] (Annotation: tuple containing a single string)
-            return _convert_tuple(type_, element, converter=converter)
+            return convert_tuple(type_, element, converter=converter)
         else:
-            return _convert_tuple(type_, *element, converter=converter)
+            return convert_tuple(type_, *element, converter=converter)
     elif isclass(type_) and issubclass(type_, Enum):
         if converter is None:
-            element_lower = element.lower().replace("-", "_")
+            element_lower = name_transform(element)
             for member in type_:
-                if member.name.lower().strip("_") == element_lower:
+                if name_transform(member.name) == element_lower:
                     return member
             raise CoercionError(input_value=element, target_type=type_)
         else:
@@ -240,7 +259,12 @@ def resolve_annotated(type_: Type) -> Type:
     return type_
 
 
-def convert(type_: Type, *args: str, converter: Optional[Callable] = None):
+def convert(
+    type_: Type,
+    *args: str,
+    converter: Optional[Callable[[Type, str], Any]] = None,
+    name_transform: Optional[Callable[[str], str]] = None,
+):
     """Coerce variables into a specified type.
 
     Internally used to coercing string CLI tokens into python builtin types.
@@ -259,8 +283,7 @@ def convert(type_: Type, *args: str, converter: Optional[Callable] = None):
         A type hint/annotation to coerce ``*args`` into.
     `*args`: str
         String tokens to coerce.
-    converter: Optional[Callable]
-
+    converter: Optional[Callable[[Type, str], Any]]
         An optional function to convert tokens to the inner-most types.
         The converter should have signature:
 
@@ -272,12 +295,31 @@ def convert(type_: Type, *args: str, converter: Optional[Callable] = None):
         This allows to use the :func:`convert` function to handle the the difficult task
         of traversing lists/tuples/unions/etc, while leaving the final conversion logic to
         the caller.
+    name_transform: Optional[Callable[[str], str]]
+        Currently only used for ``Enum`` type hints.
+        A function that transforms enum names and CLI values into a normalized format.
+
+        The function should have signature:
+
+        .. code-block:: python
+
+            def name_transform(s: str) -> str:
+                ...
+
+        where the returned value is the name to be used on the CLI.
+
+        If ``None``, defaults to ``cyclopts.default_name_transform``.
 
     Returns
     -------
     Any
         Coerced version of input ``*args``.
     """
+    if name_transform is None:
+        name_transform = default_name_transform
+
+    convert = partial(_convert, converter=converter, name_transform=name_transform)
+    convert_tuple = partial(_convert_tuple, converter=converter, name_transform=name_transform)
     type_ = resolve(type_)
 
     if type_ is Any:
@@ -288,13 +330,13 @@ def convert(type_: Type, *args: str, converter: Optional[Callable] = None):
     origin_type = get_origin_and_validate(type_)
 
     if origin_type is tuple:
-        return _convert_tuple(type_, *args, converter=converter)
+        return convert_tuple(type_, *args)
     elif (origin_type or type_) in _iterable_types or origin_type is collections.abc.Iterable:
-        return _convert(type_, args, converter=converter)
+        return convert(type_, args)
     elif len(args) == 1:
-        return _convert(type_, args[0], converter=converter)
+        return convert(type_, args[0])
     else:
-        return [_convert(type_, item, converter=converter) for item in args]
+        return [convert(type_, item) for item in args]
 
 
 def token_count(type_: Union[Type[Any], inspect.Parameter]) -> Tuple[int, bool]:

--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -185,9 +185,9 @@ def _convert(
             return convert_tuple(type_, *element, converter=converter)
     elif isclass(type_) and issubclass(type_, Enum):
         if converter is None:
-            element_lower = name_transform(element)
+            element_transformed = name_transform(element)
             for member in type_:
-                if name_transform(member.name) == element_lower:
+                if name_transform(member.name) == element_transformed:
                     return member
             raise CoercionError(input_value=element, target_type=type_)
         else:

--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -120,7 +120,7 @@ def _convert_tuple(type_: Type[Any], *args: str, converter: Optional[Callable] =
     return out
 
 
-def _convert(type_, element, converter=None):
+def _convert(type_, element, converter=None, name_transform=None):
     pconvert = partial(_convert, converter=converter)
     origin_type = get_origin(type_)
     inner_types = [resolve(x) for x in get_args(type_)]

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -178,11 +178,11 @@ def default_name_transform(s: str) -> str:
 
     Performs the following operations (in order):
 
-    1. ``lower`` the string.
+    1. Convert the string to all lowercase.
     2. Replace ``_`` with ``-``.
-    3. Strip any leading/trailing ``_`` or ``-``.
+    3. Strip any leading/trailing ``-`` (also stripping ``_``, due to point 2).
 
-    TODO: ADD INTENDED USE-CASE.
+    Intended to be used with :attr:`App.name_transform` and :attr:`Parameter.name_transform`.
 
     Parameters
     ----------

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -176,6 +176,12 @@ def optional_to_tuple_converter(value: Union[None, Any, Iterable[Any]]) -> Optio
 def default_name_transform(s: str) -> str:
     """Converts a python identifier into a CLI token.
 
+    Performs the following operations (in order):
+
+    1. ``lower`` the string.
+    2. Replace ``_`` with ``-``.
+    3. Strip any leading/trailing ``_`` or ``-``.
+
     TODO: ADD INTENDED USE-CASE.
 
     Parameters

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -171,3 +171,21 @@ def optional_to_tuple_converter(value: Union[None, Any, Iterable[Any]]) -> Optio
         return ()
 
     return to_tuple_converter(value)
+
+
+def default_name_transform(s: str) -> str:
+    """Converts a python identifier into a CLI token.
+
+    TODO: ADD INTENDED USE-CASE.
+
+    Parameters
+    ----------
+    s: str
+        Input python identifier string.
+
+    Returns
+    -------
+    str
+        Transformed name.
+    """
+    return s.lower().replace("_", "-").strip("-")

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -320,6 +320,21 @@ API
       If multiple environment variables are given, the left-most environment variable with a set value will be used.
       If no environment variable is set, Cyclopts will fallback to the function-signature default.
 
+   .. attribute:: name_transform
+       :type: Optional[Callable[[str], str]]
+       :value: None
+
+       A function that converts python parameter names to their CLI command counterparts.
+
+       The function must have signature:
+
+       .. code-block:: python
+
+          def name_transform(s: str) -> str:
+              ...
+
+       If :obj:`None` (default value), uses :func:`cyclopts.default_name_transform`.
+
    .. automethod:: combine
 
    .. automethod:: default

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -480,6 +480,7 @@ API
 
 .. autofunction:: cyclopts.convert
 
+.. autofunction:: cyclopts.default_name_transform
 
 .. _API Validators:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -161,6 +161,22 @@ API
 
       The raised error message will be presented to the user with python-variables prepended with "--" remapped to their CLI counterparts.
 
+   .. attribute:: name_transform
+      :type: Optional[Callable[[str], str]]
+      :value: None
+
+      A function that converts function names to their CLI command counterparts.
+
+      The function must have signature:
+
+      .. code-block:: python
+
+         def name_transform(s: str) -> str:
+             ...
+
+      If :obj:`None` (default value), uses :func:`cyclopts.default_name_transform`.
+      If a subapp, inherits from first non-:obj:`None` parent.
+
 .. autoclass:: cyclopts.Parameter
 
    Cyclopts configuration for individual function parameters.

--- a/docs/source/args_and_kwargs.rst
+++ b/docs/source/args_and_kwargs.rst
@@ -57,7 +57,7 @@ A variable number of keyword arguments consume all remaining CLI tokens starting
 Individual values are converted to the annotated type.
 As with normal python ``**kwargs``, the keywords are limited to python identifiers.
 Most prominently, no spaces allowed.
-Keyword name-conversion is the :ref:`same as commands <Changing Name>`.
+Keyword name-conversion is the :ref:`same as commands <Command Changing Name>`.
 
 .. code-block:: python
 

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -11,7 +11,6 @@ There are 2 function-registering decorators:
    This was previously demonstrated in :ref:`Getting Started`.
 
    A sub-app **cannot** be registered with :meth:`@app.default <cyclopts.App.default>`.
-
    The default :meth:`app.default <cyclopts.App.default>` handler runs :meth:`app.help_print <cyclopts.App.help_print>`.
 
 2. :meth:`@app.command <cyclopts.App.command>` - Registers a function or :class:`.App` as a command.
@@ -92,17 +91,23 @@ The :meth:`@app.command <cyclopts.App.command>` method can also register another
 The subcommand may have it's own registered ``default`` action.
 Cyclopts's command structure is fully recursive.
 
-.. _Changing Name:
+.. _Command Changing Name:
 
 -------------
 Changing Name
 -------------
 By default, a command is registered to the function name with underscores replaced with hyphens.
 Any leading or trailing underscore/hyphens will also be stripped.
-For example, ``def _foo_bar()`` will become the command ``foo-bar``.
+For example, the function ``_foo_bar()`` will become the command ``foo-bar``.
+This automatic command name transform can be configured by :attr:`App.name_transform <cyclopts.App.name_transform>`.
+For example, to make CLI command names be identical to their python function name counterparts, we can configure :class:`~cyclopts.App` as follows:
 
-The name can be manually changed in the :meth:`@app.command <cyclopts.App.command>` decorator.
-Manually set names are not subject to this name conversion.
+.. code-block:: python
+
+   app = App(name_transform=lambda s: s)
+
+Alternatively, the name can be manually changed in the :meth:`@app.command <cyclopts.App.command>` decorator.
+Manually set names are not subject to :attr:`App.name_transform <cyclopts.App.name_transform>`.
 
 .. code-block:: python
 

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -63,6 +63,22 @@ Prior to Python 3.9, :obj:`~typing.Annotated` has to be imported from ``typing_e
 :class:`.Parameter` gives complete control on how Cyclopts processes the annotated parameter.
 See the API page for all configurable options.
 
+------
+Naming
+------
+Like :ref:`command names <Command Changing Name>`, commandline parameters are derived from their python function argument counterparts.
+This automatic command name transform can be configured by :attr:`Parameter.name_transform <cyclopts.Parameter.name_transform>`. Note that the resulting string is **before** the standard ``--`` is prepended.
+
+To change the :attr:`~cyclopts.Parameter.name_transform` across your entire app, add the following to your :class:`~cyclopts.App` configuration:
+
+.. code-block:: python
+
+   app = App(
+       default_parameter=Parameter(name_transform=my_custom_name_transform),
+   )
+
+Manually set names via :attr:`Parameter.name <cyclopts.Parameter.name>` are not subject to :attr:`Parameter.name_transform <cyclopts.Parameter.name_transform>`.
+
 ----
 Help
 ----

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -276,6 +276,7 @@ While `Literal`_ is the recommended way of providing the user options, another m
 For a user provided token, a **case-insensitive name** lookup is performed.
 If an enum name contains an underscore, the CLI parameter **may** instead contain a hyphen, ``-``.
 Leading/Trailing underscores will be stripped.
+TODO: refer to ``name_transform``.
 
 If coming from Typer_, **Cyclopts Enum handling is reversed compared to Typer**.
 Typer attempts to match the token to an Enum **value**; Cyclopts attempts to match the token to an Enum **name**.

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -273,12 +273,12 @@ Enum
 ****
 While `Literal`_ is the recommended way of providing the user options, another method is using :class:`~enum.Enum`.
 
-For a user provided token, a **case-insensitive name** lookup is performed.
+:attr:`Parameter.name_transform <cyclopts.Parameter.name_transform>` gets applied to all :class:`~enum.Enum` names, as well as the CLI provided token.
+By default,this means that a **case-insensitive name** lookup is performed.
 If an enum name contains an underscore, the CLI parameter **may** instead contain a hyphen, ``-``.
 Leading/Trailing underscores will be stripped.
-TODO: refer to ``name_transform``.
 
-If coming from Typer_, **Cyclopts Enum handling is reversed compared to Typer**.
+If coming from Typer_, **Cyclopts Enum handling is the reverse of Typer**.
 Typer attempts to match the token to an Enum **value**; Cyclopts attempts to match the token to an Enum **name**.
 
 

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -132,7 +132,10 @@ def test_coerce_enum():
         PROD = auto()
         _PROD_OLD = auto()
 
+    # tests case-insensitivity
     assert SoftwareEnvironment.STAGING == convert(SoftwareEnvironment, "staging")
+
+    # tests underscore/hyphen support
     assert SoftwareEnvironment._PROD_OLD == convert(SoftwareEnvironment, "prod_old")
     assert SoftwareEnvironment._PROD_OLD == convert(SoftwareEnvironment, "prod-old")
 

--- a/tests/test_name_transform.py
+++ b/tests/test_name_transform.py
@@ -1,0 +1,46 @@
+import pytest
+
+from cyclopts import default_name_transform
+
+
+@pytest.mark.parametrize(
+    "before,after",
+    [
+        ("FOO", "foo"),
+        ("_FOO", "foo"),
+        ("_FOO_", "foo"),
+        ("_F_O_O_", "f-o-o"),
+    ],
+)
+def test_default_name_transform(before, after):
+    assert default_name_transform(before) == after
+
+
+@pytest.mark.skip(reason="TODO")
+def test_app_name_transform_default(app):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_app_name_transform_custom(app):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_subapp_name_transform_override(app):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_subapp_name_transform_custom(app):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_parameter_name_transform_default(app):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_parameter_name_transform_custom(app):
+    pass

--- a/tests/test_name_transform.py
+++ b/tests/test_name_transform.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cyclopts import default_name_transform
+from cyclopts import App, default_name_transform
 
 
 @pytest.mark.parametrize(
@@ -16,24 +16,62 @@ def test_default_name_transform(before, after):
     assert default_name_transform(before) == after
 
 
-@pytest.mark.skip(reason="TODO")
 def test_app_name_transform_default(app):
-    pass
+    @app.command
+    def _F_O_O_():  # noqa: N802
+        pass
+
+    assert "f-o-o" in app
 
 
-@pytest.mark.skip(reason="TODO")
 def test_app_name_transform_custom(app):
-    pass
+    def name_transform(s: str) -> str:
+        return "my-custom-name-transform"
+
+    app.name_transform = name_transform
+
+    @app.command
+    def foo():
+        pass
+
+    assert "my-custom-name-transform" in app
 
 
-@pytest.mark.skip(reason="TODO")
-def test_subapp_name_transform_override(app):
-    pass
-
-
-@pytest.mark.skip(reason="TODO")
 def test_subapp_name_transform_custom(app):
-    pass
+    """A subapp with an explicitly set ``name_transform`` should NOT inherit from parent."""
+
+    def name_transform_1(s: str) -> str:
+        return "my-custom-name-transform-1"
+
+    def name_transform_2(s: str) -> str:
+        return "my-custom-name-transform-2"
+
+    app.name_transform = name_transform_1
+
+    app.command(subapp := App(name="bar", name_transform=name_transform_2))
+
+    @subapp.command
+    def foo():
+        pass
+
+    assert "my-custom-name-transform-2" in subapp
+
+
+def test_subapp_name_transform_custom_inherited(app):
+    """A subapp without an explicitly set ``name_transform`` should inherit it from the first parent."""
+
+    def name_transform(s: str) -> str:
+        return "my-custom-name-transform"
+
+    app.name_transform = name_transform
+
+    app.command(subapp := App(name="bar"))
+
+    @subapp.command
+    def foo():
+        pass
+
+    assert "my-custom-name-transform" in subapp
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
This PR primarily adds two new fields: `App.name_transform` and `Parameter.name_transform`. The function's responsibility is to convert python identifiers to their CLI counterparts and has signature:

```
def name_transform(s: str) -> str:
    ...
```

These name transforms can be set at a global level for your app:

```
app = App(
    name_transform=lambda name: name,  # don't modify the name at all. This applies to command names.
    default_parameter=Parameter(name_transform=lambda name: name),  # This applies to parameter names.
)
```

They can also be set in individual subapps (subapps inherit `name_transform` from their parent), or in individual `Annotated[...., Parameter(name_transform=my_custom_transform)]` definitions.

Addresses #140.