### PR TITLE
Show choices in help output for Sequence

### DIFF
--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -18,6 +18,7 @@ from typing import (
 from attrs import define, field
 
 import cyclopts.utils
+from cyclopts._convert import ITERABLE_TYPES
 from cyclopts.annotations import is_union
 from cyclopts.group import Group
 from cyclopts.utils import SortHelper, frozen, resolve_callables
@@ -329,7 +330,7 @@ def _get_choices(type_: type, name_transform: Callable[[str], str]) -> str:
         choices = ", ".join(x for x in inner_choices if x)
     elif _origin is Literal:
         choices = ", ".join(str(x) for x in get_args(type_))
-    elif _origin in (list, set, tuple):
+    elif _origin in ITERABLE_TYPES:
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):
             choices = get_choices(args[0])

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,7 +1,7 @@
 import sys
 from enum import Enum
 from textwrap import dedent
-from typing import Annotated, List, Literal, Optional, Set, Tuple, Union
+from typing import Annotated, List, Literal, Optional, Sequence, Set, Tuple, Union
 
 import pytest
 
@@ -646,6 +646,52 @@ def test_help_format_group_parameters_choices_enum_list_typing(capture_format_gr
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
+    assert actual == expected
+
+
+def test_help_format_group_parameters_choices_enum_sequence(capture_format_group_parameters):
+    class CompSciProblem(Enum):
+        fizz = "bleep bloop blop"
+        buzz = "blop bleep bloop"
+
+    def cmd(
+        foo: Annotated[
+            Optional[Sequence[CompSciProblem]],  # pyright: ignore
+            Parameter(help="Docstring for foo.", negative_iterable=(), show_default=False, show_choices=True),
+        ] = None,
+    ):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO --foo  Docstring for foo. [choices: fizz, buzz]                │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
+def test_help_format_group_parameters_choices_literal_sequence(capture_format_group_parameters):
+    def cmd(
+        steps_to_skip: Annotated[
+            Optional[Sequence[Literal["build", "deploy"]]],  # pyright: ignore
+            Parameter(help="Docstring for steps_to_skip.", negative_iterable=(), show_default=False, show_choices=True),
+        ] = None,
+    ):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ STEPS-TO-SKIP      Docstring for steps_to_skip. [choices: build,   │
+        │   --steps-to-skip  deploy]                                         │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    print(expected)
     assert actual == expected
 
 


### PR DESCRIPTION
cyclopt already correctly parses (and validates) Sequence, but it wasn't showing the valid choices in the help output.