### PR TITLE
Include root import module in automatic version detection

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1,3 +1,4 @@
+import importlib
 import inspect
 import os
 import sys
@@ -9,6 +10,7 @@ from enum import Enum
 from functools import lru_cache, partial
 from itertools import chain
 from pathlib import Path
+from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -65,6 +67,13 @@ if sys.version_info < (3, 11):  # pragma: no cover
 else:  # pragma: no cover
     from typing import assert_never
 
+if sys.version_info < (3, 10):  # pragma: no cover
+    from importlib_metadata import PackageNotFoundError  # pyright: ignore[reportMissingImports]
+    from importlib_metadata import version as importlib_metadata_version  # pyright: ignore[reportMissingImports]
+else:  # pragma: no cover
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as importlib_metadata_version
+
 T = TypeVar("T", bound=Callable[..., Any])
 V = TypeVar("V")
 
@@ -104,15 +113,6 @@ def _default_version(default="0.0.0") -> str:
     version: str
         ``default`` if it cannot determine version.
     """
-    import importlib
-
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from importlib_metadata import PackageNotFoundError  # pyright: ignore[reportMissingImports]
-        from importlib_metadata import version as importlib_metadata_version  # pyright: ignore[reportMissingImports]
-    else:  # pragma: no cover
-        from importlib.metadata import PackageNotFoundError
-        from importlib.metadata import version as importlib_metadata_version
-
     try:
         root_module_name = _get_root_module_name()
     except _CannotDeriveCallingModuleNameError:  # pragma: no cover
@@ -339,10 +339,26 @@ class App:
     _meta: Optional["App"] = field(init=False, default=None)
     _meta_parent: Optional["App"] = field(init=False, default=None)
 
+
+    # We will populate this attribute ourselves after initialization
+    # `init=False` tells attrs not to include it in the generated __init__
+    _instantiating_module: ModuleType | None = field(init=False, default=None)
+
     def __attrs_post_init__(self):
         # Trigger the setters
         self.help_flags = self._help_flags
         self.version_flags = self._version_flags
+
+        # inspect.stack()[2] is needed now because the call stack is deeper:
+        # [0]: __attrs_post_init__
+        # [1]: the attrs-generated __init__
+        # [2]: the caller who created the instance
+        try:
+            caller_frame = inspect.stack()[2]
+            self._instantiating_module = inspect.getmodule(caller_frame.frame)
+        except IndexError:
+            # Fallback in case the stack is not as deep as expected
+            self._instantiating_module = None
 
     ###########
     # Methods #
@@ -531,8 +547,15 @@ class App:
 
         version_raw = self.version() if callable(self.version) else self.version
 
-        if version_raw is None:
+        if version_raw is None or version_raw == "0.0.0":
             version_raw = "0.0.0"
+            if self._instantiating_module is not None:
+                full_module_name = self._instantiating_module.__name__
+                root_module_name = full_module_name.split('.')[0]
+                try:
+                    version_raw = importlib_metadata_version(root_module_name)
+                except PackageNotFoundError:
+                    pass
 
         version_formatted = InlineText.from_format(version_raw, format=version_format)
         console.print(version_formatted)


### PR DESCRIPTION
--version now automatically check the version of root import module (e.g. `my_package` of from `my_package.cli import main`) before returning default value

The logic of importing from importlib is now in a global manner instead of inside the function _default_version. In App.version_print, when version is None or 0.0.0, we now tries to check the version of the root module that instantiated the App object. That is, if app is instantiated in the module my_package.cli, App.version_print will try to get the __version__ the package my_package.

This change is mainly to enable automatic version detection in entry points. tests are performed with pytest. resulting in 19 failed, 837 passed, 4 skipped both before and after this commit.