### PR TITLE
Allow Parameter to be used as a decorator. Introduce the hidden __cyclopts__ attribute.

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -12,7 +12,6 @@ from cyclopts._convert import (
     token_count,
 )
 from cyclopts.annotations import (
-    is_annotated,
     is_attrs,
     is_dataclass,
     is_namedtuple,
@@ -43,7 +42,7 @@ from cyclopts.field_info import (
     get_field_infos,
 )
 from cyclopts.group import Group
-from cyclopts.parameter import ITERATIVE_BOOL_IMPLICIT_VALUE, Parameter
+from cyclopts.parameter import ITERATIVE_BOOL_IMPLICIT_VALUE, Parameter, get_parameters
 from cyclopts.token import Token
 from cyclopts.utils import UNSET, ParameterDict, grouper, is_builtin
 
@@ -110,21 +109,6 @@ def _missing_keys_factory(get_field_info: Callable[[Any], dict[str, FieldInfo]])
 
 def _identity_converter(type_, token):
     return token
-
-
-def _get_parameters(hint: Any) -> tuple[Any, list[Parameter]]:
-    """At root level, checks for cyclopts.Parameter annotations.
-
-    Includes checking the ``__cyclopts__`` attribute.
-    """
-    parameters = []
-    if cyclopts_config := getattr(hint, "__cyclopts__", None):
-        parameters.extend(cyclopts_config.parameters)
-    if is_annotated(hint):
-        inner = get_args(hint)
-        hint = inner[0]
-        parameters.extend(x for x in inner[1:] if isinstance(x, Parameter))
-    return hint, parameters
 
 
 class ArgumentCollection(list["Argument"]):
@@ -221,7 +205,7 @@ class ArgumentCollection(list["Argument"]):
         cyclopts_parameters_no_group = []
 
         hint = field_info.hint
-        hint, hint_parameters = _get_parameters(hint)
+        hint, hint_parameters = get_parameters(hint)
         cyclopts_parameters_no_group.extend(hint_parameters)
 
         if not keys:  # root hint annotation

--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -113,13 +113,18 @@ def _identity_converter(type_, token):
 
 
 def _get_parameters(hint: Any) -> tuple[Any, list[Parameter]]:
-    """At root level, checks for cyclopts.Parameter annotations."""
+    """At root level, checks for cyclopts.Parameter annotations.
+
+    Includes checking the ``__cyclopts__`` attribute.
+    """
+    parameters = []
+    if cyclopts_config := getattr(hint, "__cyclopts__", None):
+        parameters.extend(cyclopts_config.parameters)
     if is_annotated(hint):
         inner = get_args(hint)
         hint = inner[0]
-        return hint, [x for x in inner[1:] if isinstance(x, Parameter)]
-    else:
-        return hint, []
+        parameters.extend(x for x in inner[1:] if isinstance(x, Parameter))
+    return hint, parameters
 
 
 class ArgumentCollection(list["Argument"]):

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -231,7 +231,7 @@ class Parameter:
 
     @classmethod
     def combine(cls, *parameters: Optional["Parameter"]) -> "Parameter":
-        """Returns a new Parameter with values of ``parameters``.
+        """Returns a new Parameter with combined values of all provided ``parameters``.
 
         Parameters
         ----------
@@ -288,9 +288,9 @@ class Parameter:
                     return EMPTY_PARAMETER
 
     def __call__(self, obj: T) -> T:
-        """Decorator interface for annotating a function/class with a Parameter.
+        """Decorator interface for annotating a function/class with a :class:`Parameter`.
 
-        Most commonly used for directly configuring a class
+        Most commonly used for directly configuring a class:
 
         .. code-block:: python
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -320,6 +320,7 @@ API
 
 
 .. autoclass:: cyclopts.Parameter
+   :special-members: __call__
 
    .. attribute:: name
       :type: Union[None, str, Iterable[str]]

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -167,7 +167,7 @@ We can add application-level help documentation when creating our ``app``:
    │ *  COUNT --count  [required]                                        │
    ╰─────────────────────────────────────────────────────────────────────╯
 
-.. note:
+.. note::
    Help flags can be changed with :attr:`~cyclopts.App.help_flags`.
 
 Let's add some help documentation for our parameters.
@@ -212,7 +212,7 @@ Cyclopts uses the function's docstring and can interpret ReST, Google, Numpydoc-
    │ *  COUNT --count  Number of times to greet. [required]              │
    ╰─────────────────────────────────────────────────────────────────────╯
 
-.. note:
+.. note::
    If :attr:`.App.help` is not explicitly set, Cyclopts will fallback to the first line
    (short description) of the registered ``@app.default`` function's docstring.
 

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -22,6 +22,8 @@ Typically, Cyclopts gets all the information it needs from object names, type hi
 
    app()
 
+Running the example:
+
 .. code-block:: console
 
    $ my-script --help
@@ -63,6 +65,10 @@ However, if more control is required, we can provide additional information by `
 :class:`.Parameter` gives complete control on how Cyclopts processes the annotated parameter.
 See the :ref:`API` page for all configurable options.
 This page will investigate some of the more common use-cases.
+
+.. note::
+   :class:`.Parameter` can also be used as a decorator.
+   This is :ref:`particularly useful for class definitions <Namespace Flattening>`.
 
 ------
 Naming
@@ -152,7 +158,7 @@ The name transform function that converts the python variable name to it's CLI c
 
 Notice how the parameter is now ``--FOO`` instead of the standard ``--foo``.
 
-.. note:
+.. note::
    The returned string is **before** the standard ``--`` is prepended.
 
 Generally, it is not very useful to set the name transform on **individual** parameters; it would be easier/clearer :ref:`to manually specify the name <Parameters - Naming - Manual Naming>`.

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -615,7 +615,7 @@ Cyclopts supports classically defined user classes, as well as classes defined b
 * `pydantic <https://docs.pydantic.dev/latest/>`_
 * `TypedDict <https://docs.python.org/3/library/typing.html#typing.TypedDict>`_
 
-.. note:
+.. note::
    For ``pydantic`` classes, Cyclopts will *not* internally perform type conversions and instead relies on pydantic's coercion engine.
 
 Subkey parsing allows for assigning values positionally and by keyword with a dot-separator.

--- a/docs/source/user_classes.rst
+++ b/docs/source/user_classes.rst
@@ -46,6 +46,8 @@ As an example, lets consider using the builtin :obj:`~dataclasses.dataclass` to 
    $ movie-maintainer add --movie.title 'Furiosa: A Mad Max Saga' --movie.year 2024
    Adding movie: Movie(title='Furiosa: A Mad Max Saga', year=2024)
 
+.. _Namespace Flattening:
+
 --------------------
 Namespace Flattening
 --------------------
@@ -81,6 +83,29 @@ It is likely that the actual movie class/object is not important to the CLI user
    │ *  YEAR --year    [required]                                │
    ╰─────────────────────────────────────────────────────────────╯
 
+An alternative way of supplying the :class:`.Parameter` configuration is via a decorator.
+This way can be cleaner and terser in many scenarios.
+The :class:`.Parameter` configuration will also be inherited by subclasses.
+
+.. code-block:: python
+
+   from cyclopts import App, Parameter
+   from dataclasses import dataclass
+
+   app = App(name="movie-maintainer")
+
+   @Parameter(name="*")
+   @dataclass
+   class Movie:
+      title: str
+      year: int
+
+   @app.command
+   def add(movie: Movie):
+      print(f"Adding movie: {movie}")
+
+   app()
+
 .. _Sharing Parameters:
 
 ------------------
@@ -92,16 +117,14 @@ A flattened dataclass provides a natural way of easily sharing a set of paramete
 
    from cyclopts import App, Parameter
    from dataclasses import dataclass
-   from typing import Annotated
 
    app = App(name="movie-maintainer")
 
+   @Parameter(name="*")
    @dataclass
-   class _Config:
+   class Config:
       user: str
       server: str = "media.sqlite"
-
-   Config = Annotated[_Config, Parameter(name="*")]
 
    @dataclass
    class Movie:
@@ -134,7 +157,7 @@ A flattened dataclass provides a natural way of easily sharing a set of paramete
    ╰─────────────────────────────────────────────────────────────╯
 
    $ movie-maintainer remove 'Mad Max: Fury Road' 2015 --user Guido
-   Config: _Config(user='Guido', server='media.sqlite')
+   Config: Config(user='Guido', server='media.sqlite')
    Removing movie: Movie(title='Mad Max: Fury Road', year=2015)
 
 
@@ -164,12 +187,11 @@ We can update our app to fill in missing CLI parameters from this file:
       config=config.Toml("config.toml", use_commands_as_keys=False),
    )
 
+   @Parameter(name="*")
    @dataclass
-   class _Config:
+   class Config:
       user: str
       server: str = "media.sqlite"
-
-   Config = Annotated[_Config, Parameter(name="*")]
 
    @dataclass
    class Movie:
@@ -186,5 +208,5 @@ We can update our app to fill in missing CLI parameters from this file:
 .. code-block:: console
 
    $ movie-maintainer add 'Mad Max: Fury Road' 2015
-   Config: _Config(user='Guido', server='media.sqlite')
+   Config: Config(user='Guido', server='media.sqlite')
    Adding movie: Movie(title='Mad Max: Fury Road', year=2015)

--- a/tests/apps/draw.py
+++ b/tests/apps/draw.py
@@ -34,17 +34,15 @@ class Coordinate(NamedTuple):
     "Y coordinate."
 
 
+@Parameter(name="*")
 @dataclass
-class _Config:
+class Config:
     _: KW_ONLY
     units: Literal["meters", "feet"] = "meters"
     "Drawing units."
 
     color: tuple[UInt8, UInt8, UInt8] = (0x00, 0x00, 0x00)
     "RGB uint8 triple."
-
-
-Config = Annotated[_Config, Parameter(name="*")]
 
 
 @app.command

--- a/tests/test_parameter_decorator.py
+++ b/tests/test_parameter_decorator.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+import pytest
+
+from cyclopts import Parameter
+from cyclopts.exceptions import UnknownOptionError
+
+
+def test_parameter_decorator_dataclass(app, assert_parse_args):
+    @Parameter(name="*")  # Flatten namespace.
+    @dataclass
+    class User:
+        name: str
+        age: int
+
+    @app.command
+    def create(*, user: User | None = None):
+        pass
+
+    assert_parse_args(create, "create")
+    assert_parse_args(create, "create --name=Bob --age=100", user=User("Bob", 100))
+
+
+def test_parameter_decorator_dataclass_inheritance(app, assert_parse_args):
+    @Parameter(name="u", negative_bool=[])
+    @dataclass
+    class User:
+        name: str
+        age: int
+        privileged: bool = False
+
+    @Parameter(name="a", negative_bool=None)  # Should revert to Cyclopts defaults
+    @dataclass
+    class Admin(User):
+        privileged: bool = True
+
+    @app.command
+    def create(*, user: User | None = None, admin: Admin | None = None):
+        pass
+
+    assert_parse_args(create, "create --u.name=Bob --u.age=100", user=User("Bob", 100))
+    with pytest.raises(UnknownOptionError):
+        app("create --u.no-privileged", exit_on_error=False)
+
+    assert_parse_args(create, "create --a.name=Bob --a.age=100", admin=Admin("Bob", 100))
+    assert_parse_args(
+        create, "create --a.name=Bob --a.age=100 --a.no-privileged", admin=Admin("Bob", 100, privileged=False)
+    )

--- a/tests/test_parameter_decorator.py
+++ b/tests/test_parameter_decorator.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 
@@ -14,7 +15,7 @@ def test_parameter_decorator_dataclass(app, assert_parse_args):
         age: int
 
     @app.command
-    def create(*, user: User | None = None):
+    def create(*, user: Optional[User] = None):
         pass
 
     assert_parse_args(create, "create")
@@ -35,7 +36,7 @@ def test_parameter_decorator_dataclass_inheritance(app, assert_parse_args):
         privileged: bool = True
 
     @app.command
-    def create(*, user: User | None = None, admin: Admin | None = None):
+    def create(*, user: Optional[User] = None, admin: Optional[Admin] = None):
         pass
 
     assert_parse_args(create, "create --u.name=Bob --u.age=100", user=User("Bob", 100))

--- a/tests/test_parameter_decorator.py
+++ b/tests/test_parameter_decorator.py
@@ -2,14 +2,16 @@ from dataclasses import dataclass
 from typing import Optional
 
 import pytest
+from attrs import define
 
 from cyclopts import Parameter
 from cyclopts.exceptions import UnknownOptionError
 
 
-def test_parameter_decorator_dataclass(app, assert_parse_args):
+@pytest.mark.parametrize("decorator", [dataclass, define])
+def test_parameter_decorator_dataclass(app, assert_parse_args, decorator):
     @Parameter(name="*")  # Flatten namespace.
-    @dataclass
+    @decorator
     class User:
         name: str
         age: int
@@ -19,7 +21,7 @@ def test_parameter_decorator_dataclass(app, assert_parse_args):
         pass
 
     assert_parse_args(create, "create")
-    assert_parse_args(create, "create --name=Bob --age=100", user=User("Bob", 100))
+    assert_parse_args(create, "create --name=Bob --age=100", user=User("Bob", 100))  # pyright: ignore[reportCallIssue]
 
 
 def test_parameter_decorator_dataclass_inheritance(app, assert_parse_args):


### PR DESCRIPTION
Allows `cyclopts.Parameter` to be used as a decorator. This is accomplished by assigning to a private/secret attribute `__cyclopts__`. Feature originally proposed/described [here](https://github.com/BrianPugh/cyclopts/issues/248#issuecomment-2476377673).

### TODO

- [x] update docs.

### Motivation
It can be cumbersome/inelegant to annotate a class definition with `Annotated`. For example:

```python
from dataclasses import dataclass
from typing import Annotated
from cyclopts import Parameter

@dataclass
class _Config:
    foo: str = ""
    
# Flatten the namespace
Config = Annotated[_Config, Parameter(name="*")]

@app.command
def create(*, config: Config | None = None):
    if config is None:
        config = _Config()
    ...
```

The intermediate `_Config` class is required because [Annotated types should not be directly instantiated](https://typing.readthedocs.io/en/latest/spec/qualifiers.html#annotated).

> An attempt to call Annotated (whether parameterized or not) should be treated as a type error by type checkers:
> ```python
> Annotated()  # Type error
> Annotated[int, ""](0)  # Type error
> 
> SmallInt = Annotated[int, ValueRange(0, 100)]
> SmallInt(1)  # Type error
> ```

This is particularly icky/confusing because in the command we have to use both the unannotated `_Config` to create an object if no keyword arguments are provided, and the annotated `Config` for the type-hint. If the `create` command is in another file, then we have to additionally import both `Config` and `_Config`.

With this PR, this can be simplified to:

```python
from dataclasses import dataclass
from cyclopts import Parameter

@Parameter(name="*")
@dataclass
class Config:
    foo: str = ""

@app.command
def create(*, config: Config | None = None):
    if config is None:
        config = Config()
    ...
```

Benefits of this approach:
1. Avoids the confusing `_Config`/`Config` issue.
2. Possibly avoids an `from typing import Annotated` import.
3. Minimizes additional cyclopts functions/classes/syntax the developer has to learn. It's just `Parameter` and everything that goes with it, but being used as a decorator.
4. Easier to read. It's generally kind of confusing to modify a class outside of it's immediate class definition.

### Alternative Syntax
A possible alternative syntax is a [pydantic-style nested config class](https://docs.pydantic.dev/1.10/usage/model_config/):
```python
@dataclass
class Config:
    class CycloptsConfig:
        name = "*"
    user_stuff_here: str
```

I'm not a fan of this because:
1. It introduces a new Cyclopts concept that the developer has to understand (even though internally it's basically just a `Parameter`).
2. It relies on "magic naming." While cyclopts does an incredible amount of introspection, those variable names are always user-controlled.
3. It might negatively interact with other dataclass-like libraries.

### Additional Notes
Some may think that the syntax for optional user-classes could be additionally streamlined from:
```python
@app.command
def create(*, config: Config | None = None):
    if config is None:
        config = _Config()
    ...
```
to
```python
@app.command
def create(*, config: Config):  # Cyclopts detects that Config has all optional subkeys and provides a Config() object
    ...
```
However, I am opposed to this because it introduces inconsistencies on how Cyclopts provides arguments to commands. I think it's better to be a tiny bit more verbose (and more straightforward to read!) than for users to lose faith in if Cyclopts is going to behave as-expected. Additionally, if `Config` is an immutable object, then the user could directly provide a default object in the function signature while still being perfectly good python.

### Misc

Tagging @vhdirk from the discussion.
Also tagging @BruceEckel because I decided to make this a higher-priority feature after trying to improve some docs for you. Without this PR the examples were getting a bit large, which suggests that the syntax could be improved (i.e. by this PR).