### PR TITLE
Handle the first block of docstring text as a potential multi-line short description.

### DIFF
--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -43,14 +43,22 @@ def docstring_parse(doc: str, format: str):
     import docstring_parser
 
     cleaned_doc = inspect.cleandoc(doc)
-    if format != "plaintext":
-        if len(short_description_and_remainder := cleaned_doc.split("\n\n", 1)) == 2:
-            # Place multi-line summary into a single line.
-            # This kind of goes against PEP-0257, but any reasonable CLI command will
-            # have either no description, or it will have both a short and long description.
-            short = short_description_and_remainder[0].replace("\n", " ")
-            cleaned_doc = short + "\n\n" + short_description_and_remainder[1]
+    short_description_and_maybe_remainder = cleaned_doc.split("\n\n", 1)
+
+    # Place multi-line summary into a single line.
+    # This kind of goes against PEP-0257, but any reasonable CLI command will
+    # have either no description, or it will have both a short and long description.
+    short = short_description_and_maybe_remainder[0].replace("\n", " ")
+    if len(short_description_and_maybe_remainder) == 1:
+        cleaned_doc = short
+    else:
+        cleaned_doc = short + "\n\n" + short_description_and_maybe_remainder[1]
+
     res = docstring_parser.parse(cleaned_doc)
+
+    # Ensure a short description exists if there's a long description
+    assert not res.long_description or res.short_description
+
     return res
 
 

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -11,6 +11,7 @@ from typing import (
     Callable,
     Literal,
     Optional,
+    Sequence,
     get_args,
     get_origin,
 )
@@ -37,19 +38,19 @@ else:  # pragma: no cover
 
 
 @lru_cache(maxsize=16)
-def docstring_parse(doc: str):
-    """Addon to :func:`docstring_parser.parse` that double checks the `short_description`."""
+def docstring_parse(doc: str, format: str):
+    """Addon to :func:`docstring_parser.parse` that supports multi-line `short_description`."""
     import docstring_parser
 
-    res = docstring_parser.parse(doc)
     cleaned_doc = inspect.cleandoc(doc)
-    short = cleaned_doc.split("\n\n")[0]
-    if res.short_description != short:
-        if res.long_description is None:
-            res.long_description = res.short_description
-        elif res.short_description is not None:
-            res.long_description = res.short_description + "\n" + res.long_description
-        res.short_description = None
+    if format != "plaintext":
+        if len(short_description_and_remainder := cleaned_doc.split("\n\n", 1)) == 2:
+            # Place multi-line summary into a single line.
+            # This kind of goes against PEP-0257, but any reasonable CLI command will
+            # have either no description, or it will have both a short and long description.
+            short = short_description_and_remainder[0].replace("\n", " ")
+            cleaned_doc = short + "\n\n" + short_description_and_remainder[1]
+    res = docstring_parser.parse(cleaned_doc)
     return res
 
 
@@ -348,13 +349,28 @@ def format_usage(
     return Text(" ".join(usage) + "\n", style="bold")
 
 
+def _smart_join(strings: Sequence[str]) -> str:
+    """Joins strings with a space, unless the previous string ended in a newline."""
+    if not strings:
+        return ""
+
+    result = [strings[0]]
+    for s in strings[1:]:
+        if result[-1].endswith("\n"):
+            result.append(s)
+        else:
+            result.append(" " + s)
+
+    return "".join(result)
+
+
 def format_doc(app: "App", format: str = "restructuredtext"):
     raw_doc_string = app.help
 
     if not raw_doc_string:
         return _silent
 
-    parsed = docstring_parse(raw_doc_string)
+    parsed = docstring_parse(raw_doc_string, format)
 
     components: list[str] = []
     if parsed.short_description:
@@ -364,7 +380,7 @@ def format_doc(app: "App", format: str = "restructuredtext"):
         if parsed.short_description:
             components.append("\n")
         components.append(parsed.long_description + "\n")
-    return InlineText.from_format(" ".join(components), format=format, force_empty_end=True)
+    return InlineText.from_format(_smart_join(components), format=format, force_empty_end=True)
 
 
 def _get_choices(type_: type, name_transform: Callable[[str], str]) -> str:
@@ -481,7 +497,7 @@ def format_command_entries(apps: Iterable["App"], format: str) -> list[HelpEntry
         entry = HelpEntry(
             name="\n".join(long_names),
             short=" ".join(short_names),
-            description=InlineText.from_format(docstring_parse(app.help).short_description, format=format),
+            description=InlineText.from_format(docstring_parse(app.help, format).short_description, format=format),
             sort_key=resolve_callables(app.sort_key, app),
         )
         if entry not in entries:

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -91,6 +91,17 @@ Cyclopts mostly respects `PEP-0257`_, but has some slight differences for develo
 
 1. The "summary line" (AKA short-description) may actually be multiple lines. Cyclopts will unwrap the first block of text and interpret it as the short description. The first block of text ends at the first double-newline (i.e. a single blank line) is reached.
 
+   .. code-block:: python
+
+      def my_command():
+          """
+          This entire sentence
+          is part of the short description and will
+          have all the newlines removed.
+
+          This is the beginning of the long description.
+          """
+
 2. If a docstring is provided with a long description, it **must** also have a short description.
 
 By default, Cyclopts parses docstring descriptions as restructuredtext and renders it appropriately.

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -87,8 +87,14 @@ The source resolution order is as follows (as applicable):
 Markup Format
 -------------
 The standard markup language for docstrings in python is reStructuredText (see `PEP-0287`_).
+Cyclopts mostly respects `PEP-0257`_, but has some slight differences for developer ergonomics:
+
+1. The "summary line" (AKA short-description) may actually be multiple lines. Cyclopts will unwrap the first block of text and interpret it as the short description. The first block of text ends at the first double-newline (i.e. a single blank line) is reached.
+
+2. If a docstring is provided with a long description, it **must** also have a short description.
+
 By default, Cyclopts parses docstring descriptions as restructuredtext and renders it appropriately.
-To change the markup format, set the :attr:`.App.help_format` field accordingly.
+To change the markup format, set the :attr:`.App.help_format` field accordingly. The different options are described below.
 
 Subapps inherit their parent's :attr:`.App.help_format` unless explicitly overridden. I.e. you only need
 to set :attr:`.App.help_format` in your main root application for all docstrings to be parsed appropriately.

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1686,6 +1686,8 @@ def test_help_plaintext(app, console):
     """Tests that plaintext documents don't get interpreted otherwise."""
     description = dedent(
         """\
+        This is the short description.
+
         This is a long sentence that
         is spread across
         three lines.
@@ -1714,6 +1716,8 @@ def test_help_plaintext(app, console):
     expected = dedent(
         """\
         Usage: test_help COMMAND
+
+        This is the short description.
 
         This is a long sentence that
         is spread across


### PR DESCRIPTION
Addresses #393. @ RandallPittmanOrSt what do you think of this solution? If we like it, i'll fix tests.