### PR TITLE
defer import docstring_parser

### DIFF
--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -15,7 +15,6 @@ from typing import (
     get_origin,
 )
 
-import docstring_parser
 from attrs import define, field, frozen
 
 import cyclopts.utils
@@ -31,6 +30,8 @@ if TYPE_CHECKING:
 @lru_cache(maxsize=16)
 def docstring_parse(doc: str):
     """Addon to :func:`docstring_parser.parse` that double checks the `short_description`."""
+    import docstring_parser
+
     res = docstring_parser.parse(doc)
     cleaned_doc = inspect.cleandoc(doc)
     short = cleaned_doc.split("\n\n")[0]

--- a/cyclopts/resolve.py
+++ b/cyclopts/resolve.py
@@ -8,8 +8,6 @@ import inspect
 from functools import cached_property
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast, get_origin
 
-from docstring_parser import parse as docstring_parse
-
 import cyclopts.utils
 from cyclopts.exceptions import DocstringError
 from cyclopts.group import Group
@@ -95,6 +93,8 @@ def _resolve_groups(
 
 
 def _resolve_docstring(f: Callable, signature: inspect.Signature) -> ParameterDict:
+    from docstring_parser import parse as docstring_parse
+
     iparam_to_docstring_cparam = ParameterDict()
     if f.__doc__ is None:
         return iparam_to_docstring_cparam

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ sections=["tool.poetry.dependencies"]
 exclude-deps =[
   "importlib-metadata",
   "typing-extensions",
+  "docstring-parser",  # Not detected due to deferred import.
   "rich-rst",  # Not detected due to deferred import.
   "rich",  # Not detected due to deferred import.
   "tomli",  # Not detected due to optional feature.


### PR DESCRIPTION
* slightly speeds up import time for the "happy" execution path where we don't need to parse docstrings.