### PR TITLE
introduce `App.run_async`

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -213,7 +213,7 @@ There are a few ways to add a help string to a command:
 -----
 Async
 -----
-Cyclopts also works with **async** commands:
+Cyclopts also works with **async** commands; when an async command is encountered, an event loop will be automatically created using the specified ``backend`` parameter (default :mod:`asyncio`).
 
 .. code-block:: python
 
@@ -227,6 +227,14 @@ Cyclopts also works with **async** commands:
        await asyncio.sleep(10)
 
    app()
+
+When calling from within an existing async context, :keyword:`await` the async method :meth:`~cyclopts.App.run_async`:
+
+.. code-block:: python
+
+   async def main():
+       result = await app.run_async(["foo"])
+       # Instead of: app(["foo"]) which would raise RuntimeError
 
 --------------------------
 Decorated Function Details

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,6 +1,9 @@
+import asyncio
+from typing import Annotated
+
 import sniffio
 
-from cyclopts import App
+from cyclopts import App, Parameter
 
 
 def test_async_handler():
@@ -36,3 +39,74 @@ def test_handler():
         return "Sync handler works"
 
     assert app("command") == "Sync handler works"
+
+
+def test_async_meta_with_async_command():
+    app = App()
+    results = []
+
+    @app.command
+    async def async_command(value: int):
+        await asyncio.sleep(0)  # Simulate async work
+        result = f"Async command executed with {value}"
+        results.append(result)
+        return result
+
+    @app.meta.default
+    async def launcher(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+        await asyncio.sleep(0)  # Simulate async initialization
+        results.append("Meta initialized")
+        result = await app.run_async(tokens)  # Use run_async when inside an async context
+        results.append("Meta finished")
+        return result
+
+    result = app.meta(["async-command", "42"])
+    assert result == "Async command executed with 42"
+    assert results == ["Meta initialized", "Async command executed with 42", "Meta finished"]
+
+
+def test_async_meta_with_sync_command():
+    app = App()
+    results = []
+
+    @app.command
+    def sync_command(value: int):
+        result = f"Sync command executed with {value}"
+        results.append(result)
+        return result
+
+    @app.meta.default
+    async def launcher(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+        await asyncio.sleep(0)  # Simulate async initialization
+        results.append("Meta initialized")
+        # Synchronous commands should also work from async meta
+        result = await app.run_async(tokens)  # Use run_async when inside an async context
+        results.append("Meta finished")
+        return result
+
+    result = app.meta(["sync-command", "42"])
+    assert result == "Sync command executed with 42"
+    assert results == ["Meta initialized", "Sync command executed with 42", "Meta finished"]
+
+
+def test_async_meta_with_nested_async():
+    app = App()
+    results = []
+
+    @app.default
+    async def default_handler():
+        await asyncio.sleep(0)
+        results.append("Default handler")
+        return "Default result"
+
+    @app.meta.default
+    async def meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+        await asyncio.sleep(0)
+        results.append("Meta handler")
+        result = await app.run_async(tokens)  # Use run_async when inside an async context
+        results.append("Meta complete")
+        return result
+
+    result = app.meta([])
+    assert result == "Default result"
+    assert results == ["Meta handler", "Default handler", "Meta complete"]


### PR DESCRIPTION
An alternative (and hopefully better) solution to the recently reverted #535 . Basically define a separate async `__call__` equivalent.