### PR TITLE
Allow `asyncio` coroutines as callable `App` `version` arguments

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -238,7 +238,7 @@ class App:
         kw_only=True,
     )
 
-    version: Union[None, str, Callable[..., str]] = field(default=None, kw_only=True)
+    version: Union[None, str, Callable[..., str], Callable[..., Coroutine[Any, Any, str]]] = field(default=None, kw_only=True)
     # This can ONLY ever be a Tuple[str, ...]
     _version_flags: Union[str, Iterable[str]] = field(
         default=["--version"],
@@ -554,7 +554,15 @@ class App:
                 except PackageNotFoundError:
                     pass
         else:
-            version_raw = self.version() if callable(self.version) else self.version
+            if callable(self.version):
+                if inspect.iscoroutinefunction(self.version):
+                    # For async version callables, use asyncio as the default backend
+                    import asyncio
+                    version_raw = asyncio.run(self.version())
+                else:
+                    version_raw = self.version()
+            else:
+                version_raw = self.version
 
         if not version_raw:
             version_raw = _default_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -65,3 +65,16 @@ def test_version_print_help_format_override(app, console):
         app.version_print(console)
 
     assert "foo\n" == capture.get()
+
+
+def test_version_print_custom_async_callable(app, console):
+    """Test that async callables work for version."""
+    async def my_async_version():
+        return "**async-foo**"
+
+    app.version = my_async_version
+
+    with console.capture() as capture:
+        app.version_print(console)
+
+    assert "async-foo\n" == capture.get()


### PR DESCRIPTION
Adds support for passing an asyncio-based coroutine to the `version` argument of `Apps`. Also adds a test to check that this works.