### PR TITLE
Use last command's help/version flags.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -5,6 +5,7 @@ import traceback
 from contextlib import suppress
 from copy import copy
 from functools import partial
+from itertools import chain
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -291,8 +292,10 @@ class App:
 
     def __attrs_post_init__(self):
         # Trigger the setters
-        self.help_flags = self._help_flags
-        self.version_flags = self._version_flags
+        func = getattr(self.default_command, "__func__", None)
+        if func != type(self).version_print and func != type(self).help_print:
+            self.help_flags = self._help_flags
+            self.version_flags = self._version_flags
 
     ###########
     # Methods #
@@ -311,7 +314,7 @@ class App:
         for command in commands:
             with suppress(KeyError):
                 if default:
-                    if self[command].default == self.version_print:
+                    if self[command].default == default:
                         del self[command]
                 else:
                     del self[command]
@@ -324,14 +327,18 @@ class App:
     def version_flags(self, value):
         self._version_flags = value
         self._delete_commands(self._version_flags, default=self.version_print)
-        if self._version_flags:
+        func = getattr(self.default_command, "__func__", None)
+        if self._version_flags and func != type(self).version_print:
+            assert isinstance(self._version_flags, tuple)
             self.command(
-                self.version_print,
-                name=self._version_flags,
-                help_flags=[],
-                version_flags=[],
-                version=self.version,
-                help="Display application version.",
+                App(
+                    name=self._version_flags,
+                    default_command=self.version_print,
+                    help_flags=self.help_flags,
+                    version_flags=self.version_flags,
+                    version=self.version,
+                    help="Display application version.",
+                )
             )
 
     @property
@@ -342,14 +349,18 @@ class App:
     def help_flags(self, value):
         self._help_flags = value
         self._delete_commands(self._help_flags, default=self.help_print)
-        if self._help_flags:
+        func = getattr(self.default_command, "__func__", None)
+        if self._help_flags and func != type(self).help_print:
+            assert isinstance(self._help_flags, tuple)
             self.command(
-                self.help_print,
-                name=self._help_flags,
-                help_flags=[],
-                version_flags=[],
-                version=self.version,
-                help="Display this message and exit.",
+                App(
+                    name=self._help_flags,
+                    default_command=self.help_print,
+                    help_flags=self.help_flags,
+                    version_flags=self.version_flags,
+                    version=self.version,
+                    help="Display this message and exit.",
+                )
             )
 
     @property
@@ -460,8 +471,8 @@ class App:
     def meta(self) -> "App":
         if self._meta is None:
             self._meta = type(self)(
-                help_flags=copy(self.help_flags),
-                version_flags=copy(self.version_flags),
+                help_flags=self.help_flags,
+                version_flags=self.version_flags,
                 group_commands=copy(self.group_commands),
                 group_arguments=copy(self.group_arguments),
                 group_parameters=copy(self.group_parameters),
@@ -571,8 +582,10 @@ class App:
                 raise ValueError("Cannot supplied additional configuration when registering a sub-App.")
         else:
             validate_command(obj)
-            kwargs.setdefault("help_flags", [])
-            kwargs.setdefault("version_flags", [])
+
+            kwargs.setdefault("help_flags", self.help_flags)
+            kwargs.setdefault("version_flags", self.version_flags)
+
             if "group_commands" not in kwargs:
                 kwargs["group_commands"] = copy(self.group_commands)
             if "group_parameters" not in kwargs:
@@ -580,7 +593,9 @@ class App:
             if "group_arguments" not in kwargs:
                 kwargs["group_arguments"] = copy(self.group_arguments)
             app = App(default_command=obj, **kwargs)  # pyright: ignore
-            # app.name is handled below
+
+            for flag in chain(kwargs["help_flags"], kwargs["version_flags"]):  # pyright: ignore
+                app[flag].show = False
 
         if app._name_transform is None:
             app.name_transform = self.name_transform
@@ -704,7 +719,7 @@ class App:
         # Special flags (help/version) get intercepted by the root app.
         # Special flags are allows to be **anywhere** in the token stream.
 
-        for help_flag in self.help_flags:
+        for help_flag in command_app.help_flags:
             try:
                 help_flag_index = tokens.index(help_flag)
                 break
@@ -720,7 +735,7 @@ class App:
                 command = meta_parent.help_print
             bound = cyclopts.utils.signature(command).bind(tokens, console=console)
             unused_tokens = []
-        elif any(flag in tokens for flag in self.version_flags):
+        elif any(flag in tokens for flag in command_app.version_flags):
             # Version
             command = self.version_print
             while meta_parent := meta_parent._meta_parent:

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -183,7 +183,7 @@ def format_usage(
     for command in command_chain:
         app = app[command]
 
-    if app._commands:
+    if any(x.show for x in app._commands.values()):
         usage.append("COMMAND")
 
     if app.default_command:

--- a/tests/apps/test_burgery.py
+++ b/tests/apps/test_burgery.py
@@ -143,4 +143,4 @@ def test_create_burger_3():
 
 
 if __name__ == "__main__":
-    test_create_burger_1()
+    app()

--- a/tests/test_version_parameter.py
+++ b/tests/test_version_parameter.py
@@ -1,0 +1,33 @@
+"""From issue #219."""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "foo --version 1.2.3",
+        "foo --version=1.2.3",
+    ],
+)
+def test_version_subapp_version_parameter(app, assert_parse_args, cmd):
+    @app.command(version_flags=[])
+    def foo(version: str):
+        pass
+
+    assert_parse_args(foo, cmd, version="1.2.3")
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "foo --help 1.2.3",
+        "foo --help=1.2.3",
+    ],
+)
+def test_version_subapp_help_parameter(app, assert_parse_args, cmd):
+    @app.command(help_flags=[])
+    def foo(help: str):
+        pass
+
+    assert_parse_args(foo, cmd, help="1.2.3")


### PR DESCRIPTION
Kind of resolves #219.

The issue was that if a command wants to use a parameter like `--version` or `--help`, the version/help flag system swallows it and gets priority. Previously, only the help/version flags of the root app were used; now the help/version flags of the resolved command are used (more intuitive/correct).

@orhayat with this PR, you can use `version` in your command as the following:

```python
# notice the `version_flags`
@app.command(name="print-control-file", version_flags=[])
def print_control(version:Annotated[str|None,Parameter(help="control file version")]):
    x=f"""Package: <package name>
Version:{version}-release
Architecture: amd64
Section: admin
Priority: optional
Depends: python3,lsof
Recommends:
"""
    print(x)
```

I think I would like for the command to automatically have precedence over the help/version flags, but I don't think that will be possible until cyclopts v3.

Keeping this as a draft as I'm not totally satisfied with the solution; I want to think about it a little more.