### PR TITLE
Add `call_if_callable` `result_action`

### DIFF
--- a/cyclopts/_result_action.py
+++ b/cyclopts/_result_action.py
@@ -7,6 +7,7 @@ from cyclopts.utils import is_iterable
 ResultActionSingle = (
     Literal[
         "return_value",
+        "call_if_callable",
         "print_non_int_return_int_as_exit_code",
         "print_str_return_int_as_exit_code",
         "print_str_return_zero",
@@ -75,6 +76,10 @@ def handle_result_action(
             else:
                 sys.exit(0)
         case "return_value":
+            return result
+        case "call_if_callable":
+            if callable(result):
+                return result()
             return result
         case "sys_exit":
             if isinstance(result, bool):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -534,7 +534,7 @@ API
          app(backend="trio")  # Override the app's backend for this call
 
    .. attribute:: result_action
-      :type: Literal["return_value", "print_non_int_return_int_as_exit_code", "print_str_return_int_as_exit_code", "print_str_return_zero", "print_non_none_return_int_as_exit_code", "print_non_none_return_zero", "return_int_as_exit_code_else_zero", "print_non_int_sys_exit", "sys_exit", "return_none", "return_zero", "print_return_zero", "sys_exit_zero", "print_sys_exit_zero"] | Callable[[Any], Any] | Iterable[Literal[...] | Callable[[Any], Any]] | None
+      :type: Literal["return_value", "call_if_callable", "print_non_int_return_int_as_exit_code", "print_str_return_int_as_exit_code", "print_str_return_zero", "print_non_none_return_int_as_exit_code", "print_non_none_return_zero", "return_int_as_exit_code_else_zero", "print_non_int_sys_exit", "sys_exit", "return_none", "return_zero", "print_return_zero", "sys_exit_zero", "print_sys_exit_zero"] | Callable[[Any], Any] | Iterable[Literal[...] | Callable[[Any], Any]] | None
       :value: None
 
       Controls how :meth:`.App.__call__` and :meth:`.App.run_async` handle command return values. By default (``"print_non_int_sys_exit"``), the app will call :func:`sys.exit` with an appropriate exit code. This default was chosen for consistent functionality between standalone scripts, and console entrypoints.
@@ -566,6 +566,16 @@ API
          .. code-block:: python
 
             return result
+
+      **"call_if_callable"**
+
+         Calls the result if it's callable (with no arguments), otherwise returns it unchanged. Useful for the dataclass command pattern where commands return class instances with ``__call__`` methods. Intended to be used in composition with other result actions (e.g., ``["call_if_callable", "print_non_int_sys_exit"]``).
+
+         .. code-block:: python
+
+            return result() if callable(result) else result
+
+         See :ref:`Dataclass Commands` for usage examples.
 
       **"sys_exit"**
 

--- a/docs/source/cookbook/dataclass_commands.rst
+++ b/docs/source/cookbook/dataclass_commands.rst
@@ -1,0 +1,64 @@
+.. _Dataclass Commands:
+
+==================
+Dataclass Commands
+==================
+
+An alternative command syntax is to use dataclasses with a ``__call__`` method.
+To support this pattern, Cyclopts provides the ``"call_if_callable"`` result action,
+which can be composed with other result actions.
+
+Basic Example
+=============
+
+Here's a simple example using the dataclass command pattern:
+
+.. code-block:: python
+
+   # greeter.py
+   from dataclasses import dataclass, KW_ONLY
+   from cyclopts import App
+
+   app = App(result_action=["call_if_callable", "print_non_int_sys_exit"])
+
+   @app.command
+   @dataclass
+   class Greet:
+       """Greet someone with a message."""
+
+       name: str = "World"
+       _: KW_ONLY
+       formal: bool = False
+
+       def __call__(self):
+           greeting = "Hello" if self.formal else "Hey"
+           return f"{greeting} {self.name}."
+
+   if __name__ == "__main__":
+       app()
+
+Running this application:
+
+.. code-block:: console
+
+   $ python greeter.py greet
+   Hey World.
+
+   $ python greeter.py greet Alice
+   Hey Alice.
+
+   $ python greeter.py greet Bob --formal
+   Hello Bob.
+
+How It Works
+============
+
+The ``result_action=["call_if_callable", "print_non_int_sys_exit"]`` creates a pipeline:
+
+1. **call_if_callable**: After parsing, Cyclopts creates an instance of the ``Greet`` dataclass.
+   This action checks if the result is callable (it is, because of ``__call__``), and calls it with no arguments.
+
+2. **print_non_int_sys_exit**: Takes the string returned by ``__call__`` and prints it, then exits.
+
+Without ``"call_if_callable"``, the app would try to print the dataclass instance itself
+instead of calling it and printing the result.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,6 +51,7 @@ For extensive documentation on all the features Cyclopts has to offer, checkout 
    :caption: Cookbook
 
    cookbook/app_upgrade.rst
+   cookbook/dataclass_commands.rst
    cookbook/interactive_help.rst
    cookbook/rich_formatted_exceptions.rst
    cookbook/sharing_parameters.rst


### PR DESCRIPTION
Allows for generic usage of classes as commands. Resolves #570.

Example:

```python
 # greeter.py
 from dataclasses import dataclass, KW_ONLY
 from cyclopts import App

 app = App(result_action=["call_if_callable", "print_non_int_sys_exit"])

 @app.command
 @dataclass
 class Greet:
     """Greet someone with a message."""
     name: str = "World"
     _: KW_ONLY
     formal: bool = False

     def __call__(self):
         greeting = "Hello" if self.formal else "Hey"
         return f"{greeting} {self.name}."

 if __name__ == "__main__":
     app()
```

Tagging @beskep and @edabor

@thomasaarholt you may also care about this (and the related PR #666).