### PR TITLE
Also interpret `collections.abc.Sequence[bool]` as multiple boolean flags.

### DIFF
--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -1,3 +1,4 @@
+import collections.abc
 import inspect
 from collections.abc import Iterable
 from copy import deepcopy
@@ -37,6 +38,7 @@ ITERATIVE_BOOL_IMPLICIT_VALUE = frozenset(
     {
         Iterable[bool],
         Sequence[bool],
+        collections.abc.Sequence[bool],
         List[bool],
         list[bool],
         Tuple[bool, ...],

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -1,3 +1,4 @@
+import collections.abc
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
@@ -109,11 +110,12 @@ def test_keyword_tuple_of_bool(app, assert_parse_args, cmd_expected):
         ("--verbose --verbose=True", [True, True]),
     ],
 )
-def test_keyword_sequence_of_bool(app, assert_parse_args, cmd_expected):
+@pytest.mark.parametrize("hint", [Sequence[bool], collections.abc.Sequence[bool]])
+def test_keyword_sequence_of_bool(app, assert_parse_args, cmd_expected, hint):
     cmd, expected = cmd_expected
 
     @app.default
-    def foo(*, verbose: Optional[Sequence[bool]] = None):
+    def foo(*, verbose: Optional[hint] = None):  # pyright: ignore[reportInvalidTypeForm]
         pass
 
     if expected is None:

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -98,6 +98,31 @@ def test_keyword_tuple_of_bool(app, assert_parse_args, cmd_expected):
 
 
 @pytest.mark.parametrize(
+    "cmd_expected",
+    [
+        ("", None),
+        ("--verbose", [True]),
+        ("--verbose --verbose", [True, True]),
+        ("--verbose --verbose --no-verbose", [True, True, False]),
+        ("--verbose --verbose=False", [True, False]),
+        ("--verbose --no-verbose=False", [True, True]),
+        ("--verbose --verbose=True", [True, True]),
+    ],
+)
+def test_keyword_sequence_of_bool(app, assert_parse_args, cmd_expected):
+    cmd, expected = cmd_expected
+
+    @app.default
+    def foo(*, verbose: Optional[Sequence[bool]] = None):
+        pass
+
+    if expected is None:
+        assert_parse_args(foo, cmd)
+    else:
+        assert_parse_args(foo, cmd, verbose=expected)
+
+
+@pytest.mark.parametrize(
     "cmd",
     [
         "foo --item",


### PR DESCRIPTION
Further addresses #496 