### PR TITLE
Ensure App is permitting subclasses

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -736,7 +736,7 @@ class App:
                 kwargs["group_parameters"] = copy(self._group_parameters)
             if "group_arguments" not in kwargs:
                 kwargs["group_arguments"] = copy(self._group_arguments)
-            app = App(**kwargs)  # pyright: ignore
+            app = type(self)(**kwargs)  # pyright: ignore
             # directly call the default decorator, in case we do additional processing there.
             app.default(obj)
 


### PR DESCRIPTION
(I'd love to make a test for this but was a smidge lazy, feel free to push back)

Simple change to add some flexibility where clients can subclass `App`, and use `.command()` on a subclass'd App as well.