### PR TITLE
Better handling of nested meta apps

### DIFF
--- a/cyclopts/group_extractors.py
+++ b/cyclopts/group_extractors.py
@@ -45,8 +45,7 @@ def groups_from_app(app: "App") -> list[tuple[Group, list["App"]]]:
         (group_commands, []),
     ]
 
-    # This does NOT include app._meta commands
-    subapps = list(app._commands.values())
+    subapps = list(app.subapps)
 
     # 2 iterations need to be performed:
     # 1. Extract out all Group objects as they may have additional configuration.

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -218,7 +218,7 @@ def format_usage(
     for command in command_chain:
         app = app[command]
 
-    if any(x.show for x in app._commands.values()):
+    if any(x.show for x in app.subapps):
         usage.append("COMMAND")
 
     if app.default_command:

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,8 +1,9 @@
+from textwrap import dedent
 from typing import Annotated
 
 import pytest
 
-from cyclopts import Parameter
+from cyclopts import App, Parameter
 
 
 @pytest.mark.parametrize(
@@ -31,3 +32,121 @@ def test_meta_basic(app, cmd_str):
 def test_meta_app_config_inheritance(app):
     app.config = ("foo", "bar")
     assert app.meta.config == ("foo", "bar")
+
+
+@pytest.fixture
+def queue():
+    return []
+
+
+@pytest.fixture
+def nested_meta_app(queue, console):
+    subapp = App(console=console)
+
+    @subapp.meta.default
+    def subapp_meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]) -> None:
+        """This is subapp's help."""
+        queue.append("subapp meta")
+        subapp(tokens)
+
+    @subapp.command
+    def foo(value: int) -> None:
+        """Subapp foo help string.
+
+        Parameters
+        ----------
+        value: int
+            The value a user inputted.
+        """
+        queue.append(f"subapp foo body {value}")
+
+    app = App(name="test_app", console=console)
+    app.command(subapp.meta, name="subapp")
+
+    @app.meta.default
+    def meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+        queue.append("root meta")
+        app(tokens)
+
+    return app
+
+
+def test_meta_app_nested_root_help(nested_meta_app, console, queue):
+    with console.capture() as capture:
+        nested_meta_app.meta(["--help"])
+
+    actual = capture.get()
+
+    expected = dedent(
+        """\
+        Usage: test_app COMMAND
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ subapp     This is subapp's help.                                  │
+        │ --help -h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+
+    assert actual == expected
+    assert not queue
+
+
+def test_meta_app_nested_subapp_help(nested_meta_app, console, queue):
+    with console.capture() as capture:
+        nested_meta_app.meta(["subapp", "--help"])
+
+    actual = capture.get()
+
+    expected = dedent(
+        """\
+        Usage: test_app subapp COMMAND [ARGS]
+
+        This is subapp's help.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ foo        Subapp foo help string.                                 │
+        │ --help -h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+
+    assert actual == expected
+    assert not queue
+
+
+def test_meta_app_nested_subapp_foo_help(nested_meta_app, console, queue):
+    with console.capture() as capture:
+        nested_meta_app.meta(["subapp", "foo", "--help"])
+
+    actual = capture.get()
+
+    expected = dedent(
+        """\
+        Usage: test_app subapp foo [ARGS] [OPTIONS]
+
+        Subapp foo help string.
+
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ *  VALUE --value  The value a user inputted. [required]            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+
+    assert actual == expected
+    assert not queue
+
+
+@pytest.mark.parametrize(
+    "cmd_str,expected",
+    [
+        ("", ["root meta"]),
+        ("subapp", ["root meta", "subapp meta"]),
+        ("subapp foo 5", ["root meta", "subapp meta", "subapp foo body 5"]),
+    ],
+)
+def test_meta_app_nested_exec(nested_meta_app, queue, cmd_str, expected):
+    nested_meta_app.meta(cmd_str)
+    assert queue == expected


### PR DESCRIPTION
@AngellusMortis can you play around with this? I think the following script (along with this PR) is kind of what you want:

```python
from cyclopts import App, Parameter
from typing import Annotated

app_1 = App()

@app_1.meta.default
def meta_1(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]) -> None:
    """This is app1_meta's help."""
    print("child meta")
    app_1(tokens)

@app_1.command
def test() -> None:
    """"app_1 test" help string."""
    print("app_1 test body")

app = App()
app.command(app_1.meta, name="app1")

@app.meta.default
def meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
    print("parent meta")
    app(tokens)

if __name__ == "__main__":
    app.meta()
```

Comments:
* meta apps **don't** execute for `--help`. This is intentional as frequently expensive operations are performed in a meta app, such as connecting to an external resource (like a database).
* meta apps **do** execute during conventional command execution.
* The `tokens` in the meta signature is [copied from the meta app docs](https://cyclopts.readthedocs.io/en/latest/meta_app.html).

Addresses #290.