### PR TITLE
Allow for list[bool] and similar (list of flags).

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -31,13 +31,22 @@ if TYPE_CHECKING:
 
 
 _implicit_iterable_type_mapping: dict[type, type] = {
+    Iterable: list[str],
+    Sequence: list[str],
+    frozenset: frozenset[str],
     list: list[str],
     set: set[str],
     tuple: tuple[str, ...],
-    dict: dict[str, str],
 }
 
-ITERABLE_TYPES = {list, set, frozenset, Sequence, Iterable, tuple}
+ITERABLE_TYPES = {
+    Iterable,
+    Sequence,
+    frozenset,
+    list,
+    set,
+    tuple,
+}
 
 NestedCliArgs = dict[str, Union[Sequence[str], "NestedCliArgs"]]
 
@@ -161,7 +170,9 @@ def _convert(
     origin_type = get_origin(type_)
     inner_types = [resolve(x) for x in get_args(type_)]
 
-    if type_ in _implicit_iterable_type_mapping:
+    if type_ is dict:
+        out = convert(dict[str, str], token)
+    elif type_ in _implicit_iterable_type_mapping:
         out = convert(_implicit_iterable_type_mapping[type_], token)
     elif origin_type in (collections.abc.Iterable, collections.abc.Sequence):
         assert len(inner_types) == 1

--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -827,10 +827,7 @@ class Argument:
                 name = transform(name)
             if _startswith(term, name):
                 trailing = term[len(name) :]
-                if self.hint is bool or self.hint in ITERATIVE_BOOL_IMPLICIT_VALUE:
-                    implicit_value = True
-                else:
-                    implicit_value = None
+                implicit_value = True if self.hint is bool or self.hint in ITERATIVE_BOOL_IMPLICIT_VALUE else None
                 if trailing:
                     if trailing[0] == delimiter:
                         trailing = trailing[1:]

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -97,7 +97,7 @@ class Parameter:
         converter=lambda x: cast(tuple[Callable, ...], to_tuple_converter(x)),
     )
 
-    # This can ONLY ever be a Tuple[str, ...]
+    # This can ONLY ever be ``None`` or ``Tuple[str, ...]``
     negative: Union[None, str, Iterable[str]] = field(default=None, converter=optional_to_tuple_converter)
 
     # This can ONLY ever be a Tuple[Union[Group, str], ...]
@@ -176,8 +176,6 @@ class Parameter:
 
         origin = get_origin(type_)
 
-        if self.negative is False:
-            return ()
         if type_ not in _NEGATIVE_FLAG_TYPES:
             if origin:
                 if origin not in _NEGATIVE_FLAG_TYPES:

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -48,6 +48,27 @@ def test_keyword_optional_list_none_default(app, assert_parse_args):
 
 
 @pytest.mark.parametrize(
+    "cmd_expected",
+    [
+        ("", None),
+        ("--verbose", [True]),
+        ("--verbose --verbose", [True, True]),
+    ],
+)
+def test_keyword_list_of_bool(app, assert_parse_args, cmd_expected):
+    cmd, expected = cmd_expected
+
+    @app.default
+    def foo(*, verbose: Optional[list[bool]] = None):
+        pass
+
+    if expected is None:
+        assert_parse_args(foo, cmd)
+    else:
+        assert_parse_args(foo, cmd, verbose=expected)
+
+
+@pytest.mark.parametrize(
     "cmd",
     [
         "foo --item",

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -53,6 +53,10 @@ def test_keyword_optional_list_none_default(app, assert_parse_args):
         ("", None),
         ("--verbose", [True]),
         ("--verbose --verbose", [True, True]),
+        ("--verbose --verbose --no-verbose", [True, True, False]),
+        ("--verbose --verbose=False", [True, False]),
+        ("--verbose --no-verbose=False", [True, True]),
+        ("--verbose --verbose=True", [True, True]),
     ],
 )
 def test_keyword_list_of_bool(app, assert_parse_args, cmd_expected):


### PR DESCRIPTION
Fixes a bug discovered in #249.

Basically, use should be able to specify `list[bool]`, `tuple[bool, ...]`, `Sequence[bool]`, or `Iterable[bool]` and be able to accept the flag multiple times. Consider the example:

```python
from cyclopts import App

app = App()

@app.default
def main(
    *,
    verbose: tuple[bool, ...] = (),
):
    verbosity = sum(verbose)
    print(f"{verbosity=}")

if __name__ == "__main__":
    app()
```
Previously, this would raise an exception at runtime. Now, it handles repeated flags fine:
```bash
$ python repeated-flag-demo.py
verbosity=0

$ python repeated-flag-demo.py --verbose
verbosity=1

$ python repeated-flag-demo.py --verbose --verbose
verbosity=2
```