### PR TITLE
Passing down the App version to the help/version commands

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -330,6 +330,7 @@ class App:
                 name=self._version_flags,
                 help_flags=[],
                 version_flags=[],
+                version=self.version,
                 help="Display application version.",
             )
 
@@ -347,6 +348,7 @@ class App:
                 name=self._help_flags,
                 help_flags=[],
                 version_flags=[],
+                version=self.version,
                 help="Display this message and exit.",
             )
 


### PR DESCRIPTION
I have a performance issue where it takes 500ms to get help message from my app while it only has 6 subcommand, but nested on 3 levels, so I am creating quite a few `App` objects.  I've tracked it down to 400ms worth of `inspect.getmodule` calls from `_get_root_module_name`. This is due to the fact that every time an `App` object is initialized, it will create 2 commands for `--help` and `--version` which initialize 2 new `App` object without specifying the version, so it will call the version factory 2 times which makes `inspect.getmodule` calls.

So my fix just pass down the version from the app to the commands.