### PR TITLE
improved pytest warning variable-name detection.

### DIFF
--- a/docs/source/cookbook/unit_testing.rst
+++ b/docs/source/cookbook/unit_testing.rst
@@ -198,6 +198,32 @@ We will use :meth:`.App.parse_args`, which performs all the parsing, but doesn't
        assert command == pypi_checker
        assert bound.arguments['name'] == "foo"
 
+.. warning::
+
+   A common mistake is accidentally calling ``app()`` or ``app.parse_args()`` with the **intent of providing no arguments**.
+   Calling these methods with no arguments will read from :obj:`sys.argv`, the same as in a typical application.
+   This is basically never the intention in a unit-test, and Cyclopts will produce a warning.
+   For example, this code in a unit test:
+
+   .. code-block:: python
+
+      app()  # Wrong: will produce a warning
+
+   Will generate this warning:
+
+   .. code-block:: text
+
+      =============================== warnings summary ================================
+      test.py::test_no_args
+        /my_project/test.py:64: UserWarning: Cyclopts application invoked without tokens under unit-test framework "pytest". Did you mean "app([])"?
+          app()
+
+   The proper way to specify no CLI arguments is to provide an empty string or list:
+
+   .. code-block:: python
+
+      app([])
+
 ---------
 Help Page
 ---------

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -77,12 +77,17 @@ def test_log_framework_warning_unknown():
         _log_framework_warning(cyclopts.core.TestFramework.UNKNOWN)  # Should not raise
 
 
-def test_log_framework_warning_pytest():
+def test_log_framework_warning_pytest(app):
     # Should generate a warning when called from non-cyclopts module
     with pytest.warns(UserWarning) as warning_records:
-        _log_framework_warning(cyclopts.core.TestFramework.PYTEST)
+        try:
+            app(exit_on_error=False)
+        except Exception:
+            pass
 
     assert len(warning_records) == 1
     warning_msg = str(warning_records[0].message)
-    assert 'unit-test framework "pytest"' in warning_msg
-    assert "Did you mean" in warning_msg
+    assert (
+        warning_msg
+        == 'Cyclopts application invoked without tokens under unit-test framework "pytest". Did you mean "app([])"?'
+    )


### PR DESCRIPTION
addresses https://github.com/BrianPugh/cyclopts/pull/300#issuecomment-2596282928

Basically, detecting the calling variable name is pretty hard. This will do the best it can, and if it cannot identify exactly 1 variable name, it will fallback to `"app"`.

### TODO

- [x] update docs