### PR TITLE
Display command aliases with parentheses.

### DIFF
--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -74,6 +74,62 @@ class NameRenderer:
         return "\n".join(wrapped)
 
 
+class CommandNameRenderer:
+    """Renderer for command names with aliases in parentheses.
+
+    Displays commands in argparse-style format: ``primary (alias1, alias2)``.
+
+    Parameters
+    ----------
+    max_width : int | None
+        Maximum width for wrapping. If None, no wrapping is applied.
+    """
+
+    def __init__(self, max_width: int | None = None):
+        """Initialize the renderer with formatting options.
+
+        Parameters
+        ----------
+        max_width : int | None
+            Maximum width for wrapping. If None, no wrapping is applied.
+        """
+        self.max_width = max_width
+
+    def __call__(self, entry: "HelpEntry") -> "RenderableType":
+        """Render command name with aliases in parentheses.
+
+        Parameters
+        ----------
+        entry : HelpEntry
+            The table entry to render.
+
+        Returns
+        -------
+        ~rich.console.RenderableType
+            Primary command name with aliases in parentheses.
+        """
+        primary = entry.names[0]
+        aliases = list(entry.names[1:]) + list(entry.shorts)
+
+        if aliases:
+            text = f"{primary} ({', '.join(aliases)})"
+        else:
+            text = primary
+
+        if self.max_width is None:
+            return text
+
+        wrapped = textwrap.wrap(
+            text,
+            self.max_width,
+            subsequent_indent="  ",
+            break_on_hyphens=False,
+            tabsize=4,
+        )
+
+        return "\n".join(wrapped)
+
+
 class DescriptionRenderer:
     """Renderer for descriptions with configurable metadata formatting.
 
@@ -387,7 +443,7 @@ def get_default_command_columns(
     """
     max_width = math.ceil(console.width * 0.35)
     command_column = ColumnSpec(
-        renderer=NameRenderer(max_width=max_width),
+        renderer=CommandNameRenderer(max_width=max_width),
         header="Command",
         justify="left",
         style="cyan",

--- a/tests/config/test_end2end.py
+++ b/tests/config/test_end2end.py
@@ -68,8 +68,8 @@ def test_config_env_help(app, assert_parse_args, console):
         Usage: test_end2end FOO
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  FOO --foo  [env var: BAR, FOO] [required]                       │

--- a/tests/test_bind_dataclasses.py
+++ b/tests/test_bind_dataclasses.py
@@ -269,8 +269,8 @@ def test_bind_dataclass_positionally(app, assert_parse_args, cmd_str, console):
         Usage: test_bind_dataclasses A [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  A --a      Docstring for a. [required]                          │
@@ -301,8 +301,8 @@ def test_bind_dataclass_default_factory_help(app, console):
         Usage: test_bind_dataclasses [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ A --a  Docstring for a. [default: 5]                               │

--- a/tests/test_enum_flag.py
+++ b/tests/test_enum_flag.py
@@ -120,8 +120,8 @@ def test_flag_as_boolean_flags_star_name(app, assert_parse_args, console):
         Manage file permissions.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --read     Enable read permissions. [default: False]               │
@@ -203,8 +203,8 @@ def test_flag_help_shows_member_docstrings(app, console):
         Manage file permissions.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --perms.read          Enable read permissions. [default: False]    │
@@ -238,8 +238,8 @@ def test_flag_help_star_name_shows_member_docstrings(app, console):
         Manage file permissions.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --read --no-read        Enable read permissions. [default: False]  │
@@ -298,8 +298,8 @@ def test_flag_in_dataclass_help(app, console):
         Create a user with permissions.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.NAME --user.name      [required]                           │
@@ -335,8 +335,8 @@ def test_flag_in_dataclass_help_no_negative(app, console):
         Create a user with permissions.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.NAME --user.name  [required]                               │
@@ -377,8 +377,8 @@ def test_flag_in_dataclass_help_no_keywords(app, assert_parse_args, console):
         Create a user with permissions.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.NAME --user.name    [required]                             │

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -64,8 +64,8 @@ def test_help_default_action(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -85,8 +85,8 @@ def test_help_custom_usage(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -124,8 +124,8 @@ def test_help_default_help_flags(console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -243,9 +243,9 @@ def test_format_commands_no_show(app, console, assert_parse_args):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        Docstring for foo.                                      │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo          Docstring for foo.                                    │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -314,9 +314,9 @@ def test_help_functools_partial_1(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        Docstring for foo.                                      │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo          Docstring for foo.                                    │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -395,8 +395,8 @@ def test_format_choices_rich_format(app, console, assert_parse_args):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  REGION --region  [choices: us, ca] [required]                   │
@@ -785,8 +785,8 @@ def test_help_format_dataclass_default_parameter_negative_propagation(app, conso
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  FORCE --force  [required]                                       │
@@ -817,8 +817,8 @@ def test_help_format_dataclass_decorated_parameter_negative_propagation(app, con
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  FORCE --force  [required]                                       │
@@ -1385,8 +1385,8 @@ def test_help_print_command_group_description(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Custom Title ─────────────────────────────────────────────────────╮
         │ Command description.                                               │
@@ -1422,8 +1422,8 @@ def test_help_print_command_group_no_show(app, console):
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ cmd2                                                               │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -1483,10 +1483,47 @@ def test_help_print_commands(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ cmd1       Cmd1 help string.                                       │
-        │ cmd2       Cmd2 help string.                                       │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ cmd1         Cmd1 help string.                                     │
+        │ cmd2         Cmd2 help string.                                     │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
+def test_help_print_commands_with_aliases(app, console):
+    """Test that command aliases are displayed in parentheses."""
+
+    @app.command(alias=["g", "greet-alias"], help="Say hello.")
+    def greet():
+        pass
+
+    @app.command(alias="b", help="Say goodbye.")
+    def bye():
+        pass
+
+    @app.command(help="No aliases.")
+    def solo():
+        pass
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        Usage: app COMMAND
+
+        App Help String Line 1.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ bye (b)                 Say goodbye.                               │
+        │ greet (g, greet-alias)  Say hello.                                 │
+        │ solo                    No aliases.                                │
+        │ --help (-h)             Display this message and exit.             │
+        │ --version               Display application version.               │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -1521,8 +1558,8 @@ def test_help_print_commands_group_sort_key(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ 4 ────────────────────────────────────────────────────────────────╮
         │ cmd1                                                               │
@@ -1569,10 +1606,10 @@ def test_help_print_commands_and_function(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ cmd1       Cmd1 help string.                                       │
-        │ cmd2       Cmd2 help string.                                       │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ cmd1         Cmd1 help string.                                     │
+        │ cmd2         Cmd2 help string.                                     │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  FOO --foo  Docstring for foo. [required]                        │
@@ -1599,7 +1636,7 @@ def test_help_print_commands_special_flag_reassign(app, console):
         │ --version  Display application version.                            │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Admin ────────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
+        │ --help (-h)  Display this message and exit.                        │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -1718,8 +1755,8 @@ def test_help_print_commands_sort_key(app, console):
         │ charlie                                                            │
         │ bob                                                                │
         │ alice                                                              │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -1814,11 +1851,11 @@ def test_help_print_commands_plus_meta_short(app, console):
         App Help String Line 1 from meta.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ cmd1       Cmd1 help string.                                       │
-        │ cmd2       Cmd2 help string.                                       │
-        │ meta-cmd   Meta cmd help string.                                   │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ cmd1         Cmd1 help string.                                     │
+        │ cmd2         Cmd2 help string.                                     │
+        │ meta-cmd     Meta cmd help string.                                 │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Session Arguments ────────────────────────────────────────────────╮
         │ TOKENS                                                             │
@@ -1853,11 +1890,11 @@ def test_help_print_commands_plus_meta_short(app, console):
         Root Default Command Short Description.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ cmd1       Cmd1 help string.                                       │
-        │ cmd2       Cmd2 help string.                                       │
-        │ meta-cmd   Meta cmd help string.                                   │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ cmd1         Cmd1 help string.                                     │
+        │ cmd2         Cmd2 help string.                                     │
+        │ meta-cmd     Meta cmd help string.                                 │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  RDP --rdp  RDP description. [required]                          │
@@ -1934,9 +1971,9 @@ def test_help_restructuredtext(app, console, normalize_trailing_whitespace):
          • bulletpoint 2
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        This is bold.                                           │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo          This is bold.                                         │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -1988,9 +2025,9 @@ def test_help_markdown(app, console, normalize_trailing_whitespace):
          • bulletpoint 2
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        This is bold.                                           │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo          This is bold.                                         │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -2035,9 +2072,9 @@ def test_help_rich(app, console, normalize_trailing_whitespace):
         This text is red.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        This is italic.                                         │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo          This is italic.                                       │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -2096,9 +2133,9 @@ def test_help_plaintext(app, console):
         * point 2
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ foo        This is [italic]italic[/italic].                        │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ foo          This is [italic]italic[/italic].                      │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -2191,8 +2228,8 @@ def test_issue_373_help_space_with_meta_app(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  VALUE --value  [required]                                       │
@@ -2369,8 +2406,8 @@ def test_help_epilogue_basic(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
 
         This is an epilogue.
@@ -2406,8 +2443,8 @@ def test_help_epilogue_none(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -2428,8 +2465,8 @@ def test_help_epilogue_empty_string(app, console):
         App Help String Line 1.
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -51,8 +51,8 @@ def test_group_custom_table_spec(console: Console):
             Usage: test_help_customization [ARGS]
 
             ╭─ Commands ─────────────────────────────────────────────────────────╮
-            │ --help -h  Display this message and exit.                          │
-            │ --version  Display application version.                            │
+            │ --help (-h)  Display this message and exit.                        │
+            │ --version    Display application version.                          │
             ╰────────────────────────────────────────────────────────────────────╯
             ╭─ Custom Options ───────────────────────────────────────────────────╮
             │ These are custom options.                                          │
@@ -97,8 +97,8 @@ def test_group_custom_panel_spec(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╔═ Styled Options ═══════════════════════════════════════════════════╗
         ║                                                                    ║
@@ -152,8 +152,8 @@ def test_group_custom_columns(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Advanced Options ─────────────────────────────────────────────────╮
         │ Option             Type  Description                               │
@@ -197,8 +197,8 @@ def test_default_group_with_custom_spec(app, console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╔═ Parameters ═══════════════════════════════════════════════════════╗
         ║ ┌───────────────────┬────────────────────────────────────────────┐ ║
@@ -245,10 +245,10 @@ def test_command_group_with_custom_spec(console: Console):
         Usage: test_help_customization COMMAND
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ bar        Bar command.                                            │
-        │ foo        Foo command.                                            │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ bar          Bar command.                                          │
+        │ foo          Foo command.                                          │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -284,8 +284,8 @@ def test_panel_spec_custom_title(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Custom Title ─────────────────────────────────────────────────────╮
         │ OPTION --option  [default: default]                                │
@@ -334,8 +334,8 @@ def test_mixed_groups_with_different_specs(console: Console):
         Usage: test_help_customization NAME [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Optional ─────────────────────────────────────────────────────────╮
         │ VERBOSE --verbose         [default: False]                         │
@@ -381,8 +381,8 @@ def test_table_show_lines_with_box(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Options ──────────────────────────────────────────────────────────╮
         │                                                                    │
@@ -424,8 +424,8 @@ def test_table_headers_with_default_columns(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Config ───────────────────────────────────────────────────────────╮
         │ Option         Description                                         │
@@ -473,8 +473,8 @@ def test_table_headers_suppressed_when_all_empty(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Settings ─────────────────────────────────────────────────────────╮
         │ SETTING --setting  A configuration setting [default: default]      │
@@ -527,8 +527,8 @@ def test_table_headers_with_non_empty_headers(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Settings ─────────────────────────────────────────────────────────╮
         │ Option             Description                                     │
@@ -640,8 +640,8 @@ def test_custom_help_formatter_basic(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         +--------------------------------------------------------------------+
         |                           Custom Options                           |
@@ -829,8 +829,8 @@ def test_multiple_groups_different_formatters(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         >> Custom Group
            -> OPT1 --opt1: [default: val1]
@@ -877,8 +877,8 @@ def test_custom_formatter_protocol_validation(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         [Minimal]
           OPTION --option
@@ -1000,8 +1000,8 @@ def test_custom_formatter_receives_correct_arguments(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         Panel: Validated Group
           Entry: TEST-PARAM --test-param
@@ -1039,8 +1039,8 @@ def test_plain_formatter_with_rich_text(console: Console):
         Usage: test_help_customization [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         Plain Options:
           OPTION, --option: Test option [default: value]
@@ -1176,8 +1176,8 @@ def test_plain_formatter_parameter_with_metadata(console: Console):
         Usage: test_help_customization MODE OUTPUT
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         Settings:
           MODE, --mode: Operation mode [choices: fast, slow, medium] [env var:

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -82,9 +82,9 @@ def test_meta_app_nested_root_help(nested_meta_app, console, queue):
         Usage: test_app COMMAND
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ subapp     This is subapp's help.                                  │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ subapp       This is subapp's help.                                │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )
@@ -184,8 +184,8 @@ def test_meta_app_inheriting_root_default_parameter(app, console):
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
         │ foo                                                                │
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Global options ───────────────────────────────────────────────────╮
         │ --flag1  [default: False]                                          │

--- a/tests/test_name_transform.py
+++ b/tests/test_name_transform.py
@@ -152,8 +152,8 @@ def test_parameter_name_transform_help(app, console):
         Usage: test_name_transform --b_a_r INT
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  --b_a_r  [required]                                             │

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -156,8 +156,8 @@ def test_bind_pydantic_basemodel_help(app, console):
         Usage: test_pydantic USER.ID USER.SIGNUP-TS USER.TASTES [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.ID --user.id          [required]                           │
@@ -428,8 +428,8 @@ def test_pydantic_annotated_field_discriminator(app, assert_parse_args, console)
         Usage: test_pydantic [ARGS]
 
         ╭─ Commands ─────────────────────────────────────────────────────────╮
-        │ --help -h  Display this message and exit.                          │
-        │ --version  Display application version.                            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ DATASET.TYPE               [choices: image, video]                 │


### PR DESCRIPTION
Command aliases in help output were space-separated, making them hard to distinguish from separate commands:

```
│ greet g greet-alias          Say hello.  │
```

Now uses argparse-style parentheses format:

```
╭─ Commands ─────────────────────────────────────────────────────────╮
│ bye (b)                 Say goodbye.                               │
│ greet (g, greet-alias)  Say hello.                                 │
│ solo                    No aliases.                                │
│ --help (-h)             Display this message and exit.             │
│ --version               Display application version.               │
╰────────────────────────────────────────────────────────────────────╯
```

- Added `CommandNameRenderer` class for command-specific formatting
- Formatter for parameters remains unchanged (dashes make them visually distinct)