### PR TITLE
remove config.Env.split; it wasn't actually used.

### DIFF
--- a/cyclopts/config/_env.py
+++ b/cyclopts/config/_env.py
@@ -1,9 +1,8 @@
 import os
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from attrs import define, field
 
-from cyclopts._env_var import env_var_split
 from cyclopts.argument import ArgumentCollection, Token
 
 if TYPE_CHECKING:
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
 class Env:
     prefix: str = ""
     command: bool = field(default=True, kw_only=True)
-    split: Callable = field(default=env_var_split, kw_only=True)
 
     def __call__(self, apps: list["App"], commands: tuple[str, ...], arguments: "ArgumentCollection"):
         prefix = self.prefix

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1319,12 +1319,6 @@ All Cyclopts builtins index into the configuration file with the following rules
 
       If :obj:`True`, add the command's name (uppercase) after :attr:`prefix`.
 
-   .. attribute:: split
-      :type: Callable
-      :value: cyclopts.env_var_split
-
-      Function that splits up the read-in :attr:`~cyclopts.Parameter.env_var` value.
-
 ----------
 Exceptions
 ----------


### PR DESCRIPTION
Kind of a breaking change, in the sense that any bugfix is a breaking change, but if someone was using this it wasn't working anyways. Fine to release as a patch.