### PR TITLE
V4: Improved usage string.

### DIFF
--- a/tests/apps/test_burgery.py
+++ b/tests/apps/test_burgery.py
@@ -56,7 +56,7 @@ def test_create_burger_help(console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: burgery create burger [ARGS] [OPTIONS]
+        Usage: burgery create burger [OPTIONS] VARIETY [ARGS]
 
         Create a burger.
 

--- a/tests/config/test_end2end.py
+++ b/tests/config/test_end2end.py
@@ -65,7 +65,7 @@ def test_config_env_help(app, assert_parse_args, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_end2end [ARGS] [OPTIONS]
+        Usage: test_end2end FOO
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,19 @@ def console():
 
 
 @pytest.fixture
+def normalize_trailing_whitespace():
+    """Remove trailing whitespace from each line while preserving line breaks.
+
+    Useful for comparing console output where text wrapping may add trailing spaces.
+    """
+
+    def _normalize(text: str) -> str:
+        return "\n".join(line.rstrip() for line in text.split("\n"))
+
+    return _normalize
+
+
+@pytest.fixture
 def default_function_groups():
     return (Parameter(), Group("Arguments"), Group("Parameters"))
 

--- a/tests/test_bind_attrs.py
+++ b/tests/test_bind_attrs.py
@@ -48,7 +48,7 @@ def test_bind_attrs(app, assert_parse_args, console):
 
     expected = dedent(
         """\
-        Usage: test_bind_attrs foo [ARGS] [OPTIONS]
+        Usage: test_bind_attrs foo USER.ID [ARGS]
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.ID --user.id      [required]                               │
@@ -88,7 +88,7 @@ def test_bind_attrs_flatten(app, assert_parse_args, console):
 
     expected = dedent(
         """\
-        Usage: test_bind_attrs foo [ARGS] [OPTIONS]
+        Usage: test_bind_attrs foo ID [ARGS]
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  ID --id              [required]                                 │
@@ -124,7 +124,7 @@ def test_bind_attrs_accepts_keys_false(app, assert_parse_args, console):
 
     expected = dedent(
         """\
-        Usage: test_bind_attrs foo [ARGS] [OPTIONS]
+        Usage: test_bind_attrs foo EXAMPLE
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  EXAMPLE --example  [required]                                   │

--- a/tests/test_bind_dataclasses.py
+++ b/tests/test_bind_dataclasses.py
@@ -65,7 +65,7 @@ def test_bind_dataclass_missing_all_arguments(app, assert_parse_args, console):
     assert actual == expected
 
 
-def test_bind_dataclass_recursive(app, assert_parse_args, console):
+def test_bind_dataclass_recursive(app, assert_parse_args, console, normalize_trailing_whitespace):
     @dataclass
     class Wheel:
         diameter: int
@@ -130,7 +130,9 @@ def test_bind_dataclass_recursive(app, assert_parse_args, console):
 
     expected = dedent(
         """\
-        Usage: test_bind_dataclasses build [OPTIONS]
+        Usage: test_bind_dataclasses build --license-plate STR --car.name STR
+        --car.mileage FLOAT --car.cylinders INT --car.horsepower FLOAT
+        --car.wheel.diameter INT [OPTIONS]
 
         Build a car.
 
@@ -154,7 +156,7 @@ def test_bind_dataclass_recursive(app, assert_parse_args, console):
         """
     )
 
-    assert actual == expected
+    assert normalize_trailing_whitespace(actual) == expected
 
 
 def test_bind_dataclass_recursive_missing_arg(app, assert_parse_args, console):
@@ -263,7 +265,7 @@ def test_bind_dataclass_positionally(app, assert_parse_args, cmd_str, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_bind_dataclasses [ARGS] [OPTIONS]
+        Usage: test_bind_dataclasses A [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -295,7 +297,7 @@ def test_bind_dataclass_default_factory_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_bind_dataclasses [ARGS] [OPTIONS]
+        Usage: test_bind_dataclasses [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/test_bind_generic_class.py
+++ b/tests/test_bind_generic_class.py
@@ -77,7 +77,7 @@ def test_bind_generic_class_accepts_keys_none_1_args(app, assert_parse_args, con
 
     expected = dedent(
         """\
-        Usage: test_bind_generic_class foo [ARGS] [OPTIONS]
+        Usage: test_bind_generic_class foo USER.AGE
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.AGE --user.age  [required]                                 │
@@ -111,7 +111,7 @@ def test_bind_generic_class_accepts_keys_false_1_args(app, assert_parse_args, co
 
     expected = dedent(
         """\
-        Usage: test_bind_generic_class foo [ARGS] [OPTIONS]
+        Usage: test_bind_generic_class foo USER
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER --user  [required]                                         │
@@ -140,7 +140,9 @@ class Coordinates:
         return self.x == other.x and self.y == other.y and self.color == other.color
 
 
-def test_bind_generic_class_accepts_default_multiple_args(app, assert_parse_args, console):
+def test_bind_generic_class_accepts_default_multiple_args(
+    app, assert_parse_args, console, normalize_trailing_whitespace
+):
     @app.command
     def foo(coords: Coordinates, priority: int):
         pass
@@ -154,7 +156,8 @@ def test_bind_generic_class_accepts_default_multiple_args(app, assert_parse_args
 
     expected = dedent(
         """\
-        Usage: test_bind_generic_class foo [ARGS] [OPTIONS]
+        Usage: test_bind_generic_class foo [OPTIONS] COORDS.X COORDS.Y
+        PRIORITY
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  COORDS.X --coords.x  [required]                                 │
@@ -165,7 +168,7 @@ def test_bind_generic_class_accepts_default_multiple_args(app, assert_parse_args
         """
     )
 
-    assert actual == expected
+    assert normalize_trailing_whitespace(actual) == expected
 
 
 def test_bind_generic_class_accepts_false_multiple_args(app, assert_parse_args, console):
@@ -182,7 +185,7 @@ def test_bind_generic_class_accepts_false_multiple_args(app, assert_parse_args, 
 
     expected = dedent(
         """\
-        Usage: test_bind_generic_class foo [ARGS] [OPTIONS]
+        Usage: test_bind_generic_class foo COORDS
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  COORDS --coords  [required]                                     │
@@ -217,10 +220,9 @@ def test_bind_generic_class_keyword_with_positional_only_subkeys(app, console, a
 
     actual = capture.get()
 
-    # No arguments/parameters
     expected = dedent(
         """\
-        Usage: test_bind_generic_class foo [OPTIONS]
+        Usage: test_bind_generic_class foo --user USER
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  --user  [required]                                              │

--- a/tests/test_enum_flag.py
+++ b/tests/test_enum_flag.py
@@ -115,7 +115,7 @@ def test_flag_as_boolean_flags_star_name(app, assert_parse_args, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_enum_flag [ARGS] [OPTIONS]
+        Usage: test_enum_flag [OPTIONS]
 
         Manage file permissions.
 
@@ -198,7 +198,7 @@ def test_flag_help_shows_member_docstrings(app, console):
 
     expected = dedent(
         """\
-        Usage: test_enum_flag [ARGS] [OPTIONS]
+        Usage: test_enum_flag [OPTIONS]
 
         Manage file permissions.
 
@@ -233,7 +233,7 @@ def test_flag_help_star_name_shows_member_docstrings(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_enum_flag [ARGS] [OPTIONS]
+        Usage: test_enum_flag [OPTIONS]
 
         Manage file permissions.
 
@@ -293,7 +293,7 @@ def test_flag_in_dataclass_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_enum_flag [ARGS] [OPTIONS]
+        Usage: test_enum_flag [OPTIONS] USER.NAME
 
         Create a user with permissions.
 
@@ -330,7 +330,7 @@ def test_flag_in_dataclass_help_no_negative(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_enum_flag [ARGS] [OPTIONS]
+        Usage: test_enum_flag [OPTIONS] USER.NAME
 
         Create a user with permissions.
 
@@ -372,7 +372,7 @@ def test_flag_in_dataclass_help_no_keywords(app, assert_parse_args, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_enum_flag [ARGS] [OPTIONS]
+        Usage: test_enum_flag USER.NAME [ARGS]
 
         Create a user with permissions.
 

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -36,7 +36,7 @@ def test_generate_docs_simple_app():
         **Usage**:
 
         ```console
-        $ myapp [ARGS] [OPTIONS]
+        $ myapp NAME [ARGS]
         ```
 
         **Arguments**:
@@ -282,7 +282,7 @@ def test_generate_docs_with_required_parameters():
         **Usage**:
 
         ```console
-        $ myapp [ARGS] [OPTIONS]
+        $ myapp REQUIRED [ARGS]
         ```
 
         **Arguments**:
@@ -615,7 +615,7 @@ def test_generate_docs_with_meta_app():
         **Usage**:
 
         ```console
-        $ myapp [ARGS] [OPTIONS]
+        $ myapp INPUT-FILE
         ```
 
         **Arguments**:

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -351,7 +351,7 @@ def test_help_functools_partial_2(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app foo [ARGS] [OPTIONS]
+        Usage: app foo [OPTIONS] A
 
         Docstring for foo.
 
@@ -388,7 +388,7 @@ def test_format_choices_rich_format(app, console, assert_parse_args):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app [ARGS] [OPTIONS]
+        Usage: app REGION
 
         App Help String Line 1.
 
@@ -606,7 +606,7 @@ def test_help_format_dataclass_default_parameter_negative_propagation(app, conso
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app [ARGS] [OPTIONS]
+        Usage: app FORCE
 
         App Help String Line 1.
 
@@ -638,7 +638,7 @@ def test_help_format_dataclass_decorated_parameter_negative_propagation(app, con
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app [ARGS] [OPTIONS]
+        Usage: app FORCE
 
         App Help String Line 1.
 
@@ -1031,7 +1031,7 @@ def test_help_print_function(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app cmd [ARGS] [OPTIONS]
+        Usage: app cmd --bar STR FOO
 
         Cmd help string.
 
@@ -1065,7 +1065,7 @@ def test_help_print_parameter_required(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app cmd [ARGS] [OPTIONS]
+        Usage: app cmd --bar STR [ARGS]
 
         Cmd help string.
 
@@ -1096,7 +1096,7 @@ def test_help_print_function_defaults(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app cmd [ARGS] [OPTIONS]
+        Usage: app cmd [OPTIONS]
 
         Cmd help string.
 
@@ -1124,7 +1124,7 @@ def test_help_print_function_no_parse(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app cmd [ARGS] [OPTIONS]
+        Usage: app cmd FOO
 
         Cmd help string.
 
@@ -1151,7 +1151,7 @@ def test_help_print_parameter_group_description(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app cmd [ARGS] [OPTIONS]
+        Usage: app cmd FOO
 
         ╭─ Custom Title ─────────────────────────────────────────────────────╮
         │ Parameter description.                                             │
@@ -1180,7 +1180,7 @@ def test_help_print_parameter_group_no_show(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app cmd [ARGS] [OPTIONS]
+        Usage: app cmd FOO BAR
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  FOO --foo  Docstring for foo. [required]                        │
@@ -1272,7 +1272,7 @@ def test_help_print_combined_parameter_command_group(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app [ARGS] [OPTIONS]
+        Usage: app VALUE1
 
         App Help String Line 1.
 
@@ -1390,7 +1390,7 @@ def test_help_print_commands_and_function(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app COMMAND --bar STR FOO
 
         App Help String Line 1.
 
@@ -1445,7 +1445,7 @@ def test_help_print_parameters_no_negative_from_default_parameter(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app foo [OPTIONS]
+        Usage: app foo --flag BOOL
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  --flag  [required]                                              │
@@ -1674,7 +1674,7 @@ def test_help_print_commands_plus_meta_short(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app COMMAND [ARGS] [OPTIONS]
+        Usage: app COMMAND RDP
 
         Root Default Command Short Description.
 
@@ -1705,7 +1705,7 @@ def test_help_print_commands_plus_meta_short(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app meta-cmd [ARGS] [OPTIONS]
+        Usage: app meta-cmd A
 
         Meta cmd help string.
 
@@ -1717,7 +1717,7 @@ def test_help_print_commands_plus_meta_short(app, console):
     assert actual == expected
 
 
-def test_help_restructuredtext(app, console):
+def test_help_restructuredtext(app, console, normalize_trailing_whitespace):
     description = dedent(
         """\
         This is a long sentence that
@@ -1768,13 +1768,10 @@ def test_help_restructuredtext(app, console):
     )
 
     # Rich sticks a bunch of trailing spaces on lines.
-    expected = "\n".join(x.strip() for x in expected.split("\n"))
-    actual = "\n".join(x.strip() for x in actual.split("\n"))
-
-    assert actual == expected
+    assert normalize_trailing_whitespace(actual) == expected
 
 
-def test_help_markdown(app, console):
+def test_help_markdown(app, console, normalize_trailing_whitespace):
     description = dedent(
         """\
         This is a long sentence that
@@ -1825,13 +1822,10 @@ def test_help_markdown(app, console):
     )
 
     # Rich sticks a bunch of trailing spaces on lines.
-    expected = "\n".join(x.strip() for x in expected.split("\n"))
-    actual = "\n".join(x.strip() for x in actual.split("\n"))
-
-    assert actual == expected
+    assert normalize_trailing_whitespace(actual) == expected
 
 
-def test_help_rich(app, console):
+def test_help_rich(app, console, normalize_trailing_whitespace):
     """Newlines actually get interpreted with rich."""
     description = dedent(
         """\
@@ -1985,7 +1979,7 @@ def test_help_help_on_error(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app foo [ARGS] [OPTIONS]
+        Usage: app foo COUNT
 
         This is Foo's Help.
 
@@ -2018,7 +2012,7 @@ def test_issue_373_help_space_with_meta_app(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: app [ARGS] [OPTIONS]
+        Usage: app VALUE
 
         App Help String Line 1.
 
@@ -2070,7 +2064,7 @@ def test_format_plain_formatter(console):
 
     expected = dedent(
         """\
-        Usage: test_app COMMAND [ARGS] [OPTIONS]
+        Usage: test_app COMMAND [ARGS]
 
         Test application for PlainFormatter
 

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -48,7 +48,7 @@ def test_group_custom_table_spec(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-            Usage: test_help_customization [ARGS] [OPTIONS]
+            Usage: test_help_customization [ARGS]
 
             ╭─ Commands ─────────────────────────────────────────────────────────╮
             │ --help -h  Display this message and exit.                          │
@@ -94,7 +94,7 @@ def test_group_custom_panel_spec(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -149,7 +149,7 @@ def test_group_custom_columns(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -194,7 +194,7 @@ def test_default_group_with_custom_spec(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -281,7 +281,7 @@ def test_panel_spec_custom_title(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -331,7 +331,7 @@ def test_mixed_groups_with_different_specs(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization NAME [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -378,7 +378,7 @@ def test_table_show_lines_with_box(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -421,7 +421,7 @@ def test_table_headers_with_default_columns(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -470,7 +470,7 @@ def test_table_headers_suppressed_when_all_empty(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -524,7 +524,7 @@ def test_table_headers_with_non_empty_headers(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -637,7 +637,7 @@ def test_custom_help_formatter_basic(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -740,7 +740,7 @@ def test_custom_help_formatter_with_optional_methods(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        [CUSTOM USAGE]  Usage: test_help_customization [ARGS] [OPTIONS]
+        [CUSTOM USAGE]  Usage: test_help_customization [ARGS]
 
         [CUSTOM DESC]
         This is a test application.
@@ -826,7 +826,7 @@ def test_multiple_groups_different_formatters(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -874,7 +874,7 @@ def test_custom_formatter_protocol_validation(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -910,7 +910,7 @@ def test_group_formatter_none_fallback(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         +--------------------------------------------------------------------+
         |                              Commands                              |
@@ -997,7 +997,7 @@ def test_custom_formatter_receives_correct_arguments(console: Console):
 
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -1036,7 +1036,7 @@ def test_plain_formatter_with_rich_text(console: Console):
     # Commands group still uses default formatter, only Plain Options uses PlainFormatter
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -1121,7 +1121,7 @@ def test_plain_formatter_render_methods(console: Console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization [ARGS]
 
         Test application with plain formatter.
 
@@ -1173,7 +1173,7 @@ def test_plain_formatter_parameter_with_metadata(console: Console):
     # Commands group uses default formatter
     expected = dedent(
         """\
-        Usage: test_help_customization [ARGS] [OPTIONS]
+        Usage: test_help_customization MODE OUTPUT
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/test_markdown_formatter.py
+++ b/tests/test_markdown_formatter.py
@@ -133,13 +133,13 @@ def test_markdown_formatter_parameter_panel_list():
     formatter(None, None, panel)
     output = formatter.get_output()
 
-    expected = (
-        "## Parameters\n"
-        "\n"
-        "* `-p, --port`: Port number  **[required]**  *[default: 8080]*\n"
-        "* `--verbose`: Enable verbose mode  *[env: VERBOSE]*\n"
-        "\n"
-    )
+    expected = dedent("""\
+        ## Parameters
+
+        * `-p, --port`: Port number  **[required]**  *[default: 8080]*
+        * `--verbose`: Enable verbose mode  *[env: VERBOSE]*
+
+        """)
 
     assert output == expected
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -109,7 +109,7 @@ def test_meta_app_nested_subapp_help(nested_meta_app, console, queue):
 
     expected = dedent(
         """\
-        Usage: test_app subapp COMMAND [ARGS]
+        Usage: test_app subapp COMMAND
 
         This is subapp's help.
 
@@ -131,7 +131,7 @@ def test_meta_app_nested_subapp_foo_help(nested_meta_app, console, queue):
 
     expected = dedent(
         """\
-        Usage: test_app subapp foo [ARGS] [OPTIONS]
+        Usage: test_app subapp foo VALUE
 
         Subapp foo help string.
 
@@ -271,7 +271,7 @@ def test_meta_app_help_inconsistency_with_argument_order(app, console):
 
     expected = dedent(
         """\
-        Usage: test_meta foo [ARGS] [OPTIONS]
+        Usage: test_meta foo LOOPS
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  LOOPS --loops  [required]                                       │

--- a/tests/test_name_transform.py
+++ b/tests/test_name_transform.py
@@ -149,7 +149,7 @@ def test_parameter_name_transform_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_name_transform [OPTIONS]
+        Usage: test_name_transform --b_a_r INT
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -184,7 +184,7 @@ def test_parameter_name_transform_help_enum(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_name_transform cmd [ARGS] [OPTIONS]
+        Usage: test_name_transform cmd [ARGS]
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ FOO --foo  Docstring for foo. [choices: FIZZ, BUZZ] [default:      │

--- a/tests/test_parameter_decorator.py
+++ b/tests/test_parameter_decorator.py
@@ -52,7 +52,8 @@ def test_parameter_decorator_dataclass_nested_1(app, decorator, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_parameter_decorator action [OPTIONS]
+        Usage: test_parameter_decorator action --bucket STR --key STR --region
+        STR
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  --bucket  [required]                                            │

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -153,7 +153,7 @@ def test_bind_pydantic_basemodel_help(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_pydantic [ARGS] [OPTIONS]
+        Usage: test_pydantic USER.ID USER.SIGNUP-TS USER.TASTES [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │
@@ -232,7 +232,7 @@ def test_pydantic_alias_1(app, console, assert_parse_args):
 
     expected = dedent(
         """\
-        Usage: test_pydantic foo [ARGS] [OPTIONS]
+        Usage: test_pydantic foo USER.USER-NAME USER.AGE-IN-YEARS
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.USER-NAME         Name of user. [required]                 │
@@ -317,7 +317,7 @@ def test_parameter_decorator_pydantic_nested_1(app, console):
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_pydantic action [OPTIONS]
+        Usage: test_pydantic action --bucket STR --key STR --area STR
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  --bucket  [required]                                            │
@@ -418,7 +418,7 @@ def test_pydantic_annotated_field_discriminator(app, assert_parse_args, console)
     actual = capture.get()
     expected = dedent(
         """\
-        Usage: test_pydantic [ARGS] [OPTIONS]
+        Usage: test_pydantic [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ --help -h  Display this message and exit.                          │

--- a/tests/types/test_types_number.py
+++ b/tests/types/test_types_number.py
@@ -83,7 +83,7 @@ def test_hexuint_help_no_default(app, console):
 
     expected = dedent(
         """\
-        Usage: test_types_number foo [ARGS] [OPTIONS]
+        Usage: test_types_number foo A
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  A --a  [required]                                               │


### PR DESCRIPTION
Addresses #442. The example from that issue produces:

```console
$ python issue-442.py --help
Usage: issue-442.py --foo STR --something-else STR BEEP [ARGS]
```