### PR TITLE
Show config env in help

### DIFF
--- a/cyclopts/config/_env.py
+++ b/cyclopts/config/_env.py
@@ -9,6 +9,10 @@ if TYPE_CHECKING:
     from cyclopts.core import App
 
 
+def _transform(s: str) -> str:
+    return s.upper().replace("-", "_").replace(".", "_").lstrip("_")
+
+
 @define
 class Env:
     prefix: str = ""
@@ -27,7 +31,7 @@ class Env:
             try:
                 argument, remaining_keys, _ = arguments.match(
                     candidate_env_key[len(prefix) :],
-                    transform=lambda s: s.upper().replace("-", "_").replace(".", "_").lstrip("_"),
+                    transform=_transform,
                     delimiter="_",
                 )
             except ValueError:

--- a/cyclopts/config/_env.py
+++ b/cyclopts/config/_env.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from attrs import define, field
 
-from cyclopts.argument import ArgumentCollection, Token
+from cyclopts.argument import Argument, ArgumentCollection, Token
 
 if TYPE_CHECKING:
     from cyclopts.core import App
@@ -18,12 +18,24 @@ class Env:
     prefix: str = ""
     command: bool = field(default=True, kw_only=True)
 
-    def __call__(self, apps: list["App"], commands: tuple[str, ...], arguments: "ArgumentCollection"):
-        added_tokens = set()
-
+    def _prefix(self, commands: tuple[str, ...]) -> str:
         prefix = self.prefix
         if self.command and commands:
             prefix += "_".join(x.upper() for x in commands) + "_"
+
+        return prefix
+
+    def _convert_argument(self, commands: tuple[str, ...], argument: Argument) -> str:
+        """For generating environment variable names for the help-page.
+
+        Internal Cyclopts use only.
+        """
+        return self._prefix(commands) + _transform(argument.name)
+
+    def __call__(self, apps: list["App"], commands: tuple[str, ...], arguments: "ArgumentCollection"):
+        added_tokens = set()
+
+        prefix = self._prefix(commands)
 
         candidate_env_keys = [x for x in os.environ if x.startswith(prefix)]
         candidate_env_keys.sort()

--- a/cyclopts/config/_env.py
+++ b/cyclopts/config/_env.py
@@ -17,6 +17,7 @@ def _transform(s: str) -> str:
 class Env:
     prefix: str = ""
     command: bool = field(default=True, kw_only=True)
+    show: bool = True
 
     def _prefix(self, commands: tuple[str, ...]) -> str:
         prefix = self.prefix

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1334,7 +1334,7 @@ class App:
 
             # Special-case: add config.Env values to Parameter(env_var=)
             configs: tuple[Callable, ...] = self._resolve(apps, None, "_config") or ()
-            env_configs = tuple(x for x in configs if isinstance(x, Env))
+            env_configs = tuple(x for x in configs if isinstance(x, Env) and x.show)
             for argument in argument_collection:
                 for env_config in env_configs:
                     env_var = env_config._convert_argument(command_chain, argument)

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -27,6 +27,7 @@ from attrs import define, field
 from cyclopts.annotations import resolve_annotated
 from cyclopts.argument import ArgumentCollection
 from cyclopts.bind import create_bound_arguments, is_option_like, normalize_tokens
+from cyclopts.config._env import Env
 from cyclopts.exceptions import (
     CommandCollisionError,
     CycloptsError,
@@ -1291,7 +1292,7 @@ class App:
         from rich.console import Group as RichGroup
         from rich.console import NewLine
 
-        _, apps, _ = self.parse_commands(tokens)
+        command_chain, apps, _ = self.parse_commands(tokens)
 
         help_format = resolve_help_format(apps)
 
@@ -1330,6 +1331,19 @@ class App:
                 continue
 
             argument_collection = subapp.assemble_argument_collection(apps=apps, parse_docstring=True)
+
+            # Special-case: add config.Env values to Parameter(env_var=)
+            configs: tuple[Callable, ...] = self._resolve(apps, None, "_config") or ()
+            env_configs = tuple(x for x in configs if isinstance(x, Env))
+            for argument in argument_collection:
+                for env_config in env_configs:
+                    env_var = env_config._convert_argument(command_chain, argument)
+                    assert isinstance(argument.parameter.env_var, tuple)
+                    argument.parameter = Parameter.combine(
+                        argument.parameter,
+                        Parameter(env_var=(*argument.parameter.env_var, env_var)),
+                    )
+
             for group in argument_collection.groups:
                 if not group.show:
                     continue

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1337,6 +1337,13 @@ All Cyclopts builtins index into the configuration file with the following rules
 
       If :obj:`True`, add the command's name (uppercase) after :attr:`prefix`.
 
+   .. attribute:: show
+      :type: bool
+      :value: True
+
+      If :obj:`True`, then show the environment variables on the help-page.
+
+
 ----------
 Exceptions
 ----------

--- a/tests/config/test_end2end.py
+++ b/tests/config/test_end2end.py
@@ -69,7 +69,7 @@ def test_config_env_help(app, assert_parse_args, console):
         │ --version  Display application version.                            │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
-        │ *  FOO --foo  [env var: FOO, BAR] [required]                       │
+        │ *  FOO --foo  [env var: BAR, FOO] [required]                       │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )

--- a/tests/config/test_end2end.py
+++ b/tests/config/test_end2end.py
@@ -46,3 +46,31 @@ def test_config_env_repeated(app, monkeypatch, assert_parse_args):
         pass
 
     assert_parse_args(default, "", "bar")
+
+
+def test_config_env_help(app, assert_parse_args, console):
+    """Special-case for :class:`.config.Env` to get added to help-page."""
+    app.config = Env()
+
+    @app.default
+    def default(foo: Annotated[str, Parameter(env_var="BAR")]):
+        pass
+
+    with console.capture() as capture:
+        app(["--help"], console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        Usage: default COMMAND [ARGS] [OPTIONS]
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ --help -h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ *  FOO --foo  [env var: FOO, BAR] [required]                       │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected


### PR DESCRIPTION
Adds a special case for instances of `cyclopts.config.Env` to display environment variables via the private `_convert_argument` method on the help-page. **This private interface is subject to change**. If someone in the future wants to override this method, please open an issue where we can more carefully think through a maintainable method.

This new feature can be controllable through `cyclopts.config.Env.show: bool`. Default to `True`.

Addresses [this comment](https://github.com/BrianPugh/cyclopts/issues/415#issuecomment-2828942474) in #415. @taranlu-houzz can you test this PR out? Thanks!