### PR TITLE
Rename `format_cyclopts_error` -> `CycloptsPanel` and make it public.

### DIFF
--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "CoercionError",
     "CommandCollisionError",
     "CycloptsError",
+    "CycloptsPanel",
     "Dispatcher",
     "DocstringError",
     "EditorError",
@@ -56,6 +57,7 @@ from cyclopts.exceptions import (
     ValidationError,
 )
 from cyclopts.group import Group
+from cyclopts.help import CycloptsPanel
 from cyclopts.parameter import Parameter
 from cyclopts.protocols import Dispatcher
 from cyclopts.token import Token

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -35,11 +35,11 @@ from cyclopts.exceptions import (
     UnknownOptionError,
     UnusedCliTokensError,
     ValidationError,
-    format_cyclopts_error,
 )
 from cyclopts.group import Group, sort_groups
 from cyclopts.group_extractors import groups_from_app, inverse_groups_from_app
 from cyclopts.help import (
+    CycloptsPanel,
     HelpPanel,
     InlineText,
     create_parameter_help_panel,
@@ -1150,7 +1150,7 @@ class App:
                 self.help_print(tokens, console=e.console)
             if print_error:
                 assert e.console
-                e.console.print(format_cyclopts_error(e))
+                e.console.print(CycloptsPanel(e))
             if exit_on_error:
                 sys.exit(1)
             raise

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -29,7 +29,6 @@ __all__ = [
     "UnknownOptionError",
     "UnusedCliTokensError",
     "ValidationError",
-    "format_cyclopts_error",
 ]
 
 
@@ -53,7 +52,6 @@ class CycloptsError(Exception):
     """Root exception for runtime errors.
 
     As CycloptsErrors bubble up the Cyclopts call-stack, more information is added to it.
-    Finally, :meth:`format_cyclopts_error` formats the message nicely for the user.
     """
 
     msg: Optional[str] = None
@@ -385,19 +383,3 @@ class MixedArgumentError(CycloptsError):
         assert self.argument is not None
         display_name = next((x.keyword for x in self.argument.tokens if x.keyword), self.argument.name)
         return super().__str__() + f'Cannot supply keyword & non-keyword arguments to "{display_name}".'
-
-
-def format_cyclopts_error(e: Any):
-    from rich import box
-    from rich.panel import Panel
-    from rich.text import Text
-
-    panel = Panel(
-        Text(str(e), "default"),
-        title="Error",
-        box=box.ROUNDED,
-        expand=True,
-        title_align="left",
-        style="red",
-    )
-    return panel

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -26,6 +26,7 @@ from cyclopts.utils import SortHelper, frozen, resolve_callables
 
 if TYPE_CHECKING:
     from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+    from rich.panel import Panel
     from rich.text import Text
 
     from cyclopts.argument import ArgumentCollection
@@ -532,3 +533,44 @@ def resolve_version_format(app_chain: Iterable["App"]) -> str:
         if app.version_format is not None:
             format_ = app.version_format
     return format_
+
+
+# named like a class because it's just a very thin wrapper around a class.
+def CycloptsPanel(message: Any, title: str = "Error", style: str = "red") -> "Panel":  # noqa: N802
+    """Create a :class:`~rich.panel.Panel` with a consistent style.
+
+    The resulting panel can be displayed using a :class:`~rich.console.Console`.
+
+    .. code-block:: text
+
+        ╭─ Title ──────────────────────────────────╮
+        │ Message content here.                    │
+        ╰──────────────────────────────────────────╯
+
+    Parameters
+    ----------
+    message: Any
+        The body of the panel will be filled with the stringified version of the message.
+    title: str
+        Title of the panel that appears in the top-left corner.
+    style: str
+        Rich `style <https://rich.readthedocs.io/en/stable/style.html>`_ for the panel border.
+
+    Returns
+    -------
+    rich.panel.Panel
+        Formatted panel object.
+    """
+    from rich import box
+    from rich.panel import Panel
+    from rich.text import Text
+
+    panel = Panel(
+        Text(str(message), "default"),
+        title=title,
+        style=style,
+        box=box.ROUNDED,
+        expand=True,
+        title_align="left",
+    )
+    return panel

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -967,6 +967,8 @@ API
 
 .. autofunction:: cyclopts.run
 
+.. autoclass:: cyclopts.CycloptsPanel
+
 .. _API Validators:
 
 ----------


### PR DESCRIPTION
The user may want to format a panel in the same style as Cyclopts; this makes it a little easier.

Helps out with #435 .