### PR TITLE
`negative_iterable` with an empty string shouldn't appear in the help screen

### DIFF
--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -291,7 +291,8 @@ class Parameter:
             assert isinstance(negative_prefixes, tuple)
             if self.negative is None:
                 for negative_prefix in negative_prefixes:
-                    out.append(f"--{name_prefix}{negative_prefix}{name_components[-1]}")
+                    if negative_prefix:
+                        out.append(f"--{name_prefix}{negative_prefix}{name_components[-1]}")
             else:
                 for negative in user_negatives:
                     out.append(f"--{name_prefix}{negative}")

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -24,6 +24,12 @@ def test_parameter_get_negatives_iterable_custom_prefix(type_):
 
 
 @pytest.mark.parametrize("type_", [list, set, List[str], Set[str]])
+def test_parameter_get_negatives_iterable_empty_string_prefix(type_):
+    p = Parameter(negative_iterable="", name=("--foo", "--bar"))
+    assert () == p.get_negatives(type_)
+
+
+@pytest.mark.parametrize("type_", [list, set, List[str], Set[str]])
 def test_parameter_get_negatives_iterable_custom_prefix_list(type_):
     p = Parameter(negative_iterable=["vacant-", "blank-"], name=("--foo", "--bar"))
     assert {"--vacant-foo", "--vacant-bar", "--blank-foo", "--blank-bar"} == set(p.get_negatives(type_))


### PR DESCRIPTION
Fixes #529