### PR TITLE
Support NewType.

### DIFF
--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -96,6 +96,7 @@ def resolve(type_: Any) -> type:
         type_ = resolve_annotated(type_)
         type_ = resolve_optional(type_)
         type_ = resolve_required(type_)
+        type_ = resolve_new_type(type_)
     return type_
 
 
@@ -132,6 +133,13 @@ def resolve_required(type_: Any) -> type:
     if get_origin(type_) in (Required, NotRequired):
         type_ = get_args(type_)[0]
     return type_
+
+
+def resolve_new_type(type_: Any) -> type:
+    try:
+        return resolve_new_type(type_.__supertype__)
+    except AttributeError:
+        return type_
 
 
 def get_hint_name(hint) -> str:

--- a/tests/test_new_type.py
+++ b/tests/test_new_type.py
@@ -1,0 +1,11 @@
+from typing import NewType
+
+
+def test_new_type_str(app, assert_parse_args):
+    CustomStr = NewType("CustomStr", str)
+
+    @app.default
+    def main(a: CustomStr):
+        pass
+
+    assert_parse_args(main, "foo", CustomStr("foo"))


### PR DESCRIPTION
@m09 can you play around with this and give feedback? I'm not experienced with `NewType`, so I could use some backup 😄. The actual passed in object never gets cast to the declared new-type, but I don't think that matters since static type checkers  in the parenting project won't be peeking into Cyclopts.

Addresses #262.