### PR TITLE
Move config-file-caching responsibility into ConfigFromFile.

### DIFF
--- a/cyclopts/config/_json.py
+++ b/cyclopts/config/_json.py
@@ -1,18 +1,12 @@
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from cyclopts.config._common import ConfigFromFile
 
 
-@lru_cache(8)
-def _load_json(path: Path):
-    import json
-
-    with path.open() as f:
-        return json.load(f)
-
-
 class Json(ConfigFromFile):
     def _load_config(self, path: Path) -> dict[str, Any]:
-        return _load_json(path.absolute())
+        import json
+
+        with path.open() as f:
+            return json.load(f)

--- a/cyclopts/config/_toml.py
+++ b/cyclopts/config/_toml.py
@@ -1,23 +1,17 @@
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from cyclopts.config._common import ConfigFromFile
 
 
-@lru_cache(8)
-def _load_toml(path: Path):
-    try:
-        # Attempt to use builtin >=python3.11
-        import tomllib  # pyright: ignore[reportMissingImports]
-    except ImportError:
-        # Fallback to most popular pypi toml package.
-        import tomli as tomllib  # pyright: ignore[reportMissingImports]
-
-    with path.open("rb") as f:
-        return tomllib.load(f)
-
-
 class Toml(ConfigFromFile):
     def _load_config(self, path: Path) -> dict[str, Any]:
-        return _load_toml(path.absolute())
+        try:
+            # Attempt to use builtin >=python3.11
+            import tomllib  # pyright: ignore[reportMissingImports]
+        except ImportError:
+            # Fallback to most popular pypi toml package.
+            import tomli as tomllib  # pyright: ignore[reportMissingImports]
+
+        with path.open("rb") as f:
+            return tomllib.load(f)

--- a/cyclopts/config/_yaml.py
+++ b/cyclopts/config/_yaml.py
@@ -1,18 +1,12 @@
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 from cyclopts.config._common import ConfigFromFile
 
 
-@lru_cache(8)
-def _load_yaml(path: Path):
-    from yaml import safe_load  # pyright: ignore[reportMissingImports]
-
-    with path.open() as f:
-        return safe_load(f)
-
-
 class Yaml(ConfigFromFile):
     def _load_config(self, path: Path) -> dict[str, Any]:
-        return _load_yaml(path.absolute())
+        from yaml import safe_load  # pyright: ignore[reportMissingImports]
+
+        with path.open() as f:
+            return safe_load(f)

--- a/tests/config/test_json.py
+++ b/tests/config/test_json.py
@@ -1,5 +1,9 @@
+import json
 from textwrap import dedent
 
+import pytest
+
+from cyclopts import App
 from cyclopts.config._json import Json
 
 
@@ -32,3 +36,58 @@ def test_config_json(tmp_path):
             },
         }
     }
+
+
+"""
+Test file-caching and chdir after app has been instantiated. See discussion:
+    https://github.com/BrianPugh/cyclopts/issues/309
+"""
+
+app = App(config=Json("config.json"))
+
+
+@app.command
+def create(name: str, age: int):
+    print(f"{name} is {age} years old.")
+
+
+@pytest.fixture(autouse=True)
+def chdir_to_tmp_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    return tmp_path / "config.json"
+
+
+def test_config_1(config_path, capsys, mocker):
+    with config_path.open("w") as f:
+        json.dump({"create": {"name": "Alice", "age": 30}}, f)
+
+    json_config = app.config[0]
+    spy_load_config = mocker.patch.object(json_config, "_load_config", wraps=json_config._load_config)  # pyright: ignore[reportAttributeAccessIssue]
+    app("create")
+    assert capsys.readouterr().out == "Alice is 30 years old.\n"
+    assert spy_load_config.call_count == 1
+
+    # Ensure that it doesn't get called again because the file hasn't changed.
+    app("create")
+    assert capsys.readouterr().out == "Alice is 30 years old.\n"
+    assert spy_load_config.call_count == 1
+
+    # If we modify the file, then it should get loaded again.
+    with config_path.open("w") as f:
+        json.dump({"create": {"name": "Bob", "age": 40}}, f)
+
+    app("create")
+    assert capsys.readouterr().out == "Bob is 40 years old.\n"
+    assert spy_load_config.call_count == 2
+
+
+def test_config_2(config_path, capsys):
+    with config_path.open("w") as f:
+        json.dump({"create": {"name": "Bob", "age": 40}}, f)
+
+    app("create")
+    assert capsys.readouterr().out == "Bob is 40 years old.\n"


### PR DESCRIPTION
@jayqi please give this a try!

Now on every app call, the configs will check to see if their cache is stale. It does this by comparing the previously read config's path/mtime/size to the found file's current state. This makes the `importlib.reload` hack during unit testing unnecessary. It should also still provide good performance for anyone who is invoking app multiple times in the same session with the same actual config-file.

Overall, this seems like a much more principled, clean approach than the previous caching implementation.

Addresses #309 