### PR TITLE
Treat classes with only `VAR_POSITIONAL` argument as a builtin.

### DIFF
--- a/tests/test_bind_var_pos.py
+++ b/tests/test_bind_var_pos.py
@@ -12,11 +12,14 @@ def test_bind_custom_class_only_var_positional(app, assert_parse_args):
     """It's quite common for classes with *args to really only intend to consume 1 element."""
 
     class MyCustomClass:
-        def __init__(self, *args: int):
+        def __init__(self, *args):
             self.args = args
+
+        def __eq__(self, other):
+            return self.args == other.args
 
     @app.default
     def default(value: MyCustomClass):
         pass
 
-    assert_parse_args(default, "100", MyCustomClass(100))
+    assert_parse_args(default, "100", MyCustomClass("100"))

--- a/tests/test_bind_var_pos.py
+++ b/tests/test_bind_var_pos.py
@@ -6,3 +6,17 @@ def test_bind_var_pos(app):
         assert tokens == ("Alice",)
 
     app(["Alice"])
+
+
+def test_bind_custom_class_only_var_positional(app, assert_parse_args):
+    """It's quite common for classes with *args to really only intend to consume 1 element."""
+
+    class MyCustomClass:
+        def __init__(self, *args: int):
+            self.args = args
+
+    @app.default
+    def default(value: MyCustomClass):
+        pass
+
+    assert_parse_args(default, "100", MyCustomClass(100))


### PR DESCRIPTION
Motiviation: it's not uncommon for classes to have a definition like:
```python
class MyPath:
    def __init__(self, *args):
        self.args
```
where the common use case (for a CLI) is supplying a single string: `MyPath("foo")`. This PR will attempt to parse a single token, and pass it to custom classes that do not have any non-variable-length arguments.

Limitations: this doesn't respect the type annotation of `*args`. Not saying we couldn't do it in the future, but I tried for a bit and it was making the code all unmaintainable/spaghetti.

Addresses #412. @mezuzza can you test this PR out? Thanks!