### PR TITLE
Fix  converters/validators getting the wrong type for nested Annotated[Parameter(...)]

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -168,7 +168,8 @@ def _convert(
     convert_tuple = partial(_convert_tuple, converter=converter, name_transform=name_transform)
 
     origin_type = get_origin(type_)
-    inner_types = [resolve(x) for x in get_args(type_)]
+    # Inner types **may** be ``Annotated``
+    inner_types = get_args(type_)
 
     if type_ is dict:
         out = convert(dict[str, str], token)
@@ -285,6 +286,10 @@ def _convert(
         out = type_(*pos_values)
 
     if cparam:
+        # An inner type may have an independent Parameter annotation;
+        # e.g.:
+        #    Uint8 = Annotated[int, ...]
+        #    rgb: tuple[Uint8, Uint8, Uint8]
         try:
             for validator in cparam.validator:  # pyright: ignore
                 validator(type_, out)

--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -8,7 +8,6 @@ from attrs import define, field
 
 import cyclopts.utils
 from cyclopts._convert import (
-    ITERABLE_TYPES,
     convert,
     token_count,
 )
@@ -219,21 +218,6 @@ class ArgumentCollection(list["Argument"]):
         hint = field_info.hint
         hint, hint_parameters = _get_parameters(hint)
         cyclopts_parameters_no_group.extend(hint_parameters)
-
-        # Handle annotations where ``Annotated`` is not at the root level; e.g. ``list[Annotated[...]]``.
-        # Multiple inner Parameter Annotations only make sense if providing specific converter/validators.
-        origin = get_origin(hint)
-        if origin is tuple:
-            # handled in _convert.py
-            pass
-        elif origin in ITERABLE_TYPES:
-            inner_hints = get_args(hint)
-            if len(inner_hints) > 1:
-                raise NotImplementedError(f"Did not expect multiple inner type arguments: {inner_hints}.")
-            elif len(inner_hints) == 1:
-                inner_hint = inner_hints[0]
-                _, hint_parameters = _get_parameters(inner_hint)
-                cyclopts_parameters_no_group.extend(hint_parameters)
 
         if not keys:  # root hint annotation
             if field_info.kind is field_info.VAR_KEYWORD:

--- a/tests/types/test_types_path.py
+++ b/tests/types/test_types_path.py
@@ -100,7 +100,7 @@ def test_types_resolved_existing_path_list(app, assert_parse_args):
         pass
 
     expected = Path("foo.bin").resolve()
-    assert_parse_args(main, "foo.bin", expected)
+    assert_parse_args(main, "foo.bin", [expected])
 
 
 def test_types_resolved_existing_path_validation_error(convert, tmp_path):

--- a/tests/types/test_types_path.py
+++ b/tests/types/test_types_path.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Tuple
 
 import pytest
@@ -91,6 +92,15 @@ def test_types_resolved_existing_path(convert, tmp_path, action):
     src = tmp_path / ".." / tmp_path.name / "foo"
     getattr(src, action)()
     assert src.resolve() == convert(ct.ResolvedExistingPath, src)
+
+
+def test_types_resolved_existing_path_list(app, assert_parse_args):
+    @app.default
+    def main(f: list[ct.ResolvedFile]):
+        pass
+
+    expected = Path("foo.bin").resolve()
+    assert_parse_args(main, "foo.bin", expected)
 
 
 def test_types_resolved_existing_path_validation_error(convert, tmp_path):


### PR DESCRIPTION
Addresses the [second half of this comment](https://github.com/BrianPugh/cyclopts/issues/287#issuecomment-2576538769) in #287. This solution is much cleaner/better/intended than #289.

@BruceEckel can you play with this PR to see if it adequately solves the problem you discovered? I really appreciate you kicking the tires on Cyclopts!