### PR TITLE
run: fix type signature for coroutines

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import sys
 import traceback
-from collections.abc import Iterable, Iterator
+from collections.abc import Coroutine, Iterable, Iterator
 from contextlib import suppress
 from copy import copy
 from enum import Enum
@@ -1507,7 +1507,15 @@ def _log_framework_warning(framework: TestFramework) -> None:
         break
 
 
-def run(callable: Callable[..., V], /) -> V:
+@overload
+def run(callable: Callable[..., Coroutine[None, None, V]], /) -> V: ...
+
+
+@overload
+def run(callable: Callable[..., V], /) -> V: ...
+
+
+def run(callable, /):
     """Run the given callable as a CLI command and return its result.
 
     The callable may also be a coroutine function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ exclude_lines = [
     "if sys.version_info >= (3, 10):",
     "from typing import Annotated",
     "except ImportError:",
+
+    # Overloads can't have coverage:
+    "@overload",
 ]
 
 omit = [


### PR DESCRIPTION
Fixes the type of `cyclopts.run` when the given callable is a coroutine function.

Without this, the wrong return type will be inferred, and Mypy will complain:

```python
error: Value of type "Coroutine[Any, Any, int]" must be used  [unused-coroutine]
note: Are you missing an await?
```

Let me know if you think this requires a changelog entry.