### PR TITLE
Fix `DivideByZero` error when counting `tuple[bool, ...]`

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -177,6 +177,8 @@ def _convert_tuple(
     convert = partial(_convert, converter=converter, name_transform=name_transform)
     inner_types = tuple(x for x in get_args(type_) if x is not ...)
     inner_token_count, consume_all = token_count(type_)
+    # Elements like boolean-flags will have an inner_token_count of 0.
+    inner_token_count = max(inner_token_count, 1)
     if consume_all:
         # variable-length tuple (list-like)
         remainder = len(tokens) % inner_token_count

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -360,6 +360,13 @@ def grouper(iterable: Sequence[Any], n: int) -> Iterator[Tuple[Any, ...]]:
     """Collect data into non-overlapping fixed-length chunks or blocks.
 
     https://docs.python.org/3/library/itertools.html#itertools-recipes
+
+    Parameters
+    ----------
+    iterable: Sequence[Any]
+        Some iterable sequence to group.
+    n: int
+        Number of elements to put in each group.
     """
     if len(iterable) % n:
         raise ValueError(f"{iterable!r} is not divisible by {n}.")

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -73,6 +73,31 @@ def test_keyword_list_of_bool(app, assert_parse_args, cmd_expected):
 
 
 @pytest.mark.parametrize(
+    "cmd_expected",
+    [
+        ("", None),
+        ("--verbose", (True,)),
+        ("--verbose --verbose", (True, True)),
+        ("--verbose --verbose --no-verbose", (True, True, False)),
+        ("--verbose --verbose=False", (True, False)),
+        ("--verbose --no-verbose=False", (True, True)),
+        ("--verbose --verbose=True", (True, True)),
+    ],
+)
+def test_keyword_tuple_of_bool(app, assert_parse_args, cmd_expected):
+    cmd, expected = cmd_expected
+
+    @app.default
+    def foo(*, verbose: Optional[tuple[bool, ...]] = None):
+        pass
+
+    if expected is None:
+        assert_parse_args(foo, cmd)
+    else:
+        assert_parse_args(foo, cmd, verbose=expected)
+
+
+@pytest.mark.parametrize(
     "cmd",
     [
         "foo --item",


### PR DESCRIPTION
Addresses #496 

I'll tag a release within the next few days; i want to investigate some other bugs in the meantime.