### PR TITLE
Add `end_of_options_delimiter` option.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -878,6 +878,7 @@ class App:
             All tokens after this delimiter will be force-interpreted as positional arguments.
             If :obj:`None`, fallback to :class:`App.end_of_options_delimiter`.
             If that is not set, it will default to POSIX-standard ``"--"``.
+            Set to an empty string to disable.
 
         Returns
         -------
@@ -1067,6 +1068,7 @@ class App:
             All tokens after this delimiter will be force-interpreted as positional arguments.
             If :obj:`None`, fallback to :class:`App.end_of_options_delimiter`.
             If that is not set, it will default to POSIX-standard ``"--"``.
+            Set to an empty string to disable.
 
         Returns
         -------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -325,6 +325,13 @@ API
       The intended use-case of this feature is to allow users to specify functions that can load defaults from some external configuration.
       See :ref:`cyclopts.config <API Config>` for useful builtins and :ref:`Config Files` for examples.
 
+   .. attribute:: end_of_options_delimiter
+      :type: Optional[str]
+      :value: None
+
+      All tokens after this delimiter will be force-interpreted as positional arguments.
+      If no ``end_of_options_delimiter`` is set, it will default to POSIX-standard ``"--"``.
+
 
 .. autoclass:: cyclopts.Parameter
    :special-members: __call__

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -331,6 +331,7 @@ API
 
       All tokens after this delimiter will be force-interpreted as positional arguments.
       If no ``end_of_options_delimiter`` is set, it will default to POSIX-standard ``"--"``.
+      Set to an empty string to disable.
 
 
 .. autoclass:: cyclopts.Parameter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,18 @@ def assert_parse_args(app):
 
 
 @pytest.fixture
+def assert_parse_args_config(app):
+    def inner(config: dict, f, cmd: str, *args, **kwargs):
+        signature = cyclopts.utils.signature(f)
+        expected_bind = signature.bind(*args, **kwargs)
+        actual_command, actual_bind, _ = app.parse_args(cmd, print_error=False, exit_on_error=False, **config)
+        assert actual_command == f
+        assert actual_bind == expected_bind
+
+    return inner
+
+
+@pytest.fixture
 def assert_parse_args_partial(app):
     def inner(f, cmd: str, *args, **kwargs):
         signature = cyclopts.utils.signature(f)


### PR DESCRIPTION
Allows the POSIX-standard `"--"` end-of-options-delimiter to be changed.