### PR TITLE
lazily call _default_version; it can be quite slow to call so often.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -203,7 +203,7 @@ class App:
         kw_only=True,
     )
 
-    version: Union[None, str, Callable[..., str]] = field(factory=_default_version, kw_only=True)
+    version: Union[None, str, Callable[..., str]] = field(default=_default_version, kw_only=True)
     # This can ONLY ever be a Tuple[str, ...]
     _version_flags: Union[str, Iterable[str]] = field(
         default=["--version"],

--- a/tests/test_app_name_derivation.py
+++ b/tests/test_app_name_derivation.py
@@ -12,13 +12,12 @@ def test_app_name_derivation_main_module(mocker, mock_get_root_module_name):
     mocker.patch("cyclopts.core.sys.argv", ["__main__.py"])
     app = App()
 
-    mock_get_root_module_name.assert_called()
     assert app.name == ("mock_module_name",)
+    mock_get_root_module_name.assert_called()
 
 
-def test_app_name_derivation_not_main_module(mocker, mock_get_root_module_name):
+def test_app_name_derivation_not_main_module(mocker):
     mocker.patch("cyclopts.core.sys.argv", ["my-script.py"])
     app = App()
 
-    mock_get_root_module_name.assert_called()
     assert app.name == ("my-script.py",)


### PR DESCRIPTION
Extends the work of #217 . In one of my applications (that has a sizeable number of commands and actions-on-load), this reduces the `--help` time from 4.27s to 2.61s.

FYI @daudef