### PR TITLE
Improve type inference when using decorators with pyright

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -17,7 +17,10 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    TypeVar
 )
+
+T = TypeVar('T', bound=Callable)
 
 from attrs import define, field
 
@@ -446,10 +449,10 @@ class App:
 
     def command(
         self,
-        obj: Optional[Callable] = None,
+        obj: Optional[T] = None,
         name: Union[None, str, Iterable[str]] = None,
         **kwargs,
-    ) -> Callable:
+    ) -> T:
         """Decorator to register a function as a CLI command.
 
         Parameters
@@ -510,11 +513,11 @@ class App:
 
     def default(
         self,
-        obj: Optional[Callable] = None,
+        obj: Optional[T] = None,
         *,
         converter=None,
         validator=None,
-    ):
+    ) -> T:
         """Decorator to register a function as the default action handler."""
         if obj is None:  # Called ``@app.default_command(...)``
             return partial(self.default, converter=converter, validator=validator)

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -16,11 +16,9 @@ from typing import (
     Literal,
     Optional,
     Tuple,
+    TypeVar,
     Union,
-    TypeVar
 )
-
-T = TypeVar('T', bound=Callable)
 
 from attrs import define, field
 
@@ -53,6 +51,9 @@ from cyclopts.utils import (
     to_list_converter,
     to_tuple_converter,
 )
+
+T = TypeVar("T", bound=Callable)
+
 
 if sys.version_info < (3, 9):
     from typing_extensions import Annotated
@@ -469,7 +470,7 @@ class App:
             Any argument that :class:`App` can take.
         """
         if obj is None:  # Called ``@app.command(...)``
-            return partial(self.command, name=name, **kwargs)
+            return partial(self.command, name=name, **kwargs)  # pyright: ignore[reportReturnType]
 
         if isinstance(obj, App):
             app = obj
@@ -509,7 +510,7 @@ class App:
 
         app._parents.append(self)
 
-        return obj
+        return obj  # pyright: ignore[reportReturnType]
 
     def default(
         self,
@@ -520,7 +521,7 @@ class App:
     ) -> T:
         """Decorator to register a function as the default action handler."""
         if obj is None:  # Called ``@app.default_command(...)``
-            return partial(self.default, converter=converter, validator=validator)
+            return partial(self.default, converter=converter, validator=validator)  # pyright: ignore[reportReturnType]
 
         if isinstance(obj, App):  # Registering a sub-App
             raise TypeError("Cannot register a sub-App to default.")


### PR DESCRIPTION
## Problem

`pyright` infers the wrong types for functions which are decorated with `@app.command` or `@app.default`.

Use of `TypeVar` here allows to explicitly preserve the original type information of the original non-wrapped function argument which isn't modified in anyway by the decorators