### PR TITLE
edit() to launch text editor for user input.

### DIFF
--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -14,8 +14,8 @@ __all__ = [
     "DocstringError",
     "EditorError",
     "EditorNotFoundError",
-    "DidNotSaveError",
-    "DidNotChangeError",
+    "EditorDidNotSaveError",
+    "EditorDidNotChangeError",
     "Group",
     "InvalidCommandError",
     "MissingArgumentError",
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 from cyclopts._convert import convert
-from cyclopts._edit import DidNotChangeError, DidNotSaveError, EditorError, EditorNotFoundError, edit
+from cyclopts._edit import EditorDidNotChangeError, EditorDidNotSaveError, EditorError, EditorNotFoundError, edit
 from cyclopts._env_var import env_var_split
 from cyclopts.argument import Argument, ArgumentCollection
 from cyclopts.core import App

--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -12,6 +12,10 @@ __all__ = [
     "CycloptsError",
     "Dispatcher",
     "DocstringError",
+    "EditorError",
+    "EditorNotFoundError",
+    "DidNotSaveError",
+    "DidNotChangeError",
     "Group",
     "InvalidCommandError",
     "MissingArgumentError",
@@ -25,12 +29,14 @@ __all__ = [
     "config",
     "convert",
     "default_name_transform",
+    "edit",
     "env_var_split",
     "types",
     "validators",
 ]
 
 from cyclopts._convert import convert
+from cyclopts._edit import DidNotChangeError, DidNotSaveError, EditorError, EditorNotFoundError, edit
 from cyclopts._env_var import env_var_split
 from cyclopts.argument import Argument, ArgumentCollection
 from cyclopts.core import App

--- a/cyclopts/_edit.py
+++ b/cyclopts/_edit.py
@@ -1,0 +1,103 @@
+import os
+import tempfile
+from pathlib import Path
+from typing import Sequence, Union
+
+
+class EditorError(Exception):
+    """Root editor-related error."""
+
+
+class DidNotSaveError(EditorError):
+    """User did not save upon exiting."""
+
+
+class DidNotChangeError(EditorError):
+    """User did not edit file contents."""
+
+
+class EditorNotFoundError(EditorError):
+    """Could not find a valid text editor."""
+
+
+def edit(
+    initial_text: str = "",
+    *,
+    fallback_editors: Sequence[str] = ("nano", "vim", "notepad", "gedit"),
+    editor_args: Sequence[str] = (),
+    path: Union[str, Path] = "",
+    encoding: str = "utf-8",
+    save: bool = True,
+    required: bool = True,
+) -> str:
+    """Get text input from a user via their default editor.
+
+    Parameters
+    ----------
+    initial_text: str
+        Initial text to populate the text file with.
+    fallback_editors: Sequence[str]
+        If the text editor cannot be determined from the environment variable ``EDITOR``, attempt to use these text editors in the order provided.
+    editor_args: Sequence[str]
+        Additional CLI arguments that are passed along to the editor-launch command.
+    path: Union[str, Path]
+        If specified, the path to the file that should be opened.
+        Text editors typically display this, so a custom path may result in a better user-interface.
+        Otherwiser, defaults to a temporary text file.
+    encoding: str
+        File encoding to use.
+    save: bool
+        Require the user to save before exiting the editor.
+    required: bool
+        Require for the saved text to be different from ``initial_text``.
+
+    Raises
+    ------
+    EditorError
+        Base editor error exception. Explicitly raised if editor subcommand
+        returned a non-zero exit code.
+    EditorNotFoundError
+        A suitable text editor could not be found.
+    DidNotSaveError
+        The user exited the text-editor without saving and ``save=True``.
+    DidNotChangeError
+        The user did not change the file contents and ``required=True``.
+
+    Returns
+    -------
+    str
+        The resulting text that was saved to the text editor.
+    """
+    import shutil
+    import subprocess
+
+    for editor in (os.environ.get("EDITOR"), *fallback_editors):
+        if editor and shutil.which(editor):
+            break
+    else:
+        raise EditorNotFoundError
+
+    if path:
+        path = Path(path)
+        path.parent.mkdir(exist_ok=True, parents=True)
+    else:
+        path = Path(tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False).name)
+    path.write_text(initial_text, encoding=encoding)
+
+    start_mtime = path.stat().st_mtime
+
+    try:
+        subprocess.check_output([editor, path, *editor_args])
+        end_mtime = path.stat().st_mtime
+        if save and end_mtime <= start_mtime:
+            raise DidNotSaveError
+        edited_text = path.read_text(encoding=encoding)
+    except subprocess.CalledProcessError as e:
+        raise EditorError(f"{editor} exited with status {e.returncode}") from e
+    finally:
+        path.unlink(missing_ok=True)
+
+    if required and edited_text == initial_text:
+        raise DidNotChangeError
+
+    return edited_text

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -903,6 +903,8 @@ API
 
 .. autofunction:: cyclopts.env_var_split
 
+.. autofunction:: cyclopts.edit
+
 .. _API Validators:
 
 ----------
@@ -1289,3 +1291,21 @@ Exceptions
    :members:
 
 .. autoexception:: cyclopts.CommandCollisionError
+   :show-inheritance:
+   :members:
+
+.. autoexception:: cyclopts.EditorError
+   :show-inheritance:
+   :members:
+
+.. autoexception:: cyclopts.EditorNotFoundError
+   :show-inheritance:
+   :members:
+
+.. autoexception:: cyclopts.EditorDidNotSaveError
+   :show-inheritance:
+   :members:
+
+.. autoexception:: cyclopts.EditorDidNotChangeError
+   :show-inheritance:
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ For extensive documentation on all the features Cyclopts has to offer, checkout 
    help.rst
    version.rst
    rules.rst
+   text_editor.rst
    api
 
 

--- a/docs/source/text_editor.rst
+++ b/docs/source/text_editor.rst
@@ -39,6 +39,6 @@ Here is an example application that mimics ``git commit`` functionality.
    if __name__ == "__main__":
        app()
 
-Running ``python git.py commit`` will bring up a text editor with the pre-defined text, and then return the contents of the file.
+Running ``python git.py commit`` will bring up a text editor with the pre-defined text, and then return the contents of the file. For more interactive CLI prompting, we recommend using the questionary_ package. See :func:`.edit` API page for more advanced usage.
 
-See :func:`.edit` API page for more advanced usage.
+.. _questionary: https://github.com/tmbo/questionary

--- a/docs/source/text_editor.rst
+++ b/docs/source/text_editor.rst
@@ -1,0 +1,44 @@
+===========
+Text Editor
+===========
+Some CLI programs require users to edit more complex fields in a text editor.
+For example, ``git`` may open a text editor for the user when rebasing or editing a commit message.
+While not directly related to CLI command parsing, Cyclopts provides :func:`cyclopts.edit` to satisfy this common need.
+
+Here is an example application that mimics ``git commit`` functionality.
+
+.. code-block:: python
+
+   # git.py
+   import cyclopts
+   from textwrap import dedent
+   import sys
+
+   app = cyclopts.App(name="git")
+
+   @app.command
+   def commit():
+       try:
+           response = cyclopts.edit(  # blocks until text editor is closed.
+               dedent(  # removes the  leading 4-tab indentation.
+                   """\
+
+
+                   # Please enter the commit message for your changes.Lines starting
+                   # with '#' will be ignored, and an empty message aborts the commit.
+                   """
+               )
+           )
+       except (cyclopts.EditorDidNotSaveError, cyclopts.EditorDidNotChangeError):
+           print("Aborting commit due to empty commit message.")
+           sys.exit(1)
+       filtered = "\n".join(x for x in response.split("\n") if not x.startswith("#"))
+       filtered = filtered.strip()  # remove leading/trailing whitespace.
+       print(f"Your commit message: {filtered}")
+
+   if __name__ == "__main__":
+       app()
+
+Running ``python git.py commit`` will bring up a text editor with the pre-defined text, and then return the contents of the file.
+
+See :func:`.edit` API page for more advanced usage.

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,0 +1,174 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cyclopts._edit import (
+    DidNotChangeError,
+    DidNotSaveError,
+    EditorError,
+    EditorNotFoundError,
+    edit,
+)
+
+
+@pytest.fixture
+def mock_editor():
+    """Mock editor that simulates saving file with edited content."""
+
+    def fake_editor(args):
+        Path(args[1]).write_text("edited content")
+        return 0
+
+    return fake_editor
+
+
+def test_basic_edit(mocker, mock_editor, monkeypatch):
+    """Test basic editing functionality."""
+    monkeypatch.setenv("EDITOR", "test_editor")
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=mock_editor)
+
+    result = edit("initial text")
+    assert result == "edited content"
+
+
+def test_custom_path(mocker, mock_editor, tmp_path, monkeypatch):
+    """Test editing with custom path."""
+    custom_path = tmp_path / "custom.txt"
+    monkeypatch.setenv("EDITOR", "test_editor")
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=mock_editor)
+
+    result = edit("initial text", path=custom_path)
+    assert result == "edited content"
+
+
+def test_editor_not_found(mocker, monkeypatch):
+    """Test behavior when no editor is found."""
+    monkeypatch.delenv("EDITOR", raising=False)
+    mocker.patch("shutil.which", return_value=False)
+
+    with pytest.raises(EditorNotFoundError):
+        edit("test")
+
+
+def test_did_not_save(mocker, monkeypatch):
+    """Test behavior when user doesn't save."""
+    monkeypatch.setenv("EDITOR", "test_editor")
+
+    def fake_editor(_):  # Doesn't "save"
+        return 0
+
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=fake_editor)
+
+    with pytest.raises(DidNotSaveError):
+        edit("initial text", save=True)
+
+
+def test_did_not_change(mocker, monkeypatch):
+    """Test behavior when content isn't changed."""
+    monkeypatch.setenv("EDITOR", "test_editor")
+    initial_text = "unchanged text"
+
+    def fake_editor(args):
+        assert args[0] == "test_editor"
+        Path(args[1]).write_text(initial_text)
+        return 0
+
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=fake_editor)
+
+    with pytest.raises(DidNotChangeError):
+        edit(initial_text, required=True)
+
+
+def test_editor_error(mocker, monkeypatch):
+    """Test handling of editor errors."""
+    monkeypatch.setenv("EDITOR", "test_editor")
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "test_editor"))
+
+    with pytest.raises(EditorError) as exc_info:
+        edit("test")
+    assert "status 1" in str(exc_info.value)
+
+
+def test_custom_encoding(mocker, tmp_path, monkeypatch):
+    """Test custom encoding support."""
+    test_path = tmp_path / "test.txt"
+    monkeypatch.setenv("EDITOR", "test_editor")
+
+    def fake_editor_with_encoding(args):
+        assert args[0] == "test_editor"
+        Path(args[1]).write_text("текст", encoding="utf-16")
+        return 0
+
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=fake_editor_with_encoding)
+
+    result = edit("initial", path=test_path, encoding="utf-16")
+    assert result == "текст"
+
+
+def test_fallback_editors(mocker, mock_editor, monkeypatch):
+    """Test fallback editor selection."""
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    def mock_which(editor_name):
+        return editor_name == "vim"
+
+    mocker.patch("shutil.which", side_effect=mock_which)
+    mock_check_output = mocker.patch("subprocess.check_output", side_effect=mock_editor)
+
+    result = edit("test", fallback_editors=["emacs", "vim", "nano"])
+    assert result == "edited content"
+    assert mock_check_output.call_args_list[0].args[0][0] == "vim"
+
+
+def test_editor_args(mocker, monkeypatch):
+    """Test passing additional arguments to editor."""
+    monkeypatch.setenv("EDITOR", "test_editor")
+
+    def check_editor_args(args):
+        assert args[0] == "test_editor"
+        assert "--no-splash" in args
+        Path(args[1]).write_text("edited with args")
+        return 0
+
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=check_editor_args)
+
+    result = edit("test", editor_args=["--no-splash"])
+    assert result == "edited with args"
+
+
+def test_optional_change(mocker, monkeypatch):
+    """Test when content changes are optional."""
+    monkeypatch.setenv("EDITOR", "test_editor")
+    initial_text = "unchanged"
+
+    def fake_editor(args):
+        assert args[0] == "test_editor"
+        Path(args[1]).write_text(initial_text)
+        return 0
+
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=fake_editor)
+
+    # Should not raise DidNotChangeError
+    result = edit(initial_text, required=False)
+    assert result == initial_text
+
+
+def test_file_cleanup(mocker, tmp_path, monkeypatch, mock_editor):
+    """Test temporary file cleanup."""
+    test_path = tmp_path / "cleanup_test.txt"
+    monkeypatch.setenv("EDITOR", "test_editor")
+
+    mocker.patch("shutil.which", return_value=True)
+    mocker.patch("subprocess.check_output", side_effect=mock_editor)
+
+    edit("test", path=test_path)
+    assert not test_path.exists()


### PR DESCRIPTION
Adds `cyclopts.edit()` that launches a text-editor for the user for getting input.

Addresses #298 