### PR TITLE
Fix parsing of double-digit negative numbers.

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -140,7 +140,8 @@ def _parse_kw_and_flags(
             matches.append(_KeywordMatch(cli_option, *argument_collection.match(cli_option)))
         except ValueError:
             # Length has to be greater than 2 (hyphen + character) to be exploded.
-            if allow_combined_flags and len(token) > 2:
+            # Also exclude numeric values (e.g., -10, -3.14) from combined flag parsing.
+            if allow_combined_flags and len(token) > 2 and is_option_like(token, allow_numbers=False):
                 # GNU-style combined short options: process left-to-right
                 # Once we hit an option that takes a value, the rest is the value
                 chars = cli_option.lstrip("-")

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -257,6 +257,32 @@ def test_short_integer_flag(app, assert_parse_args):
 
 
 @pytest.mark.parametrize(
+    "cmd_str,expected",
+    [
+        ("-9", -9),
+        ("-10", -10),  # Multi-digit negatives should NOT be treated as combined short flags
+        ("-100", -100),
+        ("-3.14", -3.14),
+        ("-1e5", -1e5),
+        ("-1.5e-3", -1.5e-3),
+    ],
+)
+def test_negative_number_not_combined_short_flags(app, cmd_str, expected, assert_parse_args):
+    """Negative numbers should be parsed as values, not as combined short flags.
+
+    Regression test for issue where -10 was incorrectly interpreted as combined
+    short flags -1 and -0, while -9 worked because len("-9") == 2 doesn't trigger
+    combined flag parsing (which requires len > 2).
+    """
+
+    @app.default
+    def main(value: float):
+        pass
+
+    assert_parse_args(main, cmd_str, expected)
+
+
+@pytest.mark.parametrize(
     "cmd_str",
     [
         "foo --age 10",


### PR DESCRIPTION
Fixing parsing of greater-than-single-digit negative numbers. Originally reported [here](https://github.com/BrianPugh/cyclopts/issues/707#issuecomment-3639575464).