### PR TITLE
Allow Parameter.show_default to be a callable. Add `HexUInt*` types.

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -713,7 +713,7 @@ class Argument:
         return any(dict in (arg, get_origin(arg)) for arg in args)
 
     @property
-    def show_default(self) -> bool:
+    def show_default(self) -> Union[bool, Callable[[Any], str]]:
         """Show the default value on the help page."""
         if self.parameter.show_default is None:
             return not self.required and self.field_info.default not in _SHOW_DEFAULT_BLOCKLIST

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -440,11 +440,12 @@ def create_parameter_help_panel(
             help_description.append(Text(rf"[env var: {env_vars}]", "dim"))
 
         if argument.show_default:
-            default = ""
             if isclass(argument.hint) and issubclass(argument.hint, Enum):
                 default = argument.parameter.name_transform(argument.field_info.default.name)
             else:
                 default = argument.field_info.default
+            if callable(argument.show_default):
+                default = argument.show_default(default)
 
             help_description.append(Text(rf"[default: {default}]", "dim"))
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -127,7 +127,7 @@ class Parameter:
 
     _show: Optional[bool] = field(default=None, alias="show")
 
-    show_default: Optional[bool] = field(default=None)
+    show_default: Union[None, bool, Callable[[Any], str]] = field(default=None)
 
     show_choices: bool = field(default=None, converter=attrs.converters.default_if_none(True))
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -127,7 +127,7 @@ class Parameter:
 
     _show: Optional[bool] = field(default=None, alias="show")
 
-    show_default: Union[None, bool, Callable[[Any], str]] = field(default=None)
+    show_default: Union[None, bool, Callable[[Any], Any]] = field(default=None)
 
     show_choices: bool = field(default=None, converter=attrs.converters.default_if_none(True))
 

--- a/cyclopts/types.py
+++ b/cyclopts/types.py
@@ -1,3 +1,4 @@
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Sequence
 
@@ -54,6 +55,11 @@ __all__ = [
     "Int32",
     "UInt64",
     "Int64",
+    "HexUInt",
+    "HexUInt8",
+    "HexUInt16",
+    "HexUInt32",
+    "HexUInt64",
     # Json,
     "Json",
     # Web
@@ -182,6 +188,26 @@ UInt64 = Annotated[int, Parameter(validator=validators.Number(gte=0, lt=1 << 64)
 "An unsigned 64-bit integer."
 Int64 = Annotated[int, Parameter(validator=validators.Number(gte=(-1 << 63), lt=(1 << 63)))]
 "A signed 64-bit integer."
+
+
+def _hex_formatter(value: int, digits=0) -> str:
+    return f"0x{value:X}" if digits <= 0 else f"0x{value:0{digits}X}"
+
+
+HexUInt = Annotated[NonNegativeInt, Parameter(show_default=_hex_formatter)]
+"A non-negative integer who's default value will be displayed as hexadecimal in the help-page."
+
+HexUInt8 = Annotated[UInt8, Parameter(show_default=partial(_hex_formatter, digits=2))]
+"An unsigned 8-bit integer who's default value will be displayed as hexadecimal in the help-page."
+
+HexUInt16 = Annotated[UInt16, Parameter(show_default=partial(_hex_formatter, digits=4))]
+"An unsigned 16-bit integer who's default value will be displayed as hexadecimal in the help-page."
+
+HexUInt32 = Annotated[UInt32, Parameter(show_default=partial(_hex_formatter, digits=8))]
+"An unsigned 32-bit integer who's default value will be displayed as hexadecimal in the help-page."
+
+HexUInt64 = Annotated[UInt64, Parameter(show_default=partial(_hex_formatter, digits=16))]
+"An unsigned 64-bit integer who's default value will be displayed as hexadecimal in the help-page."
 
 
 ########

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -575,7 +575,7 @@ API
       Defaults to :attr:`parse` value (default: :obj:`True`).
 
    .. attribute:: show_default
-      :type: Union[None, bool, Callable[[Any], str]]
+      :type: Union[None, bool, Callable[[Any], Any]]
       :value: None
 
       If a variable has a default, display the default on the help page.
@@ -585,10 +585,10 @@ API
 
       .. code-block:: python
 
-         def formatter(value: Any) -> str:
+         def formatter(value: Any) -> Any:
              ...
 
-      Then the function will be called with the default value, and the returned string will be used as the displayed default value.
+      Then the function will be called with the default value, and the returned value will be used as the displayed default value.
 
       Example formatting function:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -575,11 +575,28 @@ API
       Defaults to :attr:`parse` value (default: :obj:`True`).
 
    .. attribute:: show_default
-      :type: Optional[bool]
+      :type: Union[None, bool, Callable[[Any], str]]
       :value: None
 
       If a variable has a default, display the default on the help page.
-      Defaults to :obj:`None`, similar to :obj:`True`, but will not display the default if it's :obj:`None`.
+      Defaults to :obj:`None`, similar to :obj:`True`, but will **not** display the default if it is :obj:`None`.
+
+      If set to a function with signature:
+
+      .. code-block:: python
+
+         def formatter(value: Any) -> str:
+             ...
+
+      Then the function will be called with the default value, and the returned string will be used as the displayed default value.
+
+      Example formatting function:
+
+      .. code-block:: python
+
+         def hex_formatter(value: int) -> str
+            """Will result in something like "[default: 0xFF]" instead of "[default: 255]"."""
+            return f"0x{value:X}"
 
    .. attribute:: show_choices
       :type: Optional[bool]
@@ -1076,17 +1093,25 @@ All of these types will also work on sequence of numbers (e.g. ``tuple[int, int]
 
 .. autodata:: cyclopts.types.UInt8
 
+.. autodata:: cyclopts.types.HexUInt8
+
 .. autodata:: cyclopts.types.Int8
 
 .. autodata:: cyclopts.types.UInt16
+
+.. autodata:: cyclopts.types.HexUInt16
 
 .. autodata:: cyclopts.types.Int16
 
 .. autodata:: cyclopts.types.UInt32
 
+.. autodata:: cyclopts.types.HexUInt32
+
 .. autodata:: cyclopts.types.Int32
 
 .. autodata:: cyclopts.types.UInt64
+
+.. autodata:: cyclopts.types.HexUInt64
 
 .. autodata:: cyclopts.types.Int64
 


### PR DESCRIPTION
Previously, `Parameter.show_default` had type `None | bool`. This PR extends the functionality, where if the provided value is a callable, we will invoke it to translate the default value into a string.

Addresses #407. @domwalters what do you think of this solution? Since this is a relatively specific use-case, I'm trying to avoid adding additional `Parameter` attributes.