### PR TITLE
V5: Remove `rich-rst` from being a required dependency

### DIFF
--- a/cyclopts/help/inline_text.py
+++ b/cyclopts/help/inline_text.py
@@ -41,7 +41,12 @@ class InlineText:
 
             primary_renderable = Markdown(content)
         elif format in ("restructuredtext", "rst"):
-            from rich_rst import RestructuredText
+            try:
+                from rich_rst import RestructuredText
+            except ImportError as e:
+                raise ImportError(
+                    'reStructuredText format requires the "rst" extra. Install with: pip install "cyclopts[rst]"'
+                ) from e
 
             from cyclopts.help.rst_preprocessor import process_sphinx_directives
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -114,6 +114,11 @@ API
       If :obj:`None`, fallback to parenting :attr:`~.App.help_format`.
       If no :attr:`~.App.help_format` is defined, falls back to ``"markdown"``.
 
+      .. note::
+         The ``"restructuredtext"`` and ``"rst"`` formats require the optional ``rst`` extra,
+         which installs rich-rst_:
+         ``pip install "cyclopts[rst]"``
+
    .. attribute:: help_formatter
       :type: Union[None, Literal["default", "plain"], HelpFormatter]
       :value: None
@@ -155,6 +160,7 @@ API
       If not set, attempts to inherit from parenting :class:`.App`.
 
       The epilogue supports the same formatting as :attr:`help` based on :attr:`help_format` (markdown, plaintext, restructuredtext, or rich).
+      Note that restructuredtext format requires installing ``cyclopts[rst]``, which installs rich-rst_.
 
       Example:
 
@@ -219,6 +225,11 @@ API
       The markup language used in the version string.
       If :obj:`None`, fallback to parenting :attr:`~.App.version_format`.
       If no :attr:`~.App.version_format` is defined, falls back to resolved :attr:`~.App.help_format`.
+
+      .. note::
+         The ``"restructuredtext"`` and ``"rst"`` formats require the optional ``rst`` extra,
+         which installs rich-rst_:
+         ``pip install "cyclopts[rst]"``
 
    .. attribute:: usage
       :type: Optional[str]
@@ -2255,3 +2266,5 @@ Exceptions
 .. autoexception:: cyclopts.EditorDidNotChangeError
    :show-inheritance:
    :members:
+
+.. _rich-rst: https://github.com/wasi-master/rich-rst

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -220,6 +220,13 @@ ReStructuredText
 ^^^^^^^^^^^^^^^^
 ReStructuredText can be enabled by setting `help_format` to "restructuredtext" or "rst".
 
+.. note::
+   ReStructuredText support requires the optional ``rst`` extra, which installs rich-rst_:
+
+   .. code-block:: bash
+
+      pip install "cyclopts[rst]"
+
 .. code-block:: python
 
    app = App(help_format="restructuredtext")  # or "rst"
@@ -414,3 +421,4 @@ styled panels, and dynamic column layouts, see :ref:`Help Customization`.
 .. _PEP-0257: https://peps.python.org/pep-0257/
 .. _PEP-0287: https://peps.python.org/pep-0287/
 .. _Rich Markup: https://rich.readthedocs.io/en/stable/markup.html
+.. _rich-rst: https://github.com/wasi-master/rich-rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ dependencies = [
     "attrs>=23.1.0",
     "rich>=13.6.0",
     "docstring-parser>=0.15,<4.0",
-    "rich-rst>=1.3.1,<2.0.0",
     "typing-extensions>=4.8.0; python_version<'3.11'",
     "tomli>=2.0.0; python_version<'3.11'",
 ]
 
 [project.optional-dependencies]
+rst = ["rich-rst>=1.3.1"]
 toml = ["tomli>=2.0.0; python_version<'3.11'"]
 trio = ["trio>=0.10.0"]
 yaml = ["pyyaml>=6.0.1"]
@@ -51,6 +51,7 @@ dev = [
     "toml>=0.10.2,<1.0.0",
     "trio>=0.10.0",
     "pyyaml>=6.0.1",
+    "rich-rst>=1.3.1",
 ]
 debug = ["ipdb>=0.13.9", "line_profiler>=3.5.1"]
 
@@ -218,8 +219,6 @@ sections = ["project.dependencies"]
 exclude-deps = [
     "typing-extensions",
     "docstring-parser",  # Not detected due to deferred import.
-    "rich-rst",          # Not detected due to deferred import.
     "rich",              # Not detected due to deferred import.
     "tomli",             # Not detected due to optional feature.
-    "trio",              # Not detected due to optional feature.
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,6 @@ dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
     { name = "rich" },
-    { name = "rich-rst" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -299,6 +298,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pyyaml" },
+    { name = "rich-rst" },
     { name = "toml" },
     { name = "trio" },
 ]
@@ -310,6 +310,9 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-rtd-dark-mode" },
     { name = "sphinx-rtd-theme" },
+]
+rst = [
+    { name = "rich-rst" },
 ]
 toml = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -338,7 +341,8 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.6.0" },
-    { name = "rich-rst", specifier = ">=1.3.1,<2.0.0" },
+    { name = "rich-rst", marker = "extra == 'dev'", specifier = ">=1.3.1" },
+    { name = "rich-rst", marker = "extra == 'rst'", specifier = ">=1.3.1" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.4.7,<8.2.0" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=1.25.2,<4.0.0" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5,<1.0" },
@@ -351,7 +355,7 @@ requires-dist = [
     { name = "trio", marker = "extra == 'trio'", specifier = ">=0.10.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.8.0" },
 ]
-provides-extras = ["debug", "dev", "docs", "toml", "trio", "yaml"]
+provides-extras = ["debug", "dev", "docs", "rst", "toml", "trio", "yaml"]
 
 [[package]]
 name = "decorator"


### PR DESCRIPTION
It's subdependency, `docutils`, has licensing that may make compliance reviews more difficult).

Resolves #672. Also linking the [upstream issue](https://github.com/jlowin/fastmcp/issues/2320).