### PR TITLE
Bugfix: Resolve the default version to the nearest explicitly set value.

### DIFF
--- a/cyclopts/command_spec.py
+++ b/cyclopts/command_spec.py
@@ -129,6 +129,8 @@ class CommandSpec:
 
             app_kwargs.setdefault("help_flags", parent_app.help_flags)
             app_kwargs.setdefault("version_flags", parent_app.version_flags)
+            if "version" not in app_kwargs and parent_app.version is not None:
+                app_kwargs["version"] = parent_app.version
 
             _apply_parent_groups_to_kwargs(app_kwargs, parent_app)
 

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -129,6 +129,8 @@ def _apply_parent_defaults_to_app(app: "App", parent_app: "App") -> None:
         app._group_parameters = copy(parent_app._group_parameters)
     if app._group_arguments is None:
         app._group_arguments = copy(parent_app._group_arguments)
+    if app.version is None and parent_app.version is not None:
+        app.version = parent_app.version
 
 
 def _apply_parent_groups_to_kwargs(kwargs: dict[str, Any], parent_app: "App") -> None:
@@ -1263,6 +1265,8 @@ class App:
         else:
             kwargs.setdefault("help_flags", self.help_flags)
             kwargs.setdefault("version_flags", self.version_flags)
+            if "version" not in kwargs and self.version is not None:
+                kwargs["version"] = self.version
 
             _apply_parent_groups_to_kwargs(kwargs, self)
             app = type(self)(**kwargs)  # pyright: ignore
@@ -1521,7 +1525,7 @@ class App:
                     unused_tokens = []
                     argument_collection = ArgumentCollection()
                 elif any(flag in tokens for flag in command_app.version_flags):
-                    command = _get_version_command(self)
+                    command = _get_version_command(command_app)
                     while meta_parent := meta_parent._meta_parent:
                         command = _get_version_command(meta_parent)
 


### PR DESCRIPTION
Previously it was always using the root app's `version` field. While this is usually correct, for subcommands it is more correct to first check if they themselves have the `version` attribute set and to use that.