### PR TITLE
V4: automatically call `next` on `App.sort_key` and `Group.sort_key` if they are generators.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -334,7 +334,7 @@ class App:
     _sort_key: Any = field(
         default=None,
         alias="sort_key",
-        converter=lambda x: UNSET if x is None else x,
+        converter=lambda x: UNSET if x is None else next(x) if inspect.isgenerator(x) else x,
         kw_only=True,
     )
 
@@ -545,6 +545,8 @@ class App:
 
     @sort_key.setter
     def sort_key(self, value):
+        if inspect.isgenerator(value):
+            value = next(value)
         self._sort_key = value
 
     @property

--- a/cyclopts/group.py
+++ b/cyclopts/group.py
@@ -1,3 +1,4 @@
+import inspect
 import itertools
 from collections.abc import Iterable
 from typing import (
@@ -79,7 +80,7 @@ class Group:
     _sort_key: Any = field(
         default=None,
         alias="sort_key",
-        converter=lambda x: UNSET if x is None else x,
+        converter=lambda x: UNSET if x is None else next(x) if inspect.isgenerator(x) else x,
         kw_only=True,
     )
 
@@ -165,6 +166,8 @@ class Group:
             Custom help formatter for this group's help display.
         """
         count = next(_sort_key_counter)
+        if inspect.isgenerator(sort_key):
+            sort_key = next(sort_key)
         if sort_key is None:
             sort_key = (UNSET, count)
         elif is_iterable(sort_key):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -233,12 +233,14 @@ API
 
       Modifies command display order on the help-page.
 
-      1. If :attr:`sort_key`, or any of it's contents, are ``Callable``, then invoke it ``sort_key(app)`` and apply the returned value to (2) if :obj:`None`, (3) otherwise.
+      1. If :attr:`sort_key` is a generator, it will be consumed immediately with ``next()`` to get the actual value.
 
-      2. For all commands with ``sort_key==None`` (default value), sort them alphabetically.
-         These sorted commands will be displayed **after** ``sort_key != None`` list (see 3).
+      2. If :attr:`sort_key`, or any of it's contents, are ``Callable``, then invoke it ``sort_key(app)`` and apply the returned value to (3) if :obj:`None`, (4) otherwise.
 
-      3. For all commands with ``sort_key!=None``, sort them by ``(sort_key, app.name)``.
+      3. For all commands with ``sort_key==None`` (default value), sort them alphabetically.
+         These sorted commands will be displayed **after** ``sort_key != None`` list (see 4).
+
+      4. For all commands with ``sort_key!=None``, sort them by ``(sort_key, app.name)``.
          It is the user's responsibility that ``sort_key`` s are comparable.
 
       Example usage:
@@ -276,6 +278,26 @@ API
          │ --help -h  Display this message and exit.                   │
          │ --version  Display application version.                     │
          ╰─────────────────────────────────────────────────────────────╯
+
+      Using generators (e.g., ``itertools.count``):
+
+      .. code-block:: python
+
+         import itertools
+         from cyclopts import App
+
+         app = App()
+         counter = itertools.count()
+
+         @app.command(sort_key=counter)
+         def first():
+             pass
+
+         @app.command(sort_key=counter)
+         def second():
+             pass
+
+         # Commands will display in order: first (0), second (1)
 
    .. attribute:: version
       :type: Union[None, str, Callable]
@@ -1072,9 +1094,11 @@ API
 
       Modifies group-panel display order on the help-page.
 
-      1. If :attr:`sort_key`, or any of it's contents, are ``Callable``, then invoke it ``sort_key(group)`` and apply the rules below.
+      1. If :attr:`sort_key` is a generator, it will be consumed immediately with ``next()`` to get the actual value.
 
-      2. The :class:`App` default groups (:attr:`App.group_command`, :attr:`App.group_arguments`, :attr:`App.group_parameters`) will be displayed first.
+      2. If :attr:`sort_key`, or any of it's contents, are ``Callable``, then invoke it ``sort_key(group)`` and apply the rules below.
+
+      3. The :class:`App` default groups (:attr:`App.group_command`, :attr:`App.group_arguments`, :attr:`App.group_parameters`) will be displayed first.
          If you want to further customize the ordering of these default groups, you can define custom values and they will be treated like any other group:
 
          .. code-block:: python
@@ -1112,11 +1136,11 @@ API
             │ --version  Display application version.                               │
             ╰───────────────────────────────────────────────────────────────────────╯
 
-      2. For all groups with ``sort_key!=None``, sort them by ``(sort_key, group.name)``.
+      4. For all groups with ``sort_key!=None``, sort them by ``(sort_key, group.name)``.
          That is, sort them by their ``sort_key``, and then break ties alphabetically.
          It is the user's responsibility that ``sort_key`` are comparable.
 
-      3. For all groups with ``sort_key==None`` (default value), sort them alphabetically after (2), :attr:`App.group_commands`, :attr:`App.group_arguments`, and :attr:`.App.group_parameters`.
+      5. For all groups with ``sort_key==None`` (default value), sort them alphabetically after (4), :attr:`App.group_commands`, :attr:`App.group_arguments`, and :attr:`.App.group_parameters`.
 
       Example usage:
 
@@ -1169,6 +1193,26 @@ API
         │ --help,-h  Display this message and exit.                          │
         │ --version  Display application version.                            │
         ╰────────────────────────────────────────────────────────────────────╯
+
+      Using generators with :meth:`Group.create_ordered`:
+
+      .. code-block:: python
+
+         import itertools
+         from cyclopts import App, Group
+
+         app = App()
+         counter = itertools.count()
+
+         @app.command(group=Group.create_ordered("First Group", sort_key=counter))
+         def cmd1():
+             pass
+
+         @app.command(group=Group.create_ordered("Second Group", sort_key=counter))
+         def cmd2():
+             pass
+
+         # Groups will display in order: "First Group" (0), "Second Group" (1)
 
    .. attribute:: default_parameter
       :type: Optional[Parameter]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -131,6 +131,26 @@ def test_group_sort_key_property():
     assert g.sort_key == 1
 
 
+def test_group_sort_key_generator():
+    """Test that Group.sort_key accepts and processes generators."""
+
+    def sort_key_gen():
+        yield 5
+
+    # Test with generator function
+    g1 = Group("Test1", sort_key=sort_key_gen())
+    assert g1.sort_key == 5
+
+    # Test with generator expression
+    g2 = Group("Test2", sort_key=(x for x in [10]))
+    assert g2.sort_key == 10
+
+    # Test with create_ordered and generator
+    g3 = Group.create_ordered("Test3", sort_key=(x * 2 for x in [7]))
+    # create_ordered wraps the sort_key in a tuple with a counter
+    assert g3.sort_key[0] == 14  # pyright: ignore[reportOptionalSubscript]
+
+
 @pytest.fixture
 def mock_sort_key_counter(mocker):
     mock = mocker.patch("cyclopts.group._sort_key_counter")


### PR DESCRIPTION
Streamlines some applications (e.g. wanting declarative-ordering of commands using `itertools.count`).

Addresses #553. We could go further and add a "default sort ordering" field to `Group` that could be of type `Literal["alphabetical", "lexical"]`, but I'll try to add that in a separate PR.