### PR TITLE
Bugfix/dataclass `Parameter.negative` inheritance

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -54,7 +54,6 @@ _PARAMETER_SUBKEY_BLOCKER = Parameter(
     name=None,
     converter=None,  # pyright: ignore
     validator=None,
-    negative=None,
     accepts_keys=None,
     consume_multiple=None,
     env_var=None,

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 from enum import Enum
 from functools import partial
 from textwrap import dedent
@@ -567,6 +568,72 @@ def test_help_format_group_parameters_defaults_no_show(capture_format_group_para
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ FOO --foo  Docstring for foo.                                      │
         │ BAR --bar  Docstring for bar. [default: buzz]                      │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
+def test_help_format_dataclass_default_parameter_negative_propagation(app, console):
+    app.default_parameter = Parameter(negative=())
+
+    @Parameter(name="*")
+    @dataclass
+    class Common:
+        force: bool
+
+    @app.default
+    def default(common: Common):
+        pass
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        Usage: app COMMAND [ARGS] [OPTIONS]
+
+        App Help String Line 1.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ --help -h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ *  FORCE --force  [required]                                       │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
+def test_help_format_dataclass_decorated_parameter_negative_propagation(app, console):
+    @Parameter(name="*", negative=())
+    @dataclass
+    class Common:
+        force: bool
+
+    @app.default
+    def default(common: Common):
+        pass
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        Usage: app COMMAND [ARGS] [OPTIONS]
+
+        App Help String Line 1.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ --help -h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ *  FORCE --force  [required]                                       │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )


### PR DESCRIPTION
Should fix #425, @wohali can you give this a try? The fix was super simple, I'm not sure what my original intent of blocking specifically `Parameter.negative` from the parameter-resolution-hierarchy. Thanks!