### PR TITLE
Partially fix `from __future__ import annotations`

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -646,13 +646,15 @@ class Argument:
             # providing a single positional argument is what we want.
             self._accepts_keywords = True
             self._missing_keys_checker = _missing_keys_factory(_generic_class_field_infos)
+            type_hints = get_type_hints(hint.__init__)
             for i, iparam in enumerate(cyclopts.utils.signature(hint.__init__).parameters.values()):
                 if i == 0 and iparam.name == "self":
                     continue
+                annotation = type_hints.get(iparam.name, iparam.annotation)
                 if iparam.kind is iparam.VAR_KEYWORD:
-                    self._default = iparam.annotation
+                    self._default = annotation
                 else:
-                    self._lookup[iparam.name] = FieldInfo.from_iparam(iparam)
+                    self._lookup[iparam.name] = FieldInfo.from_iparam(iparam, annotation=annotation)
 
     @property
     def value(self):

--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -8,7 +8,6 @@ from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Sequence, Union
 
-import cyclopts.utils
 from cyclopts._convert import _bool
 from cyclopts.argument import ArgumentCollection
 from cyclopts.exceptions import (
@@ -278,8 +277,7 @@ def _bind(
     func: Callable,
 ):
     """Bind the mapping to the function signature."""
-    signature = cyclopts.utils.signature(func)
-    bound = signature.bind_partial()
+    bound = inspect.signature(func).bind_partial()
     for argument in argument_collection._root_arguments:
         if argument.value is not UNSET:
             bound.arguments[argument.field_info.name] = argument.value

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -24,7 +24,6 @@ from typing import (
 
 from attrs import define, field
 
-import cyclopts.utils
 from cyclopts.annotations import resolve_annotated
 from cyclopts.argument import ArgumentCollection
 from cyclopts.bind import create_bound_arguments, is_option_like, normalize_tokens
@@ -964,7 +963,7 @@ class App:
             command = self.help_print
             while meta_parent := meta_parent._meta_parent:
                 command = meta_parent.help_print
-            bound = cyclopts.utils.signature(command).bind(tokens, console=console)
+            bound = inspect.signature(command).bind(tokens, console=console)
             unused_tokens = []
             argument_collection = ArgumentCollection()
         elif any(flag in tokens for flag in command_app.version_flags):
@@ -972,7 +971,7 @@ class App:
             command = self.version_print
             while meta_parent := meta_parent._meta_parent:
                 command = meta_parent.version_print
-            bound = cyclopts.utils.signature(command).bind()
+            bound = inspect.signature(command).bind()
             unused_tokens = []
             argument_collection = ArgumentCollection()
         else:
@@ -1019,7 +1018,7 @@ class App:
                         # Running the application with no arguments and no registered
                         # ``default_command`` will default to ``help_print``.
                         command = self.help_print
-                        bound = cyclopts.utils.signature(command).bind(tokens=tokens, console=console)
+                        bound = inspect.signature(command).bind(tokens=tokens, console=console)
                         unused_tokens = []
                         argument_collection = ArgumentCollection()
             except CycloptsError as e:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -737,7 +737,9 @@ class App:
                 kwargs["group_parameters"] = copy(self._group_parameters)
             if "group_arguments" not in kwargs:
                 kwargs["group_arguments"] = copy(self._group_arguments)
-            app = App(default_command=obj, **kwargs)  # pyright: ignore
+            app = App(**kwargs)  # pyright: ignore
+            # directly call the default decorator, in case we do additional processing there.
+            app.default(obj)
 
             for flag in chain(kwargs["help_flags"], kwargs["version_flags"]):  # pyright: ignore
                 app[flag].show = False

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -112,7 +112,7 @@ class CycloptsError(Exception):
             if self.target:
                 file, lineno = _get_function_info(self.target)
                 strings.append(f'Function defined in file "{file}", line {lineno}:')
-                strings.append(f"    {self.target.__name__}{cyclopts.utils.signature(self.target)}")
+                strings.append(f"    {self.target.__name__}{inspect.signature(self.target)}")
             if self.root_input_tokens is not None:
                 strings.append(f"Root Input Tokens: {self.root_input_tokens}")
         else:

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -5,7 +5,6 @@ from typing import Annotated, Any, ClassVar, Optional, Sequence, get_args, get_o
 import attrs
 from attrs import field
 
-import cyclopts.utils
 from cyclopts.annotations import (
     NotRequired,
     Required,
@@ -108,6 +107,9 @@ class FieldInfo:
     def is_keyword_only(self) -> bool:
         return self.kind in (KEYWORD_ONLY, VAR_KEYWORD)
 
+    def evolve(self, **kwargs):
+        return attrs.evolve(self, **kwargs)
+
 
 def _typed_dict_field_infos(typeddict) -> dict[str, FieldInfo]:
     # The ``__required_keys__`` and ``__optional_keys__`` attributes of TypedDict are kind of broken in <cp3.11.
@@ -131,16 +133,15 @@ def _generic_class_field_infos(
     include_var_positional=False,
     include_var_keyword=False,
 ) -> dict[str, FieldInfo]:
-    signature = cyclopts.utils.signature(f.__init__)
     out = {}
-    for name, iparam in signature.parameters.items():
-        if iparam.name == "self":
+    for name, field_info in signature_parameters(f.__init__).items():
+        if field_info.name == "self":
             continue
-        if not include_var_positional and iparam.kind is iparam.VAR_POSITIONAL:
+        if not include_var_positional and field_info.kind is field_info.VAR_POSITIONAL:
             continue
-        if not include_var_keyword and iparam.kind is iparam.VAR_KEYWORD:
+        if not include_var_keyword and field_info.kind is field_info.VAR_KEYWORD:
             continue
-        out[name] = FieldInfo.from_iparam(iparam)
+        out[name] = field_info
     return out
 
 
@@ -190,13 +191,12 @@ def _namedtuple_field_infos(hint) -> dict[str, FieldInfo]:
 
 def _attrs_field_infos(hint) -> dict[str, FieldInfo]:
     out = {}
-    signature = cyclopts.utils.signature(hint.__init__)
-    iparams = signature.parameters
+    field_infos = signature_parameters(hint.__init__)
     for attribute in hint.__attrs_attrs__:
         if not attribute.init:
             continue
 
-        iparam = iparams[attribute.alias]
+        field_info = field_infos[attribute.alias]
 
         if isinstance(attribute.default, attrs.Factory):  # pyright: ignore
             required = False
@@ -208,13 +208,7 @@ def _attrs_field_infos(hint) -> dict[str, FieldInfo]:
             required = False
             default = attribute.default
 
-        out[iparam.name] = FieldInfo(
-            names=(attribute.alias,),
-            annotation=attribute.type,
-            kind=iparam.kind,
-            default=default,
-            required=required,
-        )
+        out[field_info.name] = field_info.evolve(names=(attribute.alias,), required=required, default=default)
     return out
 
 
@@ -266,3 +260,12 @@ def get_field_infos(hint) -> dict[str, FieldInfo]:
         return _dataclass_field_infos(hint)
     else:
         return _generic_class_field_infos(hint)
+
+
+def signature_parameters(f: Any) -> dict[str, FieldInfo]:
+    type_hints = get_type_hints(f, include_extras=True)
+    out = {}
+    for name, iparam in inspect.signature(f).parameters.items():
+        annotation = type_hints.get(name, iparam.annotation)
+        out[name] = FieldInfo.from_iparam(iparam, annotation=annotation)
+    return out

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -178,11 +178,12 @@ def _pydantic_field_infos(model) -> dict[str, FieldInfo]:
 
 def _namedtuple_field_infos(hint) -> dict[str, FieldInfo]:
     out = {}
+    type_hints = get_type_hints(hint)
     for name in hint._fields:
         out[name] = FieldInfo(
             names=(name,),
             kind=FieldInfo.POSITIONAL_OR_KEYWORD,
-            annotation=hint.__annotations__.get(name, str),
+            annotation=type_hints.get(name, str),
             default=hint._field_defaults.get(name, FieldInfo.empty),
             required=name not in hint._field_defaults,
         )

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -17,9 +17,9 @@ from typing import (
 
 from attrs import define, field
 
-import cyclopts.utils
 from cyclopts._convert import ITERABLE_TYPES
 from cyclopts.annotations import is_union
+from cyclopts.field_info import signature_parameters
 from cyclopts.group import Group
 from cyclopts.utils import SortHelper, frozen, resolve_callables
 
@@ -224,10 +224,14 @@ def format_usage(
 
     if app.default_command:
         to_show = set()
-        for parameter in cyclopts.utils.signature(app.default_command).parameters.values():
-            if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.VAR_POSITIONAL, parameter.POSITIONAL_OR_KEYWORD):
+        for field_info in signature_parameters(app.default_command).values():
+            if field_info.kind in (
+                field_info.POSITIONAL_ONLY,
+                field_info.VAR_POSITIONAL,
+                field_info.POSITIONAL_OR_KEYWORD,
+            ):
                 to_show.add("[ARGS]")
-            if parameter.kind in (parameter.KEYWORD_ONLY, parameter.VAR_KEYWORD, parameter.POSITIONAL_OR_KEYWORD):
+            if field_info.kind in (field_info.KEYWORD_ONLY, field_info.VAR_KEYWORD, field_info.POSITIONAL_OR_KEYWORD):
                 to_show.add("[OPTIONS]")
         usage.extend(sorted(to_show))
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -23,6 +23,7 @@ import cyclopts._env_var
 import cyclopts.utils
 from cyclopts._convert import ITERABLE_TYPES, convert
 from cyclopts.annotations import is_annotated, is_union, resolve_optional
+from cyclopts.field_info import signature_parameters
 from cyclopts.group import Group
 from cyclopts.token import Token
 from cyclopts.utils import (
@@ -333,15 +334,14 @@ def validate_command(f: Callable):
     """
     if (f.__module__ or "").startswith("cyclopts"):  # Speed optimization.
         return
-    signature = cyclopts.utils.signature(f)
-    for iparam in signature.parameters.values():
+    for field_info in signature_parameters(f).values():
         # Speed optimization: if an object is not annotated, then there's nothing
         # to validate. Checking if there's an annotation is significantly faster
         # than instantiating a cyclopts.Parameter object.
-        if not is_annotated(iparam.annotation):
+        if not is_annotated(field_info.annotation):
             continue
-        _, cparam = Parameter.from_annotation(iparam.annotation)
-        if not cparam.parse and iparam.kind is not iparam.KEYWORD_ONLY:
+        _, cparam = Parameter.from_annotation(field_info.annotation)
+        if not cparam.parse and field_info.kind is not field_info.KEYWORD_ONLY:
             raise ValueError("Parameter.parse=False must be used with a KEYWORD_ONLY function parameter.")
 
 

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Tuple, Union
 
 from attrs import field, frozen
 
-# fmt: off
-
 # https://threeofwands.com/attra-iv-zero-overhead-frozen-attrs-classes/
 if TYPE_CHECKING:
     from json import JSONDecodeError
@@ -21,14 +19,6 @@ else:
     from attrs import define
 
     frozen = functools.partial(define, unsafe_hash=True)
-
-if sys.version_info >= (3, 10):  # pragma: no cover
-    def signature(f: Any) -> inspect.Signature:
-        return inspect.signature(f, eval_str=True)
-else:  # pragma: no cover
-    def signature(f: Any) -> inspect.Signature:
-        return inspect.signature(f)
-# fmt: on
 
 if sys.version_info >= (3, 10):  # pragma: no cover
     from sys import stdlib_module_names
@@ -279,7 +269,7 @@ def record_init(target: str):
 
     def decorator(cls):
         original_init = cls.__init__
-        function_signature = signature(original_init)
+        function_signature = inspect.signature(original_init)
         param_names = tuple(name for name in function_signature.parameters if name != "self")
 
         @functools.wraps(original_init)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 from pathlib import Path
 
@@ -5,7 +6,6 @@ import pytest
 from rich.console import Console
 
 import cyclopts
-import cyclopts.utils
 from cyclopts import Group, Parameter
 
 
@@ -39,7 +39,7 @@ def default_function_groups():
 @pytest.fixture
 def assert_parse_args(app):
     def inner(f, cmd: str, *args, **kwargs):
-        signature = cyclopts.utils.signature(f)
+        signature = inspect.signature(f)
         expected_bind = signature.bind(*args, **kwargs)
         actual_command, actual_bind, _ = app.parse_args(cmd, print_error=False, exit_on_error=False)
         assert actual_command == f
@@ -51,7 +51,7 @@ def assert_parse_args(app):
 @pytest.fixture
 def assert_parse_args_config(app):
     def inner(config: dict, f, cmd: str, *args, **kwargs):
-        signature = cyclopts.utils.signature(f)
+        signature = inspect.signature(f)
         expected_bind = signature.bind(*args, **kwargs)
         actual_command, actual_bind, _ = app.parse_args(cmd, print_error=False, exit_on_error=False, **config)
         assert actual_command == f
@@ -63,7 +63,7 @@ def assert_parse_args_config(app):
 @pytest.fixture
 def assert_parse_args_partial(app):
     def inner(f, cmd: str, *args, **kwargs):
-        signature = cyclopts.utils.signature(f)
+        signature = inspect.signature(f)
         expected_bind = signature.bind_partial(*args, **kwargs)
         actual_command, actual_bind, _ = app.parse_args(cmd, print_error=False, exit_on_error=False)
         assert actual_command == f

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 
 def test_future_annotations_basic(app, assert_parse_args):
     @app.default
@@ -9,8 +11,21 @@ def test_future_annotations_basic(app, assert_parse_args):
     assert_parse_args(default, "foo", "foo")
 
 
+# TODO: Resolving stringified type-hinted class with closure/local scope
+# is really hard.
+@dataclass
+class Movie:
+    title: str
+    year: int
+
+
 def test_future_annotations_dataclass(app, assert_parse_args):
     """
     https://github.com/BrianPugh/cyclopts/issues/352
     """
-    pass
+
+    @app.command
+    def add(movie: Movie):
+        print(f"Adding movie: {movie}")
+
+    assert_parse_args(add, "add BladeRunner 1982", Movie("BladeRunner", 1982))

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, TypedDict
+
+import attrs
 
 from cyclopts import Parameter
 
@@ -17,7 +19,7 @@ def test_future_annotations_basic(app, assert_parse_args):
 # TODO: Resolving stringified type-hinted class with closure/local scope
 # is really hard.
 @dataclass
-class Movie:
+class DataclassMovie:
     title: str
     year: int
 
@@ -28,10 +30,10 @@ def test_future_annotations_dataclass(app, assert_parse_args):
     """
 
     @app.command
-    def add(movie: Movie):
+    def add(movie: DataclassMovie):
         print(f"Adding movie: {movie}")
 
-    assert_parse_args(add, "add BladeRunner 1982", Movie("BladeRunner", 1982))
+    assert_parse_args(add, "add BladeRunner 1982", DataclassMovie("BladeRunner", 1982))
 
 
 # This is unrelated to "from __future__ import annotations", but it's a very similar problem
@@ -47,12 +49,37 @@ class GenericMovie:
 
 
 def test_future_annotations_generic_class(app, assert_parse_args):
-    """
-    https://github.com/BrianPugh/cyclopts/issues/352
-    """
-
     @app.command
     def add(movie: Annotated[GenericMovie, Parameter(accepts_keys=True)]):
         print(f"Adding movie: {movie}")
 
     assert_parse_args(add, "add BladeRunner 1982", GenericMovie("BladeRunner", 1982))
+
+
+@attrs.define
+class AttrsMovie:
+    title: str
+    year: int
+
+
+def test_future_annotations_attrs_movie(app, assert_parse_args):
+    @app.command
+    def add(movie: Annotated[AttrsMovie, Parameter(accepts_keys=True)]):
+        print(f"Adding movie: {movie}")
+
+    assert_parse_args(add, "add BladeRunner 1982", AttrsMovie("BladeRunner", 1982))
+
+
+class TypedDictMovie(TypedDict):
+    title: str
+    year: int
+
+
+def test_future_annotations_typed_dict_movie(app, assert_parse_args):
+    @app.command
+    def add(movie: Annotated[TypedDictMovie, Parameter(accepts_keys=True)]):
+        print(f"Adding movie: {movie}")
+
+    assert_parse_args(
+        add, "add --movie.title=BladeRunner --movie.year=1982", TypedDictMovie(title="BladeRunner", year=1982)
+    )

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated, TypedDict
+from typing import Annotated, NamedTuple, TypedDict
 
 import attrs
+from pydantic import BaseModel
 
 from cyclopts import Parameter
 
@@ -83,3 +84,29 @@ def test_future_annotations_typed_dict_movie(app, assert_parse_args):
     assert_parse_args(
         add, "add --movie.title=BladeRunner --movie.year=1982", TypedDictMovie(title="BladeRunner", year=1982)
     )
+
+
+class NamedTupleMovie(NamedTuple):
+    title: str
+    year: int
+
+
+def test_future_annotations_named_tuple_movie(app, assert_parse_args):
+    @app.command
+    def add(movie: Annotated[NamedTupleMovie, Parameter(accepts_keys=True)]):
+        print(f"Adding movie: {movie}")
+
+    assert_parse_args(add, "add BladeRunner 1982", NamedTupleMovie(title="BladeRunner", year=1982))
+
+
+class PydanticMovie(BaseModel):
+    title: str
+    year: int
+
+
+def test_future_annotations_pydantic_movie(app, assert_parse_args):
+    @app.command
+    def add(movie: Annotated[PydanticMovie, Parameter(accepts_keys=True)]):
+        print(f"Adding movie: {movie}")
+
+    assert_parse_args(add, "add BladeRunner 1982", PydanticMovie(title="BladeRunner", year=1982))

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Annotated
+
+from cyclopts import Parameter
 
 
 def test_future_annotations_basic(app, assert_parse_args):
@@ -29,3 +32,27 @@ def test_future_annotations_dataclass(app, assert_parse_args):
         print(f"Adding movie: {movie}")
 
     assert_parse_args(add, "add BladeRunner 1982", Movie("BladeRunner", 1982))
+
+
+# This is unrelated to "from __future__ import annotations", but it's a very similar problem
+class GenericMovie:
+    def __init__(self, title: str, year: int):
+        self.title = title
+        self.year = year
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+        return self.title == other.title and self.year == other.year
+
+
+def test_future_annotations_generic_class(app, assert_parse_args):
+    """
+    https://github.com/BrianPugh/cyclopts/issues/352
+    """
+
+    @app.command
+    def add(movie: Annotated[GenericMovie, Parameter(accepts_keys=True)]):
+        print(f"Adding movie: {movie}")
+
+    assert_parse_args(add, "add BladeRunner 1982", GenericMovie("BladeRunner", 1982))

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def test_future_annotations_basic(app, assert_parse_args):
+    @app.default
+    def default(value: str):
+        pass
+
+    assert_parse_args(default, "foo", "foo")
+
+
+def test_future_annotations_dataclass(app, assert_parse_args):
+    """
+    https://github.com/BrianPugh/cyclopts/issues/352
+    """
+    pass


### PR DESCRIPTION
Hopefully this solves the problem "good enough." This still doesn't work whenever the annotated type hint is defined in a local scope, but I think that is generally relatively rare given Cyclopts use-case. From my initial attempts, a solution that resolves the surrounding closure is really complicated. I think this PR mostly solves the problem in a pragmatic sense, without adding a ton of code to maintain.

@beskep can you give this a try? What are your thoughts on it?

Addresses #352.