### PR TITLE
`Parameter.count` for `int` counting-flags (e.g. verbosity `-vvv`).

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -136,7 +136,9 @@ def _parse_kw_and_flags(
                 unused_tokens.append(token)
                 continue
         for argument, leftover_keys, implicit_value in matches:
-            if implicit_value is not UNSET:
+            if argument.parameter.count:
+                argument.append(CliToken(keyword=cli_option, implicit_value=1))
+            elif implicit_value is not UNSET:
                 # A flag was parsed
                 if cli_values:
                     try:

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -249,6 +249,12 @@ class Parameter:
 
     json_list: bool | None = field(default=None, kw_only=True)
 
+    count: bool = field(
+        default=None,
+        converter=attrs.converters.default_if_none(False),
+        kw_only=True,
+    )
+
     # Populated by the record_attrs_init_args decorator.
     _provided_args: tuple[str] = field(factory=tuple, init=False, eq=False)
 
@@ -261,6 +267,9 @@ class Parameter:
         return self._name_transform if self._name_transform else default_name_transform
 
     def get_negatives(self, type_) -> tuple[str, ...]:
+        if self.count and self.negative is None:
+            return ()
+
         type_ = resolve_annotated(type_)
         if is_union(type_):
             out = []

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1248,6 +1248,42 @@ API
 
       2. The first character of the token is a ``[``.
 
+   .. attribute:: count
+      :type: bool
+      :value: False
+
+      If :obj:`True`, count the number of times the flag appears instead of parsing a value.
+      Each occurrence increments the count by 1 (e.g., ``-vvv`` results in ``3``).
+
+      Requirements and behavior:
+
+      * The parameter **must** have an :obj:`int` type hint (or ``Optional[int]``).
+      * Short flags can be concatenated: ``-vvv`` is equivalent to ``-v -v -v``.
+      * Long flags can be repeated: ``--verbose --verbose`` results in ``2``.
+      * Negative flag variants (e.g., ``--no-verbose``) are **not** generated.
+
+      Common use case: verbosity levels.
+
+      .. code-block:: python
+
+         from cyclopts import App, Parameter
+         from typing import Annotated
+
+         app = App()
+
+         @app.default
+         def main(verbose: Annotated[int, Parameter(name="-v", count=True)] = 0):
+            print(f"Verbosity level: {verbose}")
+
+         app()
+
+      .. code-block:: console
+
+         $ my-script -vvv
+         Verbosity level: 3
+
+      See :ref:`Coercion Rules` for more details.
+
    .. automethod:: combine
 
    .. automethod:: default

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -86,10 +86,45 @@ Int
 ***
 For convenience, Cyclopts provides a richer feature-set of parsing integers than just naively calling ``int``.
 
-* Accepts vanilla decimal values (e.g. `123`, `3.1415`). Floating-point values will be rounded prior to casting to an ``int``.
-* Accepts binary values (strings starting with `0b`)
-* Accepts octal values (strings starting with `0o`)
-* Accepts hexadecimal values (strings starting with `0x`).
+* Accepts vanilla decimal values (e.g. ``123``, ``3.1415``). Floating-point values will be rounded prior to casting to an ``int``.
+* Accepts binary values (strings starting with ``0b``)
+* Accepts octal values (strings starting with ``0o``)
+* Accepts hexadecimal values (strings starting with ``0x``).
+
+^^^^^^^^^^^^^^
+Counting Flags
+^^^^^^^^^^^^^^
+For parameters that need to track the number of times a flag appears (e.g., verbosity levels like ``-vvv``), use :attr:`.Parameter.count` with an :obj:`int` type hint.
+
+.. code-block:: python
+
+   from cyclopts import App, Parameter
+   from typing import Annotated
+
+   app = App()
+
+   @app.default
+   def main(verbose: Annotated[int, Parameter(alias="-v", count=True)] = 0):
+       print(f"Verbosity level: {verbose}")
+
+   app()
+
+.. code-block:: console
+
+   $ my-program
+   Verbosity level: 0
+
+   $ my-program -v
+   Verbosity level: 1
+
+   $ my-program -vvv
+   Verbosity level: 3
+
+   $ my-program --verbose --verbose
+   Verbosity level: 2
+
+   $ my-program -v --verbose -vv
+   Verbosity level: 4
 
 *****
 Float

--- a/tests/test_parameter_count.py
+++ b/tests/test_parameter_count.py
@@ -1,0 +1,126 @@
+"""Tests for Parameter(count=True) functionality."""
+
+from typing import Annotated, Optional
+
+import pytest
+
+from cyclopts import Parameter
+from cyclopts.exceptions import MissingArgumentError, UnknownOptionError
+
+
+@pytest.mark.parametrize(
+    "tokens,expected",
+    [
+        ("", 0),
+        ("-v", 1),
+        ("-vv", 2),
+        ("-vvv", 3),
+        ("-v -v -v", 3),
+        ("-v --verbose -v", 3),
+        ("--verbose", 1),
+        ("--verbose --verbose", 2),
+        ("-v --verbose -vv --verbose", 5),
+    ],
+)
+def test_count_various_inputs(app, assert_parse_args, tokens, expected):
+    """Test count with various flag combinations."""
+
+    def cmd(verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    assert_parse_args(cmd, tokens, expected)
+
+
+def test_count_negative_disabled(app):
+    """Ensure --no-verbose is NOT generated."""
+
+    def cmd(verbose: Annotated[int, Parameter(name="--verbose", count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    with pytest.raises(UnknownOptionError):
+        app.parse_args("--no-verbose", exit_on_error=False)
+
+
+@pytest.mark.parametrize(
+    "type_hint",
+    [str, bool, list, dict],
+)
+def test_count_wrong_type_error(app, type_hint):
+    """count=True with non-int type should error."""
+
+    def cmd(verbose: Annotated[type_hint, Parameter(count=True)]):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    app.default(cmd)
+    with pytest.raises(ValueError, match="requires an int type hint"):
+        app.parse_args("", exit_on_error=False)
+
+
+def test_count_optional_int(app, assert_parse_args):
+    """count=True with Optional[int] should work."""
+
+    def cmd(verbose: Annotated[Optional[int], Parameter(name="-v", count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    assert_parse_args(cmd, "-vv", 2)
+
+
+def test_count_multiple_parameters(app, assert_parse_args):
+    """Multiple count parameters in same command."""
+
+    def cmd(
+        verbose: Annotated[int, Parameter(name="-v", count=True)] = 0,
+        quiet: Annotated[int, Parameter(name="-q", count=True)] = 0,
+    ):
+        pass
+
+    app.default(cmd)
+    assert_parse_args(cmd, "", 0, 0)
+    assert_parse_args(cmd, "-vvv", 3, 0)
+    assert_parse_args(cmd, "-qq", 0, 2)
+    assert_parse_args(cmd, "-vv -qqq", 2, 3)
+
+
+def test_count_with_other_parameters(app, assert_parse_args):
+    """Count flag mixed with regular parameters."""
+
+    def cmd(
+        verbose: Annotated[int, Parameter(name="-v", count=True)] = 0,
+        output: str = "default",
+    ):
+        pass
+
+    app.default(cmd)
+    assert_parse_args(cmd, "-vv --output test.txt", 2, "test.txt")
+    assert_parse_args(cmd, "--output foo -vvv", 3, "foo")
+
+
+def test_count_no_default(app):
+    """Count without explicit default should be required."""
+
+    def cmd(verbose: Annotated[int, Parameter(name="-v", count=True)]):
+        pass
+
+    app.default(cmd)
+    with pytest.raises(MissingArgumentError):
+        app.parse_args("", exit_on_error=False)
+
+
+def test_count_help_text(app, console):
+    """Verify help text includes user-provided description."""
+
+    def cmd(verbose: Annotated[int, Parameter(name=("-v", "--verbose"), count=True, help="Increase verbosity")] = 0):
+        """Command with count flag."""
+        pass
+
+    app.default(cmd)
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+    help_text = capture.get()
+
+    assert "increase verbosity" in help_text.lower()
+    assert "verbose" in help_text.lower()


### PR DESCRIPTION
Addresses #618. This PR streamlines integer-based counting flags (common for things like verbosity).

Tagging @isoschiz for visibility.
