### PR TITLE
Enhance handling of Pydantic field annotations and improve tests

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -190,7 +190,7 @@ class ArgumentCollection(list["Argument"]):
         cls,
         field_info: FieldInfo,
         keys: tuple[str, ...],
-        *default_parameters,
+        *default_parameters: Optional[Parameter],
         group_lookup: dict[str, Group],
         group_arguments: Group,
         group_parameters: Group,
@@ -314,7 +314,9 @@ class ArgumentCollection(list["Argument"]):
                     sub_field_info,
                     keys + (sub_field_name,),
                     cparam,
-                    hint_docstring_lookup.get((sub_field_name,)),
+                    Parameter(help=sub_field_info.help)
+                    if sub_field_info.help
+                    else hint_docstring_lookup.get((sub_field_name,)),
                     Parameter(required=argument.required & sub_field_info.required),
                     group_lookup=group_lookup,
                     group_arguments=group_arguments,
@@ -379,7 +381,7 @@ class ArgumentCollection(list["Argument"]):
                 field_info,
                 (),
                 *default_parameters,
-                docstring_lookup.get((field_info.name,)),
+                Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
                 group_lookup=group_lookup,
                 group_arguments=group_arguments,
                 group_parameters=group_parameters,

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -1,6 +1,15 @@
 import inspect
 import sys
-from typing import Annotated, Any, ClassVar, Optional, Sequence, get_args, get_origin, get_type_hints  # noqa: F401
+from typing import (  # noqa: F401
+    Annotated,
+    Any,
+    ClassVar,
+    Optional,
+    Sequence,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 import attrs
 from attrs import field
@@ -160,11 +169,51 @@ def _pydantic_field_infos(model) -> dict[str, FieldInfo]:
 
         # Pydantic places ``Annotated`` data into pydantic.FieldInfo.metadata, while
         # pydantic.FieldInfo.annotation contains the "real" resolved type-hint.
-        # We have to re-combine them into a single Annotated hint.
-        if pydantic_field.metadata:
-            annotation = Annotated[(pydantic_field.annotation,) + tuple(pydantic_field.metadata)]  # pyright: ignore
+        metadata_list = list(pydantic_field.metadata) if pydantic_field.metadata else []
+
+        # First check for a Parameter with help in the metadata
+        parameter_with_help = None
+        field_with_description = None
+
+        # Extract Parameter with help
+        for meta in metadata_list:
+            if (
+                hasattr(meta, "__cyclopts__")
+                and meta.__cyclopts__.parameters
+                and any(param.help is not None for param in meta.__cyclopts__.parameters)
+            ):
+                parameter_with_help = meta
+                break
+
+        # Extract Field with description from metadata
+        for meta in metadata_list:
+            if hasattr(meta, "description") and meta.description:
+                field_with_description = meta
+                break
+
+        # Now build the annotation with the right help information
+        if parameter_with_help:
+            # Parameter(help=...) takes precedence
+            annotation = Annotated[(pydantic_field.annotation,) + tuple(metadata_list)]  # pyright: ignore
+        elif field_with_description:
+            # Field from Annotated
+            annotation = Annotated[(pydantic_field.annotation,) + tuple(metadata_list)]  # pyright: ignore
+        elif pydantic_field.description:
+            # Field.description outside Annotated, add it as a Parameter
+            from cyclopts.parameter import Parameter
+
+            if metadata_list:
+                metadata_list.append(Parameter(help=pydantic_field.description))
+                annotation = Annotated[(pydantic_field.annotation,) + tuple(metadata_list)]  # pyright: ignore
+            else:
+                annotation = Annotated[pydantic_field.annotation, Parameter(help=pydantic_field.description)]  # pyright: ignore
         else:
-            annotation = pydantic_field.annotation
+            # No help information available
+            annotation = (
+                Annotated[(pydantic_field.annotation,) + tuple(metadata_list)]  # pyright: ignore
+                if metadata_list
+                else pydantic_field.annotation
+            )
 
         out[python_name] = FieldInfo(
             names=tuple(names),

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -327,7 +327,8 @@ def test_pydantic_field_description(app, console):
         app("--help", console=console)
 
     actual = capture.get()
-    print(f"\nActual help content:\n{actual}")
+    # Debugging output removed to avoid cluttering test outputs
+    # If needed, use: logging.debug(f"Actual help content: {actual}")
 
     # Verify that Field.description is used for help text
     assert "User name." in actual


### PR DESCRIPTION
Improve the handling of field descriptions in Pydantic by ensuring that the correct metadata is utilized. Add tests to verify that field descriptions are correctly displayed in help text, while also cleaning up unnecessary debugging output from the tests.

**[copilot summary]**

Enhancements to metadata handling:

* [`cyclopts/field_info.py`](diffhunk://#diff-2871769754c62ee5f56dc08047ba331f8fdd75f21296e41454437793337b73e2L3-R12): Refactored the import statements for better readability.
* [`cyclopts/field_info.py`](diffhunk://#diff-2871769754c62ee5f56dc08047ba331f8fdd75f21296e41454437793337b73e2L163-R216): Enhanced the `_pydantic_field_infos` function to handle `Parameter` with help and `Field` descriptions more comprehensively, ensuring the correct metadata is applied to annotations.

Test improvements:

* [`tests/test_pydantic.py`](diffhunk://#diff-a21200f7d363575c6fcd0e1faae0c092a8c8ac8755f7c9f14791e20b17fafa60R298-R343): Added a new test case `test_pydantic_field_description` to verify that `Field.description` and `Parameter(help=...)` are correctly used for generating help text.