### PR TITLE
Do not catch `pydantic.ValidationError` from calling user's command.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1187,27 +1187,13 @@ class App:
             verbose=verbose,
             end_of_options_delimiter=end_of_options_delimiter,
         )
-        try:
-            if inspect.iscoroutinefunction(command):
-                import asyncio
 
-                return asyncio.run(command(*bound.args, **bound.kwargs))
-            else:
-                return command(*bound.args, **bound.kwargs)
-        except Exception as e:
-            try:
-                from pydantic import ValidationError as PydanticValidationError
-            except ImportError:
-                PydanticValidationError = None  # noqa: N806
+        if inspect.iscoroutinefunction(command):
+            import asyncio
 
-            if PydanticValidationError is not None and isinstance(e, PydanticValidationError):
-                if print_error:
-                    console = self._resolve_console(tokens, console)
-                    console.print(format_cyclopts_error(e))
-
-                if exit_on_error:
-                    sys.exit(1)
-            raise
+            return asyncio.run(command(*bound.args, **bound.kwargs))
+        else:
+            return command(*bound.args, **bound.kwargs)
 
     def _resolve(self, tokens_or_apps: Optional[Sequence], override: Optional[V], attribute: str) -> Optional[V]:
         if override is not None:

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -26,6 +26,9 @@ class User(BaseModel):
     outfit: Optional[Outfit] = None
 
 
+@pytest.mark.skip(
+    reason="We disabled catching pydantic.ValidationError exceptions from @pydantic.validate_call because we would also erroneously catch exceptions from the command's body."
+)
 def test_pydantic_error_msg(app, console):
     @app.command
     @validate_call


### PR DESCRIPTION
Addresses #376 .

A downside to this is that we do not catch pydantic ValidationErrors from the command's signature (if decorated with `@validate_call`).