### PR TITLE
List correct values when unsupported value passed to Enum param

### DIFF
--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -243,7 +243,8 @@ class CoercionError(CycloptsError):
             choices = "{" + ", ".join(repr(x) for x in get_args(self.target_type)) + "}"
             target_type_name = f"one of {choices}"
         elif isinstance(self.target_type, type) and issubclass(self.target_type, Enum):
-            choices = "{" + ", ".join(repr(x) for x in self.target_type._member_names_) + "}"
+            nt = self.argument.parameter.name_transform
+            choices = "{" + ", ".join(repr(nt(x)) for x in self.target_type.__members__) + "}"
             target_type_name = f"one of {choices}"
         else:
             target_type_name = get_hint_name(self.target_type)


### PR DESCRIPTION
This PR shows the available values of a CLI parameter when an incorrect value is passed. Closes #744