### PR TITLE
Changed the type-hints of App.command() to support recent versions of pyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^(poetry.lock|.idea/)
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.4.8"
+    rev: "v0.5.0"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -32,23 +32,23 @@ repos:
         exclude: \.(html|svg)$
 
   - repo: https://github.com/fredrikaverpil/creosote.git
-    rev: v3.0.0
+    rev: v3.0.2
     hooks:
       - id: creosote
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.21.0
+    rev: v1.22.9
     hooks:
       - id: typos
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.361
+    rev: v1.1.370
     hooks:
       - id: pyright

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -248,17 +248,20 @@ class App:
         default=None, converter=to_tuple_converter, kw_only=True
     )
 
-    group_arguments: Group = field(
+    # This can ONLY ever be a Group
+    group_arguments: Union[Group, str, None] = field(
         default=None,
         converter=GroupConverter(Group.create_default_arguments()),
         kw_only=True,
     )
-    group_parameters: Group = field(
+    # This can ONLY ever be a Group
+    group_parameters: Union[Group, str, None] = field(
         default=None,
         converter=GroupConverter(Group.create_default_parameters()),
         kw_only=True,
     )
-    group_commands: Group = field(
+    # This can ONLY ever be a Group
+    group_commands: Union[Group, str, None] = field(
         default=None,
         converter=GroupConverter(Group.create_default_commands()),
         kw_only=True,
@@ -517,7 +520,6 @@ class App:
         **kwargs: object,
     ) -> T: ...
 
-
     # This overload is used in code like:
     #
     # @app.command(name="bar")
@@ -573,7 +575,7 @@ class App:
                 kwargs["group_parameters"] = copy(self.group_parameters)
             if "group_arguments" not in kwargs:
                 kwargs["group_arguments"] = copy(self.group_arguments)
-            app = App(default_command=obj, **kwargs)
+            app = App(default_command=obj, **kwargs)  # pyright: ignore
             # app.name is handled below
 
         if app._name_transform is None:
@@ -582,7 +584,7 @@ class App:
         if name is None:
             name = app.name
         else:
-            app._name = name
+            app._name = name  # pyright: ignore[reportAttributeAccessIssue]
 
         for n in to_tuple_converter(name):
             if n in self:
@@ -931,6 +933,9 @@ class App:
 
         if not apps[-1].default_command:
             raise InvalidCommandError
+
+        assert isinstance(apps[-1].group_arguments, Group)
+        assert isinstance(apps[-1].group_parameters, Group)
 
         resolved_command = ResolvedCommand(
             apps[-1].default_command,

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -538,7 +538,7 @@ class App:
         obj: Optional[T] = None,
         name: Union[None, str, Iterable[str]] = None,
         **kwargs: object,
-    ) -> T | Callable[[T], T]:
+    ) -> Union[T, Callable[[T], T]]:
         """Decorator to register a function as a CLI command.
 
         Parameters

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 
 from attrs import define, field
@@ -503,12 +504,39 @@ class App:
 
         return tuple(command_chain), tuple(apps), unused_tokens
 
+    # This overload is used in code like:
+    #
+    # @app.command
+    # def my_command(foo: str):
+    #   ...
+    @overload
+    def command(
+        self,
+        obj: T,
+        name: Union[None, str, Iterable[str]] = None,
+        **kwargs: object,
+    ) -> T: ...
+
+
+    # This overload is used in code like:
+    #
+    # @app.command(name="bar")
+    # def my_command(foo: str):
+    #   ...
+    @overload
+    def command(
+        self,
+        obj: None = None,
+        name: Union[None, str, Iterable[str]] = None,
+        **kwargs: object,
+    ) -> Callable[[T], T]: ...
+
     def command(
         self,
         obj: Optional[T] = None,
         name: Union[None, str, Iterable[str]] = None,
-        **kwargs,
-    ) -> T:
+        **kwargs: object,
+    ) -> T | Callable[[T], T]:
         """Decorator to register a function as a CLI command.
 
         Parameters

--- a/cyclopts/group_extractors.py
+++ b/cyclopts/group_extractors.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
 
+from cyclopts.group import Group
+
 if TYPE_CHECKING:
     from cyclopts.core import App
-
-from cyclopts.group import Group
 
 
 def _create_or_append(
@@ -29,6 +29,7 @@ def _create_or_append(
 
 def groups_from_app(app: "App") -> List[Tuple[Group, List["App"]]]:
     """Extract Group/App association from all commands of ``app``."""
+    assert isinstance(app.group_commands, Group)
     group_mapping: List[Tuple[Group, List[App]]] = [
         (app.group_commands, []),
     ]

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -102,13 +102,15 @@ class Parameter:
 
     env_var_split: Callable = cyclopts._env_var.env_var_split
 
-    negative_bool: Tuple[str, ...] = field(
+    # This can ONLY ever be a Tuple[str, ...]
+    negative_bool: Union[None, str, Iterable[str]] = field(
         default=None,
         converter=_negative_converter(("--no-",)),
         validator=_double_hyphen_validator,
     )
 
-    negative_iterable: Tuple[str, ...] = field(
+    # This can ONLY ever be a Tuple[str, ...]
+    negative_iterable: Union[None, str, Iterable[str]] = field(
         default=None,
         converter=_negative_converter(("--empty-",)),
         validator=_double_hyphen_validator,
@@ -154,7 +156,7 @@ class Parameter:
                 raise ValueError("All parameters should have started with '-' or '--'.")
 
             negative_prefixes = self.negative_bool if type_ is bool else self.negative_iterable
-
+            assert isinstance(negative_prefixes, tuple)
             for negative_prefix in negative_prefixes:
                 out.append(f"{negative_prefix}{name}")
         return tuple(out)

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -6,17 +6,17 @@ from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple, Uni
 
 import pytest
 
+from cyclopts import CoercionError
+from cyclopts._convert import convert, resolve, token_count
+
 if sys.version_info < (3, 9):
     from typing_extensions import Annotated
 else:
     from typing import Annotated
 
-from cyclopts import CoercionError
-from cyclopts._convert import convert, resolve, token_count
-
 
 def _assert_tuple(expected, actual):
-    assert type(actual) == tuple
+    assert type(actual) is tuple
     assert len(expected) == len(actual)
     for e, a in zip(expected, actual):
         assert type(e) == type(a)
@@ -281,4 +281,4 @@ def test_resolve_annotated():
 
 def test_resolve_empty():
     res = resolve(inspect.Parameter.empty)
-    assert res == str
+    assert res is str


### PR DESCRIPTION
This makes two changes:

* Adds a type hint to kwargs. This will prevent recent versions of pyright from reporting an error every time App.command() is used about partially unknown argument types.
* Adds type hints for the two ways App.command() can be used using typing.overload().