### PR TITLE
docs: improve `consume_multiple`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -84,7 +84,7 @@ API
          app = App(help="This is my help string.")
          app()
 
-      .. code-block::
+      .. code-block:: console
 
          $ my-script --help
          Usage: scratch.py COMMAND
@@ -1151,7 +1151,7 @@ All definitions in this section are simply predefined annotations for convenienc
 
 Due to Cyclopts's advanced :class:`.Parameter` resolution engine, these annotations can themselves be annotated to further configure behavior. E.g:
 
-.. code-block::
+.. code-block:: python
 
    Annotated[PositiveInt, Parameter(...)]
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -749,7 +749,7 @@ API
       :type: Optional[bool]
       :value: None
 
-      If ``False``, treat the user-defined class annotation similar to a tuple.
+      If :obj:`False`, treat the user-defined class annotation similar to a tuple.
       Individual class sub-parameters will not be addressable by CLI keywords.
       The class will consume enough tokens to populate all required positional parameters.
 
@@ -828,9 +828,27 @@ API
       :type: Optional[bool]
       :value: None
 
-      When a parameter is **specified by keyword**, consume multiple elements worth of CLI tokens.
-      Will consume tokens until the stream is exhausted, or an and :attr:`.allow_leading_hyphen` is False
-      If ``False`` (default behavior), then only a single element worth of CLI tokens will be consumed.
+      If :obj:`True`, consume multiple elements worth of CLI tokens until the stream is exhausted (or, if :attr:`Parameter.allow_leading_hyphen` is :obj:`False`, until an option-like token is reached).
+
+      .. code-block:: python
+
+         from cyclopts import App, Parameter
+         from typing import Annotated
+
+         app = App()
+
+         @app.default
+         def print_extensions(ext: Annotated[list[str], Parameter(consume_multiple=True)] = []):
+            print(ext)
+
+         app()
+
+      .. code-block:: console
+
+         $ my-program --ext .pdf .html
+         [".pdf", ".html"]
+
+      If :obj:`False` (default behavior), then only a single element worth of CLI tokens will be consumed.
 
       .. code-block:: python
 
@@ -840,14 +858,15 @@ API
          app = App()
 
          @app.default
-         def rules(files: list[Path], ext: list[str] = []):
-            pass
+         def print_extensions(ext: list[str] = []):
+            print(ext)
 
          app()
 
       .. code-block:: console
 
-         $ cmd --ext .pdf --ext .html foo.md bar.md
+         $ my-program --ext .pdf --ext .html
+         [".pdf", ".html"]
 
    .. attribute:: json_dict
       :type: Optional[bool]

--- a/docs/source/cookbook/interactive_help.rst
+++ b/docs/source/cookbook/interactive_help.rst
@@ -1,7 +1,7 @@
 ========================
 Interactive Shell & Help
 ========================
-Cyclopts has a builtin :meth:`interactive shell-like feature<cyclopts.App.interactive_shell>`:
+Cyclopts has a `builtin interactive shell-like feature <../api.html#cyclopts.App.interactive_shell>`__:
 
 .. code-block:: python
 

--- a/docs/source/default_parameter.rst
+++ b/docs/source/default_parameter.rst
@@ -21,7 +21,7 @@ For example, to disable the :attr:`~.Parameter.negative` flag feature across you
 
 Consequently, ``--no-flag`` is no longer an allowed flag:
 
-.. code-block::
+.. code-block:: console
 
    $ my-script foo --help
    Usage: my-script foo [ARGS] [OPTIONS]

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -128,8 +128,9 @@ All of the following CLI invocations are equivalent:
    $ python main.py --name Alice --count 3   # Supplying arguments via keywords.
    $ python main.py --name=Alice --count=3   # Using = for matching keywords to values is allowed.
    $ python main.py --count 3 --name=Alice   # Keyword order does not matter.
-   $ python main.py Alice --count 3          # positional followed by keyword
+   $ python main.py Alice --count 3          # Positional followed by keyword
    $ python main.py --count 3 Alice          # Keywords can come before positional if the keyword is later in the function signature.
+   $ python main.py --count 3 -- Alice       # Using the POSIX convention to indicate the end of keywords
 
 Like calling functions in python, positional arguments cannot be specified after a **prior** argument in the function signature was specified via keyword.
 For example, you cannot supply the count value ``"3"`` positionally while the value for ``name`` is specified via keyword:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -117,7 +117,7 @@ Extending the example, lets add more arguments and type hints:
 
 
 The command line input ``"3"`` is converted to an integer because the parameter ``count`` has the type hint :obj:`int`.
-Boolean ( here, ``--formal``) parameters are interpreted as flags.
+Boolean parameters (e.g., ``--formal`` in this example) are interpreted as flags.
 Cyclopts natively handles all python builtin types (:ref:`and more! <Coercion Rules>`).
 Cyclopts adheres to Python's argument binding rules, allowing for both positional and keyword arguments.
 All of the following CLI invocations are equivalent:

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -339,7 +339,7 @@ We do this because mutable defaults is a `common unexpected source of bugs in py
 However, sometimes we actually want to specify an empty list.
 To get an empty list pass in the flag ``--empty-MY-LIST-NAME``.
 
-.. code-block::
+.. code-block:: python
 
    from cyclopts import App
 

--- a/docs/source/vs_typer/keyword_multiple_values/README.rst
+++ b/docs/source/vs_typer/keyword_multiple_values/README.rst
@@ -9,6 +9,13 @@ We want our application to look like the following:
 
    $ my-program output.bin --input input1.bin input2.bin input3.bin
 
+Interpreted as:
+
+.. code-block:: python
+
+   output=PosixPath('output.bin')
+   input=[PosixPath('input1.bin'), PosixPath('input2.bin'), PosixPath('input3.bin')]
+
 In Typer, `it is impossible to accomplish this <https://github.com/pallets/click/issues/484>`_.
 With Typer, the keyword must be specified before each value:
 
@@ -39,16 +46,11 @@ All of the following invocations are equivalent:
 
 .. code-block:: console
 
-   $ my-program out.bin input1.bin input2.bin input3.bin
-   input=[PosixPath('input1.bin'), PosixPath('input2.bin'), PosixPath('input3.bin')] output=PosixPath('out.bin')
-
-   $ my-program out.bin --input input1.bin --input input2.bin --input input3.bin
-
-   $ my-program out.bin --input input1.bin input2.bin input3.bin
-
-   $ my-program --input input1.bin input2.bin input3.bin --output out.bin
-
-   $ my-program --input input1.bin input2.bin input3.bin -- output.bin
+   $ my-program output.bin input1.bin input2.bin input3.bin                         # Supplying arguments positionally.
+   $ my-program output.bin --input input1.bin --input input2.bin --input input3.bin # Supplying input arguments via multiple keywords.
+   $ my-program output.bin --input input1.bin input2.bin input3.bin                 # Supplying input arguments via a single keyword.
+   $ my-program --input input1.bin input2.bin input3.bin --output output.bin        # Supplying all arguments via keywords.
+   $ my-program --input input1.bin input2.bin input3.bin -- output.bin              # Using the POSIX convention to indicate the end of keywords
 
 To set this configuration for your entire application, supply it to your root :attr:`.App.default_parameter`:
 


### PR DESCRIPTION
This library is such a joy to use. Thank you so much for creating it!

I was reading through the docs and found a few things that could be improved. Let me know if you'd like me to change something:

- improve `Parameter.consume_multiple` and "Keyword Multiple Values"
  - Fix paragraph (“or an and”), unify with the corresponding language in `rules.rst`, add a positive example and simplify the negative example. Add `:obj:` to `False`
  -  unify the examples in `getting_started.rst` and `vs_typer/README.rst`

- add syntax to code blocks
- Improve link in `interactive_help.rst` (it shouldn’t be monospaced)
- Simplify paragraph in `getting_started.rst`