### PR TITLE
By default, registering a subapp will set it's help and version "show" attribute to false.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -740,8 +740,8 @@ class App:
             # directly call the default decorator, in case we do additional processing there.
             app.default(obj)
 
-            for flag in chain(kwargs["help_flags"], kwargs["version_flags"]):  # pyright: ignore
-                app[flag].show = False
+        for flag in chain(app.help_flags, app.version_flags):
+            app[flag].show = False
 
         if app._name_transform is None:
             app.name_transform = self.name_transform
@@ -1296,11 +1296,11 @@ class App:
         # Handle commands first; there's an off chance they may be "upgraded"
         # to an argument/parameter panel.
         for subapp in _walk_metas(apps[-1]):
-            # Handle Commands
-            for group, elements in groups_from_app(subapp):
+            for group, subapps in groups_from_app(subapp):
                 if not group.show:
                     continue
 
+                # Fetch a group's help-panel, or create it if it does not yet exist.
                 try:
                     _, command_panel = panels[group.name]
                 except KeyError:
@@ -1318,7 +1318,8 @@ class App:
                     else:
                         command_panel.description = group_help
 
-                command_panel.entries.extend(format_command_entries(elements, format=help_format))
+                # Add the command to the group's help panel.
+                command_panel.entries.extend(format_command_entries(subapps, format=help_format))
 
         # Handle Arguments/Parameters
         for subapp in _walk_metas(apps[-1]):

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -87,6 +87,7 @@ def test_help_custom_usage(app, console):
 
 
 def test_help_custom_usage_subapp(app, console):
+    """Intentionally do not print --help/--version flags in subapp help."""
     app.command(App(name="foo", usage="My custom usage."))
 
     with console.capture() as capture:
@@ -97,10 +98,6 @@ def test_help_custom_usage_subapp(app, console):
         """\
         My custom usage.
 
-        ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
-        ╰────────────────────────────────────────────────────────────────────╯
         """
     )
     assert actual == expected

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -106,9 +106,7 @@ def test_meta_app_nested_subapp_help(nested_meta_app, console, queue):
         This is subapp's help.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        Subapp foo help string.                                 │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo  Subapp foo help string.                                       │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )


### PR DESCRIPTION
@Ravencentric I didn't bother adding configuration to enable/disable this behavior, I'm just changing it to always hide --version and --help in subapps. I'll admit, this isn't the cleanest work, but I think this gets the solution that 99.99% of people want. If you are in the 0.01% that need something else, you can open an issue and we can fix it up then. Let me know what you think!

Addresses #362 .  