### PR TITLE
Warn if cyclopts application is invoked with no python arguments within pytest.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1719,4 +1719,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "d646719c28b7b24aee1f3ceb3f8f62ffad596aabffb7b98f6da788ce795dcd30"
+content-hash = "81e0d77b89eb3435801d3c46ea62db37772e32f5c1f5c3814e3eb1dd1cea4997"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ sphinx-rtd-dark-mode = "^1.3.0"
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = ">=5.1"}
 pre_commit = ">=2.16.0"
-pytest = ">=7.1.2"
+pytest = ">=8.2.0"
 pytest-cov = ">=3.0.0"
 pytest-mock = ">=3.7.0"
 pydantic = "^2.7.0"

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -1,4 +1,21 @@
+import warnings
+
+import pytest
+
+import cyclopts.core
 from cyclopts import App
+from cyclopts.core import _log_framework_warning
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    # Setup
+    _log_framework_warning.cache_clear()
+
+    yield
+
+    # Teardown
+    _log_framework_warning.cache_clear()
 
 
 def test_app_iter(app):
@@ -51,3 +68,21 @@ def test_app_update():
     app1.update(app2)
 
     assert list(app1) == ["--help", "-h", "--version", "foo", "bar"]
+
+
+def test_log_framework_warning_unknown():
+    # Should not generate a warning for UNKNOWN framework
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Convert warnings to errors
+        _log_framework_warning(cyclopts.core.TestFramework.UNKNOWN)  # Should not raise
+
+
+def test_log_framework_warning_pytest():
+    # Should generate a warning when called from non-cyclopts module
+    with pytest.warns(UserWarning) as warning_records:
+        _log_framework_warning(cyclopts.core.TestFramework.PYTEST)
+
+    assert len(warning_records) == 1
+    warning_msg = str(warning_records[0].message)
+    assert 'unit-test framework "pytest"' in warning_msg
+    assert "Did you mean" in warning_msg

--- a/tests/test_bind_no_parse.py
+++ b/tests/test_bind_no_parse.py
@@ -23,4 +23,4 @@ def test_no_parse_invalid_kind(app):
         def foo(buzz: str, fizz: Annotated[str, Parameter(parse=False)]):
             pass
 
-        app()
+        app([])


### PR DESCRIPTION
Displays a warning if a user attempts to invoke a cyclopts application without python arguments while pytest is running. This causes `sys.argv` to be unexpectedly read. I cannot imagine a possible scenario where this would be intentional. This PR only covers `pytest`, but other popular testing frameworks could be added. The next obvious choice would be `unittest`, but I didn't find a definitive way of detecting it was running.

Alternative solution in response to @jayqi https://github.com/BrianPugh/cyclopts/issues/238#issuecomment-2591559815. What do you think of this?

Example output:

```text
=============================== warnings summary ================================
test.py::test_no_args
  /Users/brianpugh/projects/cyclopts2/test.py:64: UserWarning: Cyclopts application invoked without tokens under unit-test framework "pytest". Did you mean "app([])"?
    app(console=None)
```