### PR TITLE
Search the class's MRO for attribute docstrings.

### DIFF
--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -166,13 +166,38 @@ def extract_docstring_help(f: Callable) -> dict[tuple[str, ...], Parameter]:
     with suppress(AttributeError):
         f = f.func  # pyright: ignore[reportFunctionMemberAccess]
 
-    try:
-        return {
-            tuple(dparam.arg_name.split(".")): Parameter(help=dparam.description)
-            for dparam in parse_from_object(f).params
-        }
-    except TypeError:
-        return {}
+    result = {}
+
+    # For classes, walk through MRO  to include base class fields.
+    # parse_from_object only extracts docstrings from the **immediate** class's source code,
+    # not from inherited fields.
+    # From docstring_parser docs:
+    #
+    #    When given a class, only the attribute docstrings of that class are parsed, not its
+    #    inherited classes. This is a design decision. Separate calls to this function
+    #    should be performed to get attribute docstrings of parent classes.
+    if mro := getattr(f, "__mro__", None):
+        # Process base classes first (reversed MRO order), so derived classes can override
+        # their parent's docstrings if they redefine the same field with a new docstring.
+        for base_class in reversed(mro[:-1]):  # Exclude 'object'
+            try:
+                parsed = parse_from_object(base_class)
+                for dparam in parsed.params:
+                    result[tuple(dparam.arg_name.split("."))] = Parameter(help=dparam.description)
+            except (TypeError, AttributeError):
+                # Some base classes may not have parseable docstrings (e.g., built-in classes)
+                continue
+    else:
+        # For functions/callables (original behavior)
+        try:
+            parsed = parse_from_object(f)
+            for dparam in parsed.params:
+                result[tuple(dparam.arg_name.split("."))] = Parameter(help=dparam.description)
+        except (TypeError, AttributeError):
+            # parse_from_object may fail for some callables
+            pass
+
+    return result
 
 
 def resolve_parameter_name_helper(elem):

--- a/tests/test_bind_attrs.py
+++ b/tests/test_bind_attrs.py
@@ -217,3 +217,34 @@ def test_attrs_field_metadata_help(app, console):
 
     assert "Metadata help overrides docstring." in actual
     assert "This docstring is ignored." not in actual
+
+
+def test_attrs_inheritance_simple(app, console):
+    """Test that docstrings from base attrs class are inherited by derived class."""
+
+    @define
+    class BaseClass:
+        """Base class."""
+
+        some_arg: int = 42
+        """BaseClass.some_arg docstring."""
+
+    @define
+    class DerivedClass(BaseClass):
+        """Derived class."""
+
+        some_other_arg: str = "some_other_arg default value"
+        """DerivedClass.some_other_arg docstring."""
+
+    @app.default
+    def main(params: DerivedClass):
+        pass
+
+    with console.capture() as capture:
+        app("--help", console=console)
+
+    actual = capture.get()
+
+    # Check that both base and derived docstrings are present
+    assert "BaseClass.some_arg docstring." in actual
+    assert "DerivedClass.some_other_arg docstring." in actual

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -698,3 +698,30 @@ def test_pydantic_secret_explicit_value(app, assert_parse_args, secret_type, val
         f"test-cmd --some-secret {value}",
         ScriptSettings(some_secret=expected_value),
     )
+
+
+def test_pydantic_inheritance_simple(app, console):
+    """Test that Field descriptions from base pydantic model are inherited by derived model."""
+
+    class BaseModelCustom(BaseModel):
+        """Base pydantic model."""
+
+        base_field: int = Field(default=42, description="Field from base pydantic model")
+
+    class DerivedModel(BaseModelCustom):
+        """Derived pydantic model."""
+
+        derived_field: str = Field(default="test", description="Field from derived pydantic model")
+
+    @app.default
+    def main(params: DerivedModel):
+        pass
+
+    with console.capture() as capture:
+        app("--help", console=console)
+
+    actual = capture.get()
+
+    # Check that both base and derived field descriptions are present
+    assert "Field from base pydantic model" in actual
+    assert "Field from derived pydantic model" in actual


### PR DESCRIPTION
`docstring_parser.parse_from_object` does not traverse the MRO when parsing docstrings (by design choice). This PR fixes cyclopts' usage of `parse_from_object` to traverse the MRO.

Fixes #691  