### PR TITLE
`all_or_none` group validator

### DIFF
--- a/cyclopts/validators/__init__.py
+++ b/cyclopts/validators/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "all_or_none",
     "LimitedChoice",
     "MutuallyExclusive",
     "mutually_exclusive",
@@ -6,6 +7,6 @@ __all__ = [
     "Path",
 ]
 
-from cyclopts.validators._group import LimitedChoice, MutuallyExclusive, mutually_exclusive
+from cyclopts.validators._group import LimitedChoice, MutuallyExclusive, all_or_none, mutually_exclusive
 from cyclopts.validators._number import Number
 from cyclopts.validators._path import Path

--- a/cyclopts/validators/_group.py
+++ b/cyclopts/validators/_group.py
@@ -5,7 +5,12 @@ if TYPE_CHECKING:
 
 
 class LimitedChoice:
-    def __init__(self, min: int = 0, max: Optional[int] = None):
+    def __init__(
+        self,
+        min: int = 0,
+        max: Optional[int] = None,
+        allow_none: bool = False,
+    ):
         """Group validator that limits the number of selections per group.
 
         Commonly used for enforcing mutually-exclusive parameters (default behavior).
@@ -14,29 +19,48 @@ class LimitedChoice:
         ----------
         min: int
             The minimum (inclusive) number of CLI parameters allowed.
+            If negative, then **all** parameters in the group must have CLI values provided.
         max: Optional[int]
             The maximum (inclusive) number of CLI parameters allowed.
             Defaults to ``1`` if ``min==0``, ``min`` otherwise.
+        allow_none: bool
+            If :obj:`True`, also allow 0 CLI parameters (even if ``min`` is greater than 0).
+            Defaults to :obj:`False`.
         """
         self.min = min
         self.max = (self.min or 1) if max is None else max
         if self.max < self.min:
             raise ValueError("max must be >=min.")
+        self.allow_none = allow_none
 
     def __call__(self, argument_collection: "ArgumentCollection"):
-        argument_collection = argument_collection.filter_by(value_set=True)
-        n_arguments = len(argument_collection)
+        group_size = len(argument_collection)
+        populated_argument_collection = argument_collection.filter_by(value_set=True)
+        n_arguments = len(populated_argument_collection)
 
-        if self.min <= n_arguments <= self.max:
-            return  # Happy path
-
-        offenders = "{" + ", ".join(a.name for a in argument_collection) + "}"
-        if self.min == 0 and self.max == 1:
-            raise ValueError(f"Mutually exclusive arguments: {offenders}")
+        if self.allow_none and n_arguments == 0:
+            return
+        elif self.min < 0:
+            # Require all arguments in the group to be supplied.
+            if group_size == n_arguments:
+                return
+            all_names = {a.name for a in argument_collection}
+            supplied_names = {a.name for a in populated_argument_collection}
+            missing_names = sorted(all_names - supplied_names)
+            if len(missing_names) == 1:
+                raise ValueError(f"Missing argument: {missing_names[0]}")
+            else:
+                raise ValueError(f"Missing arguments: {missing_names}")
+        elif self.min <= n_arguments <= self.max:
+            return
         else:
-            raise ValueError(
-                f"Received {n_arguments} arguments: {offenders}. Only [{self.min}, {self.max}] choices may be specified."
-            )
+            offenders = "{" + ", ".join(a.name for a in populated_argument_collection) + "}"
+            if self.min == 0 and self.max == 1:
+                raise ValueError(f"Mutually exclusive arguments: {offenders}")
+            else:
+                raise ValueError(
+                    f"Received {n_arguments} arguments: {offenders}. Only [{self.min}, {self.max}] choices may be specified."
+                )
 
 
 class MutuallyExclusive(LimitedChoice):
@@ -49,3 +73,4 @@ class MutuallyExclusive(LimitedChoice):
 
 
 mutually_exclusive = MutuallyExclusive()
+all_or_none = LimitedChoice(-1, allow_none=True)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1099,6 +1099,10 @@ Cyclopts has several builtin validators for common CLI inputs.
 
        mutually_exclusive_group = Group(validator=cyclopts.validators.mutually_exclusive)
 
+.. autodata:: cyclopts.validators.all_or_none
+
+   Group validator that enforces that either all parameters in the group must be supplied an argument, or none of them.
+
 .. autoclass:: cyclopts.validators.Number
    :members:
 

--- a/docs/source/group_validators.rst
+++ b/docs/source/group_validators.rst
@@ -80,3 +80,62 @@ MutuallyExclusive
 Alias for :class:`.LimitedChoice` with default arguments.
 Exists primarily because the usage/implication will be more directly obvious and searchable to developers than :class:`.LimitedChoice`.
 Since this class takes no arguments, an already instantiated version :obj:`.mutually_exclusive` is also provided for convenience.
+
+-----------
+all_or_none
+-----------
+Group validator that enforces that either **all** parameters in the group must be supplied an argument, or **none** of them.
+
+.. code-block:: python
+
+   from typing import Annotated
+
+   from cyclopts import App, Group, Parameter
+   from cyclopts.validators import all_or_none
+
+   app = App()
+
+   group_1 = Group(validator=all_or_none)
+   group_2 = Group(validator=all_or_none)
+
+
+   @app.default
+   def default(
+       foo: Annotated[bool, Parameter(group=group_1)] = False,
+       bar: Annotated[bool, Parameter(group=group_1)] = False,
+       fizz: Annotated[bool, Parameter(group=group_2)] = False,
+       buzz: Annotated[bool, Parameter(group=group_2)] = False,
+   ):
+       print(f"{foo=} {bar=}")
+       print(f"{fizz=} {buzz=}")
+
+
+   if __name__ == "__main__":
+       app()
+
+.. code-block:: console
+
+   $ python all_or_none.py
+   foo=False bar=False
+   fizz=False buzz=False
+
+   $ python all_or_none.py --foo
+   ╭─ Error ──────────────────────────────────────────────────────────╮
+   │ Missing argument: --bar                                          │
+   ╰──────────────────────────────────────────────────────────────────╯
+
+   $ python all_or_none.py --foo --bar
+   foo=True bar=True
+   fizz=False buzz=False
+
+   $ python all_or_none.py --foo --bar --fizz
+   ╭─ Error ────────────────────────────────────────────────────────────╮
+   │ Missing argument: --buzz                                           │
+   ╰────────────────────────────────────────────────────────────────────╯
+
+   $ python all_or_none.py --foo --bar --fizz --buzz
+   foo=True bar=True
+   fizz=True buzz=True
+
+
+See the :obj:`.all_or_none` docs for more info.


### PR DESCRIPTION
* If `LimitedChoice` `min` value is negative, then all parameters in the group must be specified.
* New `LimitedChoice` argument `allow_none=False`. If `True`, then also allow 0 CLI parameters (even if `min` is greater than 0).
* New validator `all_or_none`, which is just the instantiated object `LimitedChoice(-1, allow_none=True)`.


Implements the validator described in #479.