### PR TITLE
avoid resolving lazy commands during --help

### DIFF
--- a/cyclopts/command_spec.py
+++ b/cyclopts/command_spec.py
@@ -42,6 +42,8 @@ class CommandSpec:
     import_path: str
     name: str | tuple[str, ...] | None = None
     app_kwargs: dict[str, Any] = Factory(dict)
+    help: str | None = None
+    show: bool = True
 
     _resolved: "App | None" = field(init=False, default=None, repr=False)
 

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1313,7 +1313,16 @@ class App:
 
             # Create CommandSpec with the resolved name (first name if multiple)
             # The name will be used when wrapping functions in an App
-            spec = CommandSpec(import_path=obj, name=name[0] if name else None, app_kwargs=kwargs)
+            # Extract CommandSpec-specific fields from kwargs before storing
+            spec_help: str | None = kwargs.pop("help", None)  # type: ignore[assignment]
+            spec_show: bool = kwargs.pop("show", True)  # type: ignore[assignment]
+            spec = CommandSpec(
+                import_path=obj,
+                name=name[0] if name else None,
+                app_kwargs=kwargs,
+                help=spec_help,
+                show=spec_show,
+            )
 
             # Register the CommandSpec
             for n in name + alias:

--- a/cyclopts/group_extractors.py
+++ b/cyclopts/group_extractors.py
@@ -82,6 +82,20 @@ def groups_from_app(app: "App", resolve_lazy: bool = False) -> list[tuple[Group,
         cmd = app._get_item(name, recurse_meta=True)
         if isinstance(cmd, CommandSpec) and not cmd.is_resolved:
             if not resolve_lazy:
+                if not cmd.show:
+                    continue
+                # Create a lightweight stub App for help display without importing
+                cmd_id = id(cmd)
+                app_names.setdefault(cmd_id, []).append(name)
+                if cmd_id not in unique_apps:
+                    from cyclopts.core import App as _App
+
+                    unique_apps[cmd_id] = _App(
+                        name=name,
+                        help=cmd.help or "",
+                        version_flags=[],
+                        help_flags=[],
+                    )
                 continue
         subapp = app[name]
         app_id = id(subapp)

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -272,7 +272,9 @@ def format_usage(
     for command in command_chain:
         app = app[command]
 
-    if any(app[x].show for x in app._registered_commands):
+    # Check for non-help/version commands without resolving lazy CommandSpecs.
+    help_version_flags = {*app.help_flags, *app.version_flags}
+    if any(x not in help_version_flags for x in app):
         usage.append("COMMAND")
 
     if app.default_command:


### PR DESCRIPTION
## Context

We're using cyclopts' lazy loading for Prefect's CLI (~29 subcommands). While profiling startup time, we found that `format_usage()` resolves all lazy commands via `_registered_commands` → `__getitem__`, even though `groups_from_app()` avoids resolution with its `resolve_lazy` parameter (from #710).

As you [pointed out](https://github.com/BrianPugh/cyclopts/pull/757#issuecomment-3975227056), the initial fix had an unintended side effect: lazy commands disappeared from the help page entirely, since `groups_from_app(resolve_lazy=False)` skips unresolved commands and `format_usage` was no longer resolving them either.

## What this PR does

Two changes that work together:

1. **`format_usage`**: replaces the resolving visibility check with the simpler approach you suggested — checking whether any iterator name isn't a help/version flag.

2. **`CommandSpec` + `groups_from_app`**: adds optional `help` and `show` fields to `CommandSpec` so metadata can be provided at registration time (e.g. `app.command("mod:func", name="cmd", help="...")`). `groups_from_app` creates lightweight stub Apps for unresolved lazy commands, so they appear in help output with their pre-specified help text — no module import needed.

This way, lazy commands show up in `--help` (with descriptions if `help=` is provided at registration), without triggering resolution.

## Test plan

- `test_format_usage_does_not_resolve_lazy_commands` — regression test for the `format_usage` path
- `test_lazy_command_non_leaf_help_does_not_resolve` — the case you identified, now passing (lazy children listed without resolution)
- `test_groups_from_app_resolve_lazy` — stubs appear with pre-specified help text
- `test_groups_from_app_lazy_hidden` — `show=False` commands excluded
- Updated existing tests that assumed `--help` would resolve lazy commands
- Full test suite passes (2012 passed, 35 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)