### PR TITLE
Bugfix/pydantic annotations

### DIFF
--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -194,3 +194,43 @@ def test_pydantic_alias(app, console, assert_parse_args):
         "foo --user.username='Bob Smith' --user.age_in_years=100",
         user=User(user_name="Bob Smith", age_in_years=100),
     )
+
+
+def test_parameter_decorator_pydantic_nested_1(app, console):
+    """
+    https://github.com/BrianPugh/cyclopts/issues/320
+
+    See Also
+    --------
+        test_parameter_decorator_dataclass_nested_1
+    """
+
+    class S3Path(BaseModel):
+        bucket: Annotated[str, Parameter()]
+        key: Annotated[str, Parameter()]
+
+    @Parameter(name="*")  # Flatten namespace.
+    class S3CliParams(BaseModel):
+        path: Annotated[S3Path, Parameter(name="*")]
+        region: Annotated[str, Parameter(name="region")]
+
+    @app.command
+    def action(*, s3_path: S3CliParams):
+        pass
+
+    with console.capture() as capture:
+        app("action --help", console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        Usage: test_parameter_decorator action [OPTIONS]
+
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ *  --bucket  [required]                                            │
+        │ *  --key     [required]                                            │
+        │ *  --region  [required]                                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from textwrap import dedent
-from typing import Dict, Optional, Union
+from typing import Annotated, Dict, Optional, Union
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, validate_call
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.alias_generators import to_camel
 
-from cyclopts import MissingArgumentError
+from cyclopts import MissingArgumentError, Parameter
 
 
 def test_pydantic_error_msg(app, console):
@@ -207,12 +207,12 @@ def test_parameter_decorator_pydantic_nested_1(app, console):
 
     class S3Path(BaseModel):
         bucket: Annotated[str, Parameter()]
-        key: Annotated[str, Parameter()]
+        key: str
 
     @Parameter(name="*")  # Flatten namespace.
     class S3CliParams(BaseModel):
         path: Annotated[S3Path, Parameter(name="*")]
-        region: Annotated[str, Parameter(name="region")]
+        region: Annotated[str, Parameter(name="area")]
 
     @app.command
     def action(*, s3_path: S3CliParams):
@@ -224,12 +224,12 @@ def test_parameter_decorator_pydantic_nested_1(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_parameter_decorator action [OPTIONS]
+        Usage: test_pydantic action [OPTIONS]
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  --bucket  [required]                                            │
         │ *  --key     [required]                                            │
-        │ *  --region  [required]                                            │
+        │ *  --area    [required]                                            │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )


### PR DESCRIPTION
`Annotated` attribute metadata in pydantic `BaseModel` classes was previously getting lost. This PR fixes that and addresses #320.