### PR TITLE
Allow digit flags.

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -85,7 +85,7 @@ def _parse_kw_and_flags(
             skip_next_iterations -= 1
             continue
 
-        if not is_option_like(token):
+        if not is_option_like(token, allow_numbers=True):
             unused_tokens.append(token)
             continue
 
@@ -109,7 +109,8 @@ def _parse_kw_and_flags(
         try:
             matches.append(argument_collection.match(cli_option))
         except ValueError:
-            if allow_combined_flags:
+            # Length has to be greater than 2 (hyphen + character) to be exploded.
+            if allow_combined_flags and len(token) > 2:
                 # since no direct match was found, try to see if this was a combination of short flags.
                 flags = [f"-{x}" for x in cli_option.lstrip("-")]
                 for flag in flags:

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -367,19 +367,34 @@ def grouper(iterable: Sequence[Any], n: int) -> Iterator[Tuple[Any, ...]]:
     return zip(*iterators)
 
 
-def is_option_like(token: str) -> bool:
+def is_option_like(token: str, *, allow_numbers=False) -> bool:
     """Checks if a token looks like an option.
 
     Namely, negative numbers are not options, but a token like ``--foo`` is.
+
+    Parameters
+    ----------
+    token: str
+        String to interpret.
+    allow_numbers: bool
+        If :obj:`True`, then negative numbers (e.g. ``"-2"``) will return :obj:`True`.
+        Otherwise, numbers will be interpreted as non-option-like (:obj:`False`).
+        Note: ``-j`` **is option-like**, even though it can represent an imaginary number.
+
+    Returns
+    -------
+    bool
+        Whether or not the ``token`` is option-like.
     """
-    with suppress(ValueError):
-        complex(token)
-        if token.lower() == "-j":
-            # ``complex("-j")`` is a valid imaginary number, but more than likely
-            # the caller meant it as a short flag.
-            # https://github.com/BrianPugh/cyclopts/issues/328
-            return True
-        return False
+    if not allow_numbers:
+        with suppress(ValueError):
+            complex(token)
+            if token.lower() == "-j":
+                # ``complex("-j")`` is a valid imaginary number, but more than likely
+                # the caller meant it as a short flag.
+                # https://github.com/BrianPugh/cyclopts/issues/328
+                return True
+            return False
     return token.startswith("-")
 
 

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -208,6 +208,18 @@ def test_short_flag_combining_with_short_option(app, assert_parse_args):
         app("-fb", exit_on_error=False)
 
 
+def test_short_integer_flag(app, assert_parse_args):
+    @app.default
+    def main(
+        foo: Annotated[int, Parameter(name=("--foo", "-f"))],
+        *,
+        bar: Annotated[bool, Parameter(name=("--bar", "-1"))],
+    ):
+        pass
+
+    assert_parse_args(main, "-1 -2", -2, bar=True)
+
+
 @pytest.mark.parametrize(
     "cmd_str",
     [


### PR DESCRIPTION
Addresses #454 .

@seowalex I didn't add any options to enable/disable this, because it only applies if someone explicitly gives a single-digit-name to a flag. And at that point, then the developer should inherently understand the consequences if they were also trying to parse a negative integer from the CLI. Could you give this a try? Thanks!