### PR TITLE
Bugfix/version help format

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -42,6 +42,7 @@ from cyclopts.help import (
     format_str,
     format_usage,
     resolve_help_format,
+    resolve_version_format,
 )
 from cyclopts.parameter import Parameter, validate_command
 from cyclopts.protocols import Dispatcher
@@ -229,6 +230,17 @@ class App:
         ]
     ] = field(default=None, kw_only=True)
 
+    version_format: Optional[
+        Literal[
+            "markdown",
+            "md",
+            "plaintext",
+            "restructuredtext",
+            "rst",
+            "rich",
+        ]
+    ] = field(default=None, kw_only=True)
+
     # This can ONLY ever be Tuple[Union[Group, str], ...] due to converter.
     # The other types is to make mypy happy for Cyclopts users.
     group: Union[Group, str, Tuple[Union[Group, str], ...]] = field(
@@ -397,7 +409,7 @@ class App:
 
         """
         console = self._resolve_console(None, console)
-        help_format = resolve_help_format([self])
+        help_format = resolve_version_format([self])
 
         version_raw = self.version() if callable(self.version) else self.version
 

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -409,14 +409,14 @@ class App:
 
         """
         console = self._resolve_console(None, console)
-        help_format = resolve_version_format([self])
+        version_format = resolve_version_format([self])
 
         version_raw = self.version() if callable(self.version) else self.version
 
         if version_raw is None:
             version_raw = "0.0.0"
 
-        version_formatted = format_str(version_raw, format=help_format)
+        version_formatted = format_str(version_raw, format=version_format)
         console.print(version_formatted)
 
     def __getitem__(self, key: str) -> "App":

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -39,6 +39,7 @@ from cyclopts.help import (
     create_parameter_help_panel,
     format_command_entries,
     format_doc,
+    format_str,
     format_usage,
     resolve_help_format,
 )
@@ -197,7 +198,7 @@ class App:
         kw_only=True,
     )
 
-    version: Union[None, str, Callable] = field(factory=_default_version, kw_only=True)
+    version: Union[None, str, Callable[..., str]] = field(factory=_default_version, kw_only=True)
     # This can ONLY ever be a Tuple[str, ...]
     _version_flags: Union[str, Iterable[str]] = field(
         default=["--version"],
@@ -382,9 +383,29 @@ class App:
     def name_transform(self, value):
         self._name_transform = value
 
-    def version_print(self) -> None:
-        """Print the application version."""
-        print(self.version() if callable(self.version) else self.version)
+    def version_print(
+        self,
+        console: Optional["Console"] = None,
+    ) -> None:
+        """Print the application version.
+
+        Parameters
+        ----------
+        console: rich.console.Console
+            Console to print version string to.
+            If not provided, follows the resolution order defined in :attr:`App.console`.
+
+        """
+        console = self._resolve_console(None, console)
+        help_format = resolve_help_format(None)
+
+        version_raw = self.version() if callable(self.version) else self.version
+
+        if version_raw is None:
+            version_raw = "0.0.0"
+
+        version_formatted = format_str(version_raw, format=help_format)
+        console.print(version_formatted)
 
     def __getitem__(self, key: str) -> "App":
         """Get the subapp from a command string.
@@ -430,11 +451,7 @@ class App:
 
     def parse_commands(
         self,
-        tokens: Union[
-            None,
-            str,
-            Iterable[str],
-        ] = None,
+        tokens: Union[None, str, Iterable[str]] = None,
     ) -> Tuple[Tuple[str, ...], Tuple["App", ...], List[str]]:
         """Extract out the command tokens from a command.
 
@@ -576,6 +593,9 @@ class App:
         tokens: Union[None, str, Iterable[str]]
             Either a string, or a list of strings to launch a command.
             Defaults to ``sys.argv[1:]``
+        console: rich.console.Console
+            Console to print help and runtime Cyclopts errors.
+            If not provided, follows the resolution order defined in :attr:`App.console`.
 
         Returns
         -------
@@ -912,9 +932,7 @@ class App:
                     panels[group.name] = (group, command_panel)
 
                 if group.help:
-                    import cyclopts.help
-
-                    group_help = cyclopts.help._format(group.help, format=help_format)
+                    group_help = format_str(group.help, format=help_format)
 
                     if command_panel.description:
                         command_panel.description = RichGroup(command_panel.description, NewLine(), group_help)

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -397,7 +397,7 @@ class App:
 
         """
         console = self._resolve_console(None, console)
-        help_format = resolve_help_format(None)
+        help_format = resolve_help_format([self])
 
         version_raw = self.version() if callable(self.version) else self.version
 

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -8,6 +8,7 @@ from typing import (
     Iterable,
     List,
     Literal,
+    Optional,
     Tuple,
     Type,
     Union,
@@ -212,10 +213,10 @@ def format_doc(root_app, app: "App", format: str = "restructuredtext"):
             components.append("\n")
         components.append((parsed.long_description + "\n", "info"))
 
-    return RichGroup(_format(*components, format=format), NewLine())
+    return RichGroup(format_str(*components, format=format), NewLine())
 
 
-def _format(*components: Union[str, Tuple[str, str]], format: str = "restructuredtext") -> "RenderableType":
+def format_str(*components: Union[str, Tuple[str, str]], format: str = "restructuredtext") -> "RenderableType":
     format = format.lower()
 
     if format == "plaintext":
@@ -290,7 +291,7 @@ def create_parameter_help_panel(
     cparams: List[Parameter],
     format: str,
 ) -> HelpPanel:
-    help_panel = HelpPanel(format="parameter", title=group.name, description=_format(group.help, format=format))
+    help_panel = HelpPanel(format="parameter", title=group.name, description=format_str(group.help, format=format))
     icparams = [(ip, cp) for ip, cp in zip(iparams, cparams) if cp.show]
 
     if not icparams:
@@ -358,7 +359,7 @@ def create_parameter_help_panel(
         help_panel.entries.append(
             HelpEntry(
                 name=",".join(long_options),
-                description=_format(*help_components, format=format),
+                description=format_str(*help_components, format=format),
                 short=",".join(short_options),
                 required=bool(cparam.required),
             )
@@ -376,16 +377,18 @@ def format_command_entries(apps: Iterable["App"], format: str) -> List:
         entry = HelpEntry(
             name=",".join(long_names),
             short=",".join(short_names),
-            description=_format(docstring_parse(app.help).short_description or "", format=format),
+            description=format_str(docstring_parse(app.help).short_description or "", format=format),
         )
         if entry not in entries:
             entries.append(entry)
     return entries
 
 
-def resolve_help_format(app_chain: Iterable["App"]) -> str:
+def resolve_help_format(app_chain: Optional[Iterable["App"]]) -> str:
     # Resolve help_format; None fallsback to parent; non-None overwrites parent.
     help_format = "restructuredtext"
+    if app_chain is None:
+        return help_format
     for app in app_chain:
         if app.help_format is not None:
             help_format = app.help_format

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -386,10 +386,21 @@ def format_command_entries(apps: Iterable["App"], format: str) -> List:
 
 def resolve_help_format(app_chain: Optional[Iterable["App"]]) -> str:
     # Resolve help_format; None fallsback to parent; non-None overwrites parent.
-    help_format = "restructuredtext"
+    format_ = "restructuredtext"
     if app_chain is None:
-        return help_format
+        return format_
     for app in app_chain:
         if app.help_format is not None:
-            help_format = app.help_format
-    return help_format
+            format_ = app.help_format
+    return format_
+
+
+def resolve_version_format(app_chain: Optional[Iterable["App"]]) -> str:
+    # Resolve version_format; None fallsback to parent; non-None overwrites parent.
+    format_ = resolve_help_format(app_chain)
+    if app_chain is None:
+        return format_
+    for app in app_chain:
+        if app.version_format is not None:
+            format_ = app.version_format
+    return format_

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -51,7 +51,8 @@ API
       :value: None
 
       The markup language of the version string; used in :meth:`version_print`.
-      If :obj:`None`, fallback to resolved :attr:`~.App.help_format`.
+      If :obj:`None`, fallback to parenting :attr:`~.App.version_format`.
+      If no :attr:`~.App.version_format` is defined, falls back to resolved :attr:`~.App.help_format`.
 
    .. attribute:: usage
       :type: Optional[str]

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,6 +46,13 @@ API
       If :obj:`None`, fallback to parenting :attr:`~.App.help_format`.
       If no :attr:`~.App.help_format` is defined, falls back to ``"restructuredtext"``.
 
+   .. attribute:: version_format
+      :type: Optional[Literal["plaintext", "markdown", "md", "restructuredtext", "rst"]]
+      :value: None
+
+      The markup language of the version string; used in :meth:`version_print`.
+      If :obj:`None`, fallback to resolved :attr:`~.App.help_format`.
+
    .. attribute:: usage
       :type: Optional[str]
       :value: None

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -5,11 +5,6 @@ from typing import List, Literal, Optional, Set, Tuple, Union
 
 import pytest
 
-if sys.version_info < (3, 9):
-    from typing_extensions import Annotated
-else:
-    from typing import Annotated
-
 from cyclopts import App, Group, Parameter
 from cyclopts.help import (
     HelpPanel,
@@ -18,6 +13,11 @@ from cyclopts.help import (
     format_usage,
 )
 from cyclopts.resolve import ResolvedCommand
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
 
 
 @pytest.fixture

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+def test_version_print_console_from_init(app, console):
+    app.console = console
+
+    with console.capture() as capture:
+        app.version_print()
+
+    assert "0.0.0\n" == capture.get()
+
+
+def test_version_print_console_from_method(app, console):
+    with console.capture() as capture:
+        app.version_print(console)
+
+    assert "0.0.0\n" == capture.get()
+
+
+def test_version_print_custom_string(app, console):
+    """The asterisks also test to make sure the proper help_format is being used."""
+    app.version = "**foo**"
+
+    with console.capture() as capture:
+        app.version_print(console)
+
+    assert "foo\n" == capture.get()
+
+
+def test_version_print_custom_callable(app, console):
+    def my_version():
+        return "**foo**"
+
+    app.version = my_version
+
+    with console.capture() as capture:
+        app.version_print(console)
+
+    assert "foo\n" == capture.get()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -40,7 +40,21 @@ def test_version_print_custom_callable(app, console):
 
 
 def test_version_print_help_format_fallback(app, console):
-    app.version = "[red]foo[/foo]"
+    """If no explicit version_format is provided, we should fallback to help_format."""
+    app.help_format = "rich"
+    app.version = "[red]foo[/red]"
+
+    with console.capture() as capture:
+        app.version_print(console)
+
+    assert "foo\n" == capture.get()
+
+
+def test_version_print_help_format_override(app, console):
+    """If version_format is provided, help_format should not be used for version."""
+    app.help_format = "plain"
+    app.version_format = "rich"
+    app.version = "[red]foo[/red]"
 
     with console.capture() as capture:
         app.version_print(console)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -37,3 +37,12 @@ def test_version_print_custom_callable(app, console):
         app.version_print(console)
 
     assert "foo\n" == capture.get()
+
+
+def test_version_print_help_format_fallback(app, console):
+    app.version = "[red]foo[/foo]"
+
+    with console.capture() as capture:
+        app.version_print(console)
+
+    assert "foo\n" == capture.get()


### PR DESCRIPTION
Applies the designated `App.help_format` to the `App.version` when calling `App.version_print()`.

@glenfletcher can you see if this fixes the bug for you? Thanks!

Addresses #187 .