### PR TITLE
Always apply validator to default signature values.

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -1113,6 +1113,8 @@ class Argument:
         val = self.convert(converter=converter)
         if val is not UNSET:
             self.validate(val)
+        elif self.field_info.default is not FieldInfo.empty:
+            self.validate(self.field_info.default)
         return val
 
     def token_count(self, keys: tuple[str, ...] = ()):

--- a/cyclopts/validators/_number.py
+++ b/cyclopts/validators/_number.py
@@ -1,9 +1,6 @@
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Sequence, Union
 
 from cyclopts.utils import frozen
-
-Numeric = Union[int, float]
-NumericSequence = Sequence[Union[Numeric, "NumericSequence"]]
 
 
 @frozen(kw_only=True)
@@ -43,19 +40,19 @@ class Number:
         ╰───────────────────────────────────────────────────────────────╯
     """
 
-    lt: Optional[Numeric] = None
+    lt: Union[int, float, None] = None
     """Input value must be **less than** this value."""
 
-    lte: Optional[Numeric] = None
+    lte: Union[int, float, None] = None
     """Input value must be **less than or equal** this value."""
 
-    gt: Optional[Numeric] = None
+    gt: Union[int, float, None] = None
     """Input value must be **greater than** this value."""
 
-    gte: Optional[Numeric] = None
+    gte: Union[int, float, None] = None
     """Input value must be **greater than or equal** this value."""
 
-    modulo: Optional[Numeric] = None
+    modulo: Union[int, float, None] = None
     """Input value must be a multiple of this value."""
 
     def __call__(self, type_: Any, value: Any):
@@ -65,7 +62,7 @@ class Number:
             for v in value:
                 self(type_, v)
         else:
-            if not isinstance(value, Numeric):
+            if not isinstance(value, (int, float)):
                 return
 
             if self.lt is not None and value >= self.lt:

--- a/cyclopts/validators/_number.py
+++ b/cyclopts/validators/_number.py
@@ -58,13 +58,16 @@ class Number:
     modulo: Optional[Numeric] = None
     """Input value must be a multiple of this value."""
 
-    def __call__(self, type_: Any, value: Union[Numeric, NumericSequence]):
+    def __call__(self, type_: Any, value: Any):
         if isinstance(value, Sequence):
             if isinstance(value, str):
                 raise TypeError
             for v in value:
                 self(type_, v)
         else:
+            if not isinstance(value, Numeric):
+                return
+
             if self.lt is not None and value >= self.lt:
                 raise ValueError(f"Must be < {self.lt}.")
 

--- a/cyclopts/validators/_path.py
+++ b/cyclopts/validators/_path.py
@@ -96,7 +96,7 @@ class Path:
                 self(type_, p)
         else:
             if not isinstance(path, pathlib.Path):
-                raise TypeError
+                return
 
             if self.ext and path.suffix.lower().lstrip(".") not in self.ext:
                 if len(self.ext) == 1:

--- a/cyclopts/validators/_path.py
+++ b/cyclopts/validators/_path.py
@@ -87,7 +87,7 @@ class Path:
         if self.exists and not self.file_okay and not self.dir_okay:
             raise ValueError("(exists=True, file_okay=False, dir_okay=False) is an invalid configuration.")
 
-    def __call__(self, type_: Any, path: Union[pathlib.Path, Sequence[pathlib.Path]]):
+    def __call__(self, type_: Any, path: Any):
         if isinstance(path, Sequence):
             if isinstance(path, str):
                 raise TypeError

--- a/tests/test_bind_converter_validator.py
+++ b/tests/test_bind_converter_validator.py
@@ -165,6 +165,15 @@ def test_custom_converter_and_validator(app, assert_parse_args, validator):
     validator.assert_called_once_with(int, 10)
 
 
+def test_custom_validator_on_default_signature_value(app, validator):
+    @app.default
+    def foo(age: Annotated[int, Parameter(validator=validator)] = -1):
+        pass
+
+    app.parse_args("", print_error=False, exit_on_error=False)
+    validator.assert_called_once_with(int, -1)
+
+
 def test_custom_command_validator(app, assert_parse_args):
     validator = Mock()
 

--- a/tests/types/test_types_path.py
+++ b/tests/types/test_types_path.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pytest
 
@@ -38,6 +38,32 @@ def test_types_existing_file_app(app):
 
     with pytest.raises(ValidationError):
         app(["this-file-does-not-exist"], exit_on_error=False)
+
+
+def test_types_existing_file_app_signature_default(app):
+    @app.default
+    def main(f: ct.ExistingFile = Path("this-file-does-not-exist")):
+        pass
+
+    with pytest.raises(ValidationError):
+        app([""], exit_on_error=False)
+
+
+def test_types_optional_existing_file_app_signature_default(app):
+    @app.default
+    def main(f: Optional[ct.ExistingFile] = Path("this-file-does-not-exist")):
+        pass
+
+    with pytest.raises(ValidationError):
+        app([""], exit_on_error=False)
+
+
+def test_types_optional_existing_file_app_signature_default_none(app, assert_parse_args):
+    @app.default
+    def main(f: Optional[ct.ExistingFile] = None):
+        pass
+
+    assert_parse_args(main, "")
 
 
 def test_types_existing_file_app_list(app):


### PR DESCRIPTION
@Tinche I think this sufficiently addresses #361. A downside of this is that there are more complicated interactions with `Union` type hints, but I think you would only run into these edge cases if you're intentionally trying to break Cyclopts. For example, if you were to Union 2 Annotated types with different validators. I did make sure that common use-cases like `Optional[ExistingPath]` work. I might play around with this more before merging to explore more Union-interactions.