### PR TITLE
Add check for `Annotated` to `_get_choices` in help generation

### DIFF
--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -20,7 +20,7 @@ from typing import (
 from attrs import define, field
 
 from cyclopts._convert import ITERABLE_TYPES
-from cyclopts.annotations import is_union
+from cyclopts.annotations import is_union, resolve_annotated
 from cyclopts.field_info import signature_parameters
 from cyclopts.group import Group
 from cyclopts.utils import SortHelper, frozen, resolve_callables
@@ -408,7 +408,7 @@ def _get_choices(type_: type, name_transform: Callable[[str], str]) -> list[str]
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):
             choices.extend(get_choices(args[0]))
     elif _origin is Annotated:
-        choices.extend(get_choices(get_args(type_)[0]))
+        choices.extend(get_choices(resolve_annotated(type_)))
     elif TypeAliasType is not None and isinstance(type_, TypeAliasType):
         choices.extend(get_choices(type_.__value__))
     return choices

--- a/cyclopts/help.py
+++ b/cyclopts/help.py
@@ -7,6 +7,7 @@ from inspect import isclass
 from math import ceil
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Callable,
     Literal,
@@ -406,6 +407,8 @@ def _get_choices(type_: type, name_transform: Callable[[str], str]) -> list[str]
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):
             choices.extend(get_choices(args[0]))
+    elif _origin is Annotated:
+        choices.extend(get_choices(get_args(type_)[0]))
     elif TypeAliasType is not None and isinstance(type_, TypeAliasType):
         choices.extend(get_choices(type_.__value__))
     return choices

--- a/tests/test_py312_type_alias_type.py
+++ b/tests/test_py312_type_alias_type.py
@@ -1,7 +1,9 @@
-from typing import Annotated, Literal, TypeAlias
+from enum import Enum
+from typing import Annotated, Literal, Optional, TypeAlias
 
 import pytest
 
+from cyclopts import Parameter
 from cyclopts.help import _get_choices
 
 FontSize: TypeAlias = Literal[10, 12, 16]
@@ -25,6 +27,14 @@ def test_py312_type_alias_type(app, assert_parse_args):
     assert_parse_args(main, "10 12 16", 10, 12, 16)
 
 
+class CompSciProblem(Enum):
+    fizz = "bleep bloop blop"
+    buzz = "blop bleep bloop"
+
+
+type AnnotatedEnum = Annotated[CompSciProblem, Parameter(name="foo")]
+type AnnotatedOptionalEnum = Annotated[Optional[CompSciProblem], Parameter(name="foo")]
+
 type FontSingleFormat = Literal["otf", "woff2", "ttf", "bdf", "pcf"]
 type FontCollectionFormat = Literal["otc", "ttc"]
 FontPixelFormat: TypeAlias = Literal["bmp"]
@@ -33,6 +43,8 @@ FontPixelFormat: TypeAlias = Literal["bmp"]
 @pytest.mark.parametrize(
     "type_, expected",
     [
+        (AnnotatedEnum, ["fizz", "buzz"]),
+        (AnnotatedOptionalEnum, ["fizz", "buzz"]),
         (FontPixelFormat, ["bmp"]),
         (FontSingleFormat, ["otf", "woff2", "ttf", "bdf", "pcf"]),
         (FontSingleFormat | FontPixelFormat, ["otf", "woff2", "ttf", "bdf", "pcf", "bmp"]),


### PR DESCRIPTION
Initial problem was generating help for annotated enums with typealias. 

Maybe better to fix this problem in function, that unwraps `Annotated` when it passed directly to function params, without typealias?