### PR TITLE
Various optimizations.

### DIFF
--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -107,9 +107,7 @@ def resolve_optional(type_: Any) -> type:
     """Only resolves Union's of None + one other type (i.e. Optional)."""
     # Python will automatically flatten out nested unions when possible.
     # So we don't need to loop over resolution.
-
-    origin = get_origin(type_)
-    if not is_union(origin):
+    if not is_union(type_):
         return type_
 
     non_none_types = [t for t in get_args(type_) if t is not NoneType]

--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -27,11 +27,13 @@ def is_nonetype(hint):
 
 
 def is_union(type_: Optional[type]) -> bool:
-    if type_ is None:
-        return False
     if type_ is Union or type_ is UnionType:
         return True
-    origin = get_origin(type_)
+    if (
+        type_ is str or type_ is int or type_ is float or type_ is bool or is_annotated(type_)
+    ):  # Shortcut for common types.
+        return False
+    origin = get_origin(type_)  # A relatively expensive call.
     return origin is Union or origin is UnionType
 
 

--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -27,13 +27,16 @@ def is_nonetype(hint):
 
 
 def is_union(type_: Optional[type]) -> bool:
+    """Checks if a type is a union."""
+    # Direct checks are faster than checking if the type is in a set that contains the union-types.
     if type_ is Union or type_ is UnionType:
         return True
-    if (
-        type_ is str or type_ is int or type_ is float or type_ is bool or is_annotated(type_)
-    ):  # Shortcut for common types.
+
+    # The ``get_origin`` call is relatively expensive, so we'll check common types
+    # that are passed in here to see if we can avoid calling ``get_origin``.
+    if type_ is str or type_ is int or type_ is float or type_ is bool or is_annotated(type_):
         return False
-    origin = get_origin(type_)  # A relatively expensive call.
+    origin = get_origin(type_)
     return origin is Union or origin is UnionType
 
 

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -331,12 +331,14 @@ class App:
         """
         # Remove all the old version-flag commands.
         for command in commands:
-            with suppress(KeyError):
+            try:
                 if default:
                     if self[command].default == default:
                         del self[command]
                 else:
                     del self[command]
+            except KeyError:
+                pass
 
     @property
     def version_flags(self):

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -319,7 +319,7 @@ class App:
     ###########
     # Methods #
     ###########
-    def _delete_commands(self, commands: Iterable[str], default=None):
+    def _delete_commands(self, commands: Iterable[str]):
         """Safely delete commands.
 
         Will **not** raise an exception if command(s) do not exist.
@@ -332,11 +332,7 @@ class App:
         # Remove all the old version-flag commands.
         for command in commands:
             try:
-                if default:
-                    if self[command].default == default:
-                        del self[command]
-                else:
-                    del self[command]
+                del self[command]
             except KeyError:
                 pass
 
@@ -347,7 +343,7 @@ class App:
     @version_flags.setter
     def version_flags(self, value):
         self._version_flags = value
-        self._delete_commands(self._version_flags, default=self.version_print)
+        self._delete_commands(self._version_flags)
         if self._version_flags:
             self.command(
                 self.version_print,
@@ -365,7 +361,7 @@ class App:
     @help_flags.setter
     def help_flags(self, value):
         self._help_flags = value
-        self._delete_commands(self._help_flags, default=self.help_print)
+        self._delete_commands(self._help_flags)
         if self._help_flags:
             self.command(
                 self.help_print,

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -703,8 +703,6 @@ class App:
             if app._group_arguments is None:
                 app._group_arguments = copy(self._group_arguments)
         else:
-            validate_command(obj)
-
             kwargs.setdefault("help_flags", self.help_flags)
             kwargs.setdefault("version_flags", self.version_flags)
 
@@ -802,7 +800,6 @@ class App:
         if self.default_command is not None:
             raise CommandCollisionError(f"Default command previously set to {self.default_command}.")
 
-        validate_command(obj)
         self.default_command = obj
         if validator:
             self.validator = validator  # pyright: ignore[reportAttributeAccessIssue]
@@ -944,6 +941,7 @@ class App:
             try:
                 if command_app.default_command:
                     command = command_app.default_command
+                    validate_command(command)
                     argument_collection = command_app.assemble_argument_collection(apps=apps)
                     ignored: dict[str, Any] = {
                         argument.field_info.name: resolve_annotated(argument.field_info.annotation)

--- a/cyclopts/group.py
+++ b/cyclopts/group.py
@@ -9,9 +9,9 @@ from typing import (
     cast,
 )
 
-from attrs import field, frozen
+from attrs import field
 
-from cyclopts.utils import UNSET, SortHelper, is_iterable, resolve_callables, to_tuple_converter
+from cyclopts.utils import UNSET, SortHelper, frozen, is_iterable, resolve_callables, to_tuple_converter
 
 if TYPE_CHECKING:
     from cyclopts.argument import ArgumentCollection

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -15,12 +15,12 @@ from typing import (
     get_origin,
 )
 
-from attrs import define, field, frozen
+from attrs import define, field
 
 import cyclopts.utils
 from cyclopts.annotations import is_union
 from cyclopts.group import Group
-from cyclopts.utils import SortHelper, resolve_callables
+from cyclopts.utils import SortHelper, frozen, resolve_callables
 
 if TYPE_CHECKING:
     from rich.console import Console, ConsoleOptions, RenderableType, RenderResult

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -310,7 +310,10 @@ def format_str(*components: Union[str, tuple[str, str]], format: str) -> "Render
                 else:
                     yield Text(component[0].rstrip(), style=component[1])
 
-        return Text().join(walk_components())
+        text = Text()
+        for component in walk_components():
+            text.append(component)
+        return text
     else:
         raise ValueError(f'Unknown help_format "{format}"')
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -279,6 +279,8 @@ def validate_command(f: Callable):
     ValueError
         Function has naming or parameter/signature inconsistencies.
     """
+    if (f.__module__ or "").startswith("cyclopts"):  # Speed optimization.
+        return
     signature = cyclopts.utils.signature(f)
     for iparam in signature.parameters.values():
         cparam = Parameter.from_annotation(iparam.annotation)

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -281,7 +281,6 @@ def validate_command(f: Callable):
     """
     signature = cyclopts.utils.signature(f)
     for iparam in signature.parameters.values():
-        get_origin(iparam.annotation)
         cparam = Parameter.from_annotation(iparam.annotation)
         if not cparam.parse and iparam.kind is not iparam.KEYWORD_ONLY:
             raise ValueError("Parameter.parse=False must be used with a KEYWORD_ONLY function parameter.")

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -302,6 +302,8 @@ def validate_command(f: Callable):
         return
     signature = cyclopts.utils.signature(f)
     for iparam in signature.parameters.values():
+        if not is_annotated(iparam.annotation):  # Speed optimization
+            continue
         cparam = Parameter.from_annotation(iparam.annotation)
         if not cparam.parse and iparam.kind is not iparam.KEYWORD_ONLY:
             raise ValueError("Parameter.parse=False must be used with a KEYWORD_ONLY function parameter.")

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union, cast, get_args, get_origin
 
 import attrs
-from attrs import field, frozen
+from attrs import field
 
 import cyclopts._env_var
 import cyclopts.utils
@@ -13,6 +13,7 @@ from cyclopts.annotations import is_annotated, is_union, resolve_optional
 from cyclopts.group import Group
 from cyclopts.utils import (
     default_name_transform,
+    frozen,
     optional_to_tuple_converter,
     record_init,
     to_tuple_converter,

--- a/cyclopts/token.py
+++ b/cyclopts/token.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
-from attrs import field, frozen
+from attrs import field
 
-from cyclopts.utils import UNSET
+from cyclopts.utils import UNSET, frozen
 
 
 @frozen(kw_only=True)

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -6,11 +6,20 @@ import sys
 from collections.abc import Iterable, Iterator, MutableMapping
 from contextlib import suppress
 from operator import itemgetter
-from typing import Any, Literal, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Tuple, Union
 
 from attrs import field, frozen
 
 # fmt: off
+
+# https://threeofwands.com/attra-iv-zero-overhead-frozen-attrs-classes/
+if TYPE_CHECKING:
+    from attrs import frozen
+else:
+    from attrs import define
+
+    frozen = functools.partial(define, unsafe_hash=True)
+
 if sys.version_info >= (3, 10):  # pragma: no cover
     def signature(f: Any) -> inspect.Signature:
         return inspect.signature(f, eval_str=True)

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -352,7 +352,9 @@ class ParameterDict(MutableMapping):
 
 
 def is_iterable(obj) -> bool:
-    return isinstance(obj, Iterable) and not isinstance(obj, str)
+    if isinstance(obj, (list, tuple, set, dict)):  # Fast path for common types
+        return True
+    return not isinstance(obj, str) and isinstance(obj, Iterable)
 
 
 def to_tuple_converter(value: Union[None, Any, Iterable[Any]]) -> tuple[Any, ...]:

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -278,13 +278,13 @@ def record_init(target: str):
     def decorator(cls):
         original_init = cls.__init__
         function_signature = signature(original_init)
+        param_names = tuple(name for name in function_signature.parameters if name != "self")
 
         @functools.wraps(original_init)
         def new_init(self, *args, **kwargs):
-            bound = function_signature.bind(self, *args, **kwargs)
             original_init(self, *args, **kwargs)
             # Circumvent frozen protection.
-            object.__setattr__(self, target, tuple(k for k, v in bound.arguments.items() if v is not self))
+            object.__setattr__(self, target, tuple(param_names[i] for i in range(len(args))) + tuple(kwargs))
 
         cls.__init__ = new_init
         return cls

--- a/cyclopts/validators/_number.py
+++ b/cyclopts/validators/_number.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Sequence, Union
 
-from attrs import frozen
+from cyclopts.utils import frozen
 
 Numeric = Union[int, float]
 NumericSequence = Sequence[Union[Numeric, "NumericSequence"]]

--- a/cyclopts/validators/_path.py
+++ b/cyclopts/validators/_path.py
@@ -1,7 +1,7 @@
 import pathlib
 from typing import Any, Sequence, Union
 
-from attrs import frozen
+from cyclopts.utils import frozen
 
 
 @frozen(kw_only=True)

--- a/tests/test_bind_no_parse.py
+++ b/tests/test_bind_no_parse.py
@@ -22,3 +22,5 @@ def test_no_parse_invalid_kind(app):
         @app.default
         def foo(buzz: str, fizz: Annotated[str, Parameter(parse=False)]):
             pass
+
+        app()


### PR DESCRIPTION
After profiling @mrjsj application [msfabricutils](https://github.com/mrjsj/msfabricutils/tree/feat/new-cli/cli) mentioned in #276, I was able to optimize displaying the intial helpscreen from ~570mS to ~450mS on my computer (~26% improvement). On my computer, just importing the main imports (listed below) takes roughly 360mS, suggesting that Cyclopts is taking ~90mS to parse all the commands and to display the help page. If I stub out the actual help-printing, then the resulting program takes ~430mS to execute, suggesting that Cyclopts is taking 20mS to do the help-page parsing and printing, while 70mS doing all the other stuff. Of all of this:

1. 51.5mS are spent in `@app.command`, which is what we could potentially optimize with lazy loading. I'm just super hesitant to do this because lazy-loading can get hairy (unless someone has an elegant solution!).

2. Within `@app.command`, 12.1mS are spent in the recently-optimized `validate_command`. We *could* simply get rid of this; currently its only job is to detect some rare, invalid Cyclopts configurations at application-load time. This is intended so that any cyclopts *programming* error is always detected, rather than only in potentially rare CLI invocations.

3. Within `@app.command`, 26.7mS of time are spent instantiating sub-`App`'s. I imagine most of these are help/version handlers and could be optimized, potentially shaving maybe ~15mS.

---
Main imports:
```
import cyclopts
import msfabricpysdkcore
import json
import requests
import logging
import base64
import rich
import msfabricutils
```

# Changelog
* Removed `validate_command` on register and defer it to execution. The original thinking of wanting to catch programming errors doesn't exactly hold water; it's not like people will program up commands and not test them, which will inherently cause the command to be validated.