### PR TITLE
V4: Still apply default group if only nameless groups are assigned.

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -265,8 +265,29 @@ class ArgumentCollection(list["Argument"]):
                     resolved_groups.append(group)
                     cyclopts_parameters.append(group.default_parameter)
                 cyclopts_parameters.append(cparam)
+
                 if resolved_groups:
-                    cyclopts_parameters.append(Parameter(group=resolved_groups))
+                    has_visible_group = any(g.show for g in resolved_groups)
+                    all_nameless = all(not g.name for g in resolved_groups)
+
+                    if has_visible_group:
+                        # At least one group is visible, use the resolved groups as-is
+                        cyclopts_parameters.append(Parameter(group=resolved_groups))
+                    elif all_nameless:
+                        # All groups are nameless; Include the default group to make
+                        # the parameter appears in the help-page
+                        default_group = (
+                            group_arguments
+                            if field_info.kind in (field_info.POSITIONAL_ONLY, field_info.VAR_POSITIONAL)
+                            else group_parameters
+                        )
+                        # Combine default group with resolved groups
+                        all_groups = (default_group,) + tuple(resolved_groups)
+                        cyclopts_parameters.append(Parameter(group=all_groups))
+                    else:
+                        # Has explicit show=False groups, don't add default group
+                        # Parameter should be hidden from help
+                        cyclopts_parameters.append(Parameter(group=resolved_groups))
         else:
             cyclopts_parameters = cyclopts_parameters_no_group
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -75,7 +75,6 @@ def _negative_converter(default: tuple[str, ...]):
     return converter
 
 
-# TODO: Breaking change; all fields after ``name`` should be ``kw_only=True``.
 @record_init("_provided_args")
 @frozen
 class Parameter:


### PR DESCRIPTION
Frequently, we may assign a nameless Group to a param to apply a validator, but we still want them to appear in the standard Argument/Parameter panel. If a user truly doesn't want the parameter to appear on the help-page, they can set show=False.