### PR TITLE
Only display COMMANDS in the help-page if there are registered commands

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -495,6 +495,16 @@ class App:
     def sort_key(self, value):
         self._sort_key = value
 
+    @property
+    def _registered_commands(self) -> dict[str, "App"]:
+        """Commands that are not help or version commands."""
+        out = {}
+        for x in self:
+            if x in self.help_flags or x in self.version_flags:
+                continue
+            out[x] = self[x]
+        return out
+
     def version_print(
         self,
         console: Optional["Console"] = None,

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -339,7 +339,7 @@ def format_usage(
     for command in command_chain:
         app = app[command]
 
-    if any(x.show for x in app.subapps):
+    if any(app[x].show for x in app._registered_commands):
         usage.append("COMMAND")
 
     if app.default_command:

--- a/tests/config/test_end2end.py
+++ b/tests/config/test_end2end.py
@@ -62,7 +62,7 @@ def test_config_env_help(app, assert_parse_args, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: default COMMAND [ARGS] [OPTIONS]
+        Usage: default [ARGS] [OPTIONS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/test_bind_dataclasses.py
+++ b/tests/test_bind_dataclasses.py
@@ -265,7 +265,7 @@ def test_bind_dataclass_positionally(app, assert_parse_args, cmd_str, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: my-default-command COMMAND [ARGS] [OPTIONS]
+        Usage: my-default-command [ARGS] [OPTIONS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -297,7 +297,7 @@ def test_bind_dataclass_default_factory_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: my-default-command COMMAND [ARGS] [OPTIONS]
+        Usage: my-default-command [ARGS] [OPTIONS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -54,7 +54,7 @@ def test_help_default_action(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND
+        Usage: app
 
         App Help String Line 1.
 
@@ -114,7 +114,7 @@ def test_help_default_help_flags(console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND
+        Usage: app
 
         App Help String Line 1.
 
@@ -377,7 +377,7 @@ def test_format_choices_rich_format(app, console, assert_parse_args):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app [ARGS] [OPTIONS]
 
         App Help String Line 1.
 
@@ -592,7 +592,7 @@ def test_help_format_dataclass_default_parameter_negative_propagation(app, conso
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app [ARGS] [OPTIONS]
 
         App Help String Line 1.
 
@@ -624,7 +624,7 @@ def test_help_format_dataclass_decorated_parameter_negative_propagation(app, con
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app [ARGS] [OPTIONS]
 
         App Help String Line 1.
 
@@ -1265,7 +1265,7 @@ def test_help_print_combined_parameter_command_group(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app [ARGS] [OPTIONS]
 
         App Help String Line 1.
 
@@ -1410,7 +1410,7 @@ def test_help_print_commands_special_flag_reassign(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND
+        Usage: app
 
         App Help String Line 1.
 
@@ -1970,7 +1970,7 @@ def test_issue_373_help_space_with_meta_app(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app [ARGS] [OPTIONS]
 
         App Help String Line 1.
 

--- a/tests/test_name_transform.py
+++ b/tests/test_name_transform.py
@@ -149,7 +149,7 @@ def test_parameter_name_transform_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: foo COMMAND [OPTIONS]
+        Usage: foo [OPTIONS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -135,7 +135,7 @@ def test_bind_pydantic_basemodel_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: foo COMMAND [ARGS] [OPTIONS]
+        Usage: foo [ARGS] [OPTIONS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -398,7 +398,7 @@ def test_pydantic_annotated_field_discriminator(app, assert_parse_args, console)
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: main COMMAND [ARGS] [OPTIONS]
+        Usage: main [ARGS] [OPTIONS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │


### PR DESCRIPTION
[The code always intended to do this](https://github.com/BrianPugh/cyclopts/blob/accbea6bf41371bd716a169924cd27ed8d3cabd1/cyclopts/help.py#L342), but broke with the transition to v3 where help/version flags got reclassified as commands.

Addresses bug mentioned [here](https://github.com/BrianPugh/cyclopts/issues/308#issuecomment-2891960743). @taranlu-houzz what do you think of this solution?

## TODO

- [x] fix unit tests.
- [x] Add an explicit unit test for this.