### PR TITLE
V4 develop nested config

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -1699,8 +1699,15 @@ def update_argument_collection(
                         )
                     else:
                         # Convert the value back into a string, so it can be re-converted.
+                        # For dict/list values (from YAML/TOML), use json.dumps to create valid JSON strings
+                        if isinstance(v, (dict, list)):
+                            import json
+
+                            value_str = json.dumps(v)
+                        else:
+                            value_str = str(v)
                         token = Token(
-                            keyword=complete_keyword, value=str(v), source=source, index=i, keys=remaining_keys
+                            keyword=complete_keyword, value=value_str, source=source, index=i, keys=remaining_keys
                         )
                     argument.append(token)
             else:

--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -1687,7 +1687,6 @@ def update_argument_collection(
 
             if value:
                 for i, v in enumerate(value):
-                    # TODO: is this index correct? If the source value is a list, it should probably be different
                     if v is None:
                         # Pass ``None`` as an implicit_value so it certainly gets interpreted as ``None`` later.
                         token = Token(

--- a/tests/config/test_toml_dataclass_list.py
+++ b/tests/config/test_toml_dataclass_list.py
@@ -1,0 +1,269 @@
+"""Test TOML configuration with lists of dataclasses and TypedDict.
+
+This addresses GitHub issue #507 for TOML config files.
+"""
+
+from dataclasses import dataclass
+from textwrap import dedent
+from typing import Literal, TypedDict
+
+from cyclopts.config import Toml
+
+
+@dataclass
+class User:
+    name: str
+    age: int
+    region: Literal["us", "ca"] = "us"
+
+
+class Config(TypedDict):
+    name: str
+    value: int
+
+
+def test_toml_list_of_dataclasses(app, tmp_path, assert_parse_args):
+    """Test list of dataclasses from TOML config."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            [[users]]
+            name = "alice"
+            age = 22
+            region = "us"
+
+            [[users]]
+            name = "bob"
+            age = 33
+            region = "ca"
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    # Parse with empty args, config should provide the users
+    assert_parse_args(main, "", [User("alice", 22, "us"), User("bob", 33, "ca")])
+
+
+def test_toml_list_of_dataclasses_with_cli_override(app, tmp_path, assert_parse_args):
+    """Test that CLI arguments override TOML config for list of dataclasses."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            [[users]]
+            name = "alice"
+            age = 22
+            region = "us"
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    # CLI should override config
+    assert_parse_args(
+        main,
+        '--users \'{"name": "charlie", "age": 40, "region": "ca"}\'',
+        [User("charlie", 40, "ca")],
+    )
+
+
+def test_toml_empty_list_of_dataclasses(app, tmp_path, assert_parse_args):
+    """Test empty list of dataclasses from TOML."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users = []
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(users: list[User] = None):  # pyright: ignore
+        pass
+
+    assert_parse_args(main, "", [])
+
+
+def test_toml_single_dataclass_in_list(app, tmp_path, assert_parse_args):
+    """Test single dataclass item in TOML list."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            [[users]]
+            name = "alice"
+            age = 30
+            region = "us"
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    assert_parse_args(main, "", [User("alice", 30, "us")])
+
+
+def test_toml_list_of_typeddict(app, tmp_path, assert_parse_args):
+    """Test list of TypedDict from TOML config."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            [[configs]]
+            name = "config1"
+            value = 10
+
+            [[configs]]
+            name = "config2"
+            value = 20
+
+            [[configs]]
+            name = "config3"
+            value = 30
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(configs: list[Config]):
+        pass
+
+    assert_parse_args(
+        main,
+        "",
+        [
+            {"name": "config1", "value": 10},
+            {"name": "config2", "value": 20},
+            {"name": "config3", "value": 30},
+        ],
+    )
+
+
+def test_toml_nested_dataclass_structure(app, tmp_path, assert_parse_args):
+    """Test nested dataclass structure from TOML."""
+
+    @dataclass
+    class Address:
+        street: str
+        city: str
+        country: str = "US"
+
+    @dataclass
+    class Person:
+        name: str
+        age: int
+        address: Address
+
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            [[people]]
+            name = "alice"
+            age = 25
+
+            [people.address]
+            street = "123 Main St"
+            city = "New York"
+            country = "US"
+
+            [[people]]
+            name = "bob"
+            age = 30
+
+            [people.address]
+            street = "456 Oak Ave"
+            city = "Toronto"
+            country = "CA"
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(people: list[Person]):
+        pass
+
+    expected = [
+        Person("alice", 25, Address("123 Main St", "New York", "US")),
+        Person("bob", 30, Address("456 Oak Ave", "Toronto", "CA")),
+    ]
+
+    assert_parse_args(main, "", expected)
+
+
+def test_toml_mixed_config_and_cli(app, tmp_path, assert_parse_args):
+    """Test mixing TOML config with additional CLI arguments."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            [[users]]
+            name = "alice"
+            age = 22
+            region = "us"
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(users: list[User], verbose: bool = False):
+        pass
+
+    # Config provides users, CLI provides verbose flag
+    assert_parse_args(main, "--verbose", users=[User("alice", 22, "us")], verbose=True)
+
+
+def test_toml_inline_table_list(app, tmp_path, assert_parse_args):
+    """Test TOML inline table syntax for list of dataclasses."""
+    config_fn = tmp_path / "config.toml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users = [
+                { name = "alice", age = 22, region = "us" },
+                { name = "bob", age = 33, region = "ca" }
+            ]
+            """
+        )
+    )
+
+    app.config = Toml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    assert_parse_args(main, "", [User("alice", 22, "us"), User("bob", 33, "ca")])

--- a/tests/config/test_yaml_dataclass_list.py
+++ b/tests/config/test_yaml_dataclass_list.py
@@ -1,0 +1,235 @@
+"""Test YAML configuration with lists of dataclasses and TypedDict.
+
+This addresses GitHub issue #507.
+"""
+
+from dataclasses import dataclass
+from textwrap import dedent
+from typing import Literal, TypedDict
+
+from cyclopts.config import Yaml
+
+
+@dataclass
+class User:
+    name: str
+    age: int
+    region: Literal["us", "ca"] = "us"
+
+
+class Config(TypedDict):
+    name: str
+    value: int
+
+
+def test_yaml_list_of_dataclasses(app, tmp_path, assert_parse_args):
+    """Test the exact scenario from GitHub issue #507 with YAML config."""
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users:
+              - name: alice
+                age: 22
+                region: us
+              - name: bob
+                age: 33
+                region: ca
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    # Parse with empty args, config should provide the users
+    assert_parse_args(main, "", [User("alice", 22, "us"), User("bob", 33, "ca")])
+
+
+def test_yaml_list_of_dataclasses_with_cli_override(app, tmp_path, assert_parse_args):
+    """Test that CLI arguments override YAML config for list of dataclasses."""
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users:
+              - name: alice
+                age: 22
+                region: us
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    # CLI should override config
+    assert_parse_args(
+        main,
+        '--users \'{"name": "charlie", "age": 40, "region": "ca"}\'',
+        [User("charlie", 40, "ca")],
+    )
+
+
+def test_yaml_empty_list_of_dataclasses(app, tmp_path, assert_parse_args):
+    """Test empty list of dataclasses from YAML."""
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users: []
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(users: list[User] = None):  # pyright: ignore
+        pass
+
+    assert_parse_args(main, "", [])
+
+
+def test_yaml_single_dataclass_in_list(app, tmp_path, assert_parse_args):
+    """Test single dataclass item in YAML list."""
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users:
+              - name: alice
+                age: 30
+                region: us
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(users: list[User]):
+        pass
+
+    assert_parse_args(main, "", [User("alice", 30, "us")])
+
+
+def test_yaml_list_of_typeddict(app, tmp_path, assert_parse_args):
+    """Test list of TypedDict from YAML config."""
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            configs:
+              - name: config1
+                value: 10
+              - name: config2
+                value: 20
+              - name: config3
+                value: 30
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(configs: list[Config]):
+        pass
+
+    assert_parse_args(
+        main,
+        "",
+        [
+            {"name": "config1", "value": 10},
+            {"name": "config2", "value": 20},
+            {"name": "config3", "value": 30},
+        ],
+    )
+
+
+def test_yaml_nested_dataclass_structure(app, tmp_path, assert_parse_args):
+    """Test nested dataclass structure from YAML."""
+
+    @dataclass
+    class Address:
+        street: str
+        city: str
+        country: str = "US"
+
+    @dataclass
+    class Person:
+        name: str
+        age: int
+        address: Address
+
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            people:
+              - name: alice
+                age: 25
+                address:
+                  street: 123 Main St
+                  city: New York
+                  country: US
+              - name: bob
+                age: 30
+                address:
+                  street: 456 Oak Ave
+                  city: Toronto
+                  country: CA
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(people: list[Person]):
+        pass
+
+    expected = [
+        Person("alice", 25, Address("123 Main St", "New York", "US")),
+        Person("bob", 30, Address("456 Oak Ave", "Toronto", "CA")),
+    ]
+
+    assert_parse_args(main, "", expected)
+
+
+def test_yaml_mixed_config_and_cli(app, tmp_path, assert_parse_args):
+    """Test mixing YAML config with additional CLI arguments."""
+    config_fn = tmp_path / "config.yaml"
+
+    config_fn.write_text(
+        dedent(
+            """\
+            users:
+              - name: alice
+                age: 22
+                region: us
+            """
+        )
+    )
+
+    app.config = Yaml(config_fn)
+
+    @app.default
+    def main(users: list[User], verbose: bool = False):
+        pass
+
+    # Config provides users, CLI provides verbose flag
+    assert_parse_args(main, "--verbose", users=[User("alice", 22, "us")], verbose=True)


### PR DESCRIPTION
Fixes configs from not being able to parse `list[custom_class]`