### PR TITLE
bugfix: Iterate over all members of enum (including aliases)

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -314,8 +314,8 @@ def _convert(
 
         if converter is None:
             element_transformed = name_transform(token.value)
-            for member in type_:
-                if name_transform(member.name) == element_transformed:
+            for name, member in type_.__members__.items():
+                if name_transform(name) == element_transformed:
                     out = member
                     break
             else:

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -396,7 +396,7 @@ def _get_choices(type_: type, name_transform: Callable[[str], str]) -> list[str]
     choices = []
     _origin = get_origin(type_)
     if isclass(type_) and issubclass(type_, Enum):
-        choices.extend(name_transform(x.name) for x in type_)
+        choices.extend(name_transform(x) for x in type_.__members__)
     elif is_union(_origin):
         inner_choices = [get_choices(inner) for inner in get_args(type_)]
         for x in inner_choices:

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -145,7 +145,11 @@ def test_coerce_enum():
         DEV = auto()
         STAGING = auto()
         PROD = auto()
-        _PROD_OLD = auto()
+        _PROD_OLD = (
+            auto()
+        )  # test that leading underscores are stripped and then hyphens can be used instead of underscores.
+
+        DEVELOPMENT = DEV  # Tests that aliases resolve
 
     # tests case-insensitivity
     assert SoftwareEnvironment.STAGING == convert(SoftwareEnvironment, ["staging"])
@@ -153,6 +157,9 @@ def test_coerce_enum():
     # tests underscore/hyphen support
     assert SoftwareEnvironment._PROD_OLD == convert(SoftwareEnvironment, ["prod_old"])
     assert SoftwareEnvironment._PROD_OLD == convert(SoftwareEnvironment, ["prod-old"])
+
+    # Test aliases
+    assert SoftwareEnvironment.DEV == convert(SoftwareEnvironment, ["development"])
 
     with pytest.raises(CoercionError):
         convert(SoftwareEnvironment, ["invalid-choice"])

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -680,6 +680,8 @@ def test_help_format_group_parameters_choices_enum_list(capture_format_group_par
         fizz = "bleep bloop blop"
         buzz = "blop bleep bloop"
 
+        fizz_alias = fizz
+
     def cmd(
         foo: Annotated[
             Optional[list[CompSciProblem]],  # pyright: ignore
@@ -692,7 +694,7 @@ def test_help_format_group_parameters_choices_enum_list(capture_format_group_par
     expected = dedent(
         """\
         ╭─ Parameters ───────────────────────────────────────────────────────╮
-        │ FOO --foo  Docstring for foo. [choices: fizz, buzz]                │
+        │ FOO --foo  Docstring for foo. [choices: fizz, buzz, fizz-alias]    │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )


### PR DESCRIPTION
Previously, this code was only iterating over members excluding aliases. Now it includes aliases. This seems fine to directly access from the [official python documentation](https://docs.python.org/3/library/enum.html#enum.EnumType.__members__).

Addresses #423 via the patch @beskep recommended. Thanks!