### PR TITLE
Mutually exclusive object for convenience

### DIFF
--- a/cyclopts/validators/__init__.py
+++ b/cyclopts/validators/__init__.py
@@ -1,10 +1,11 @@
 __all__ = [
     "LimitedChoice",
     "MutuallyExclusive",
+    "mutually_exclusive",
     "Number",
     "Path",
 ]
 
-from cyclopts.validators._group import LimitedChoice, MutuallyExclusive
+from cyclopts.validators._group import LimitedChoice, MutuallyExclusive, mutually_exclusive
 from cyclopts.validators._number import Number
 from cyclopts.validators._path import Path

--- a/cyclopts/validators/_group.py
+++ b/cyclopts/validators/_group.py
@@ -46,3 +46,6 @@ class MutuallyExclusive(LimitedChoice):
         Only 1 argument in the group can be supplied a value.
         """
         super().__init__()
+
+
+mutually_exclusive = MutuallyExclusive()

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1087,6 +1087,18 @@ Cyclopts has several builtin validators for common CLI inputs.
 .. autoclass:: cyclopts.validators.MutuallyExclusive
    :members:
 
+.. autodata:: cyclopts.validators.mutually_exclusive
+
+   Instantiated version of :class:`~.validators.MutuallyExclusive`.
+   Can be used directly in group validators:
+
+   .. code-block:: python
+
+       import cyclopts
+       from cyclopts import Group
+
+       mutually_exclusive_group = Group(validator=cyclopts.validators.mutually_exclusive)
+
 .. autoclass:: cyclopts.validators.Number
    :members:
 

--- a/docs/source/group_validators.rst
+++ b/docs/source/group_validators.rst
@@ -79,3 +79,4 @@ MutuallyExclusive
 -----------------
 Alias for :class:`.LimitedChoice` with default arguments.
 Exists primarily because the usage/implication will be more directly obvious and searchable to developers than :class:`.LimitedChoice`.
+Since this class takes no arguments, an already instantiated version :obj:`.mutually_exclusive` is also provided for convenience.


### PR DESCRIPTION
Introduces `cyclopts.validators.mutually_exclusive`