### PR TITLE
better 'just-works' behavior for oh-my-zsh users.

### DIFF
--- a/cyclopts/completion/install.py
+++ b/cyclopts/completion/install.py
@@ -4,12 +4,40 @@ This module handles the installation of completion scripts to shell-specific
 locations and the updating of shell RC files to load completions.
 """
 
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Literal
 
 from cyclopts.parameter import Parameter
+
+
+def _detect_omz_completions_dir() -> Path | None:
+    """Detect oh-my-zsh custom completions directory.
+
+    Uses ``$ZSH_CUSTOM/completions`` (the recommended location for user
+    completions in oh-my-zsh). Falls back to ``$ZSH/custom/completions``
+    when ``$ZSH_CUSTOM`` is not set.
+
+    Returns
+    -------
+    Path | None
+        Path to the oh-my-zsh custom completions directory, or None if
+        oh-my-zsh is not detected.
+    """
+    zsh_custom_str = os.environ.get("ZSH_CUSTOM")
+    if zsh_custom_str:
+        zsh_custom = Path(zsh_custom_str)
+        if zsh_custom.is_dir():
+            return zsh_custom / "completions"
+    zsh_dir_str = os.environ.get("ZSH")
+    if not zsh_dir_str:
+        return None
+    zsh_dir = Path(zsh_dir_str)
+    if zsh_dir.is_dir():
+        return zsh_dir / "custom" / "completions"
+    return None
 
 
 def get_default_completion_path(shell: Literal["zsh", "bash", "fish"], prog_name: str) -> Path:
@@ -34,6 +62,11 @@ def get_default_completion_path(shell: Literal["zsh", "bash", "fish"], prog_name
     """
     home = Path.home()
     if shell == "zsh":
+        omz_completions = _detect_omz_completions_dir()
+        if omz_completions is not None:
+            omz_completions.mkdir(parents=True, exist_ok=True)
+            return omz_completions / f"_{prog_name}"
+        # Vanilla zsh fallback
         zsh_completions = home / ".zsh" / "completions"
         zsh_completions.mkdir(parents=True, exist_ok=True)
         return zsh_completions / f"_{prog_name}"
@@ -74,6 +107,8 @@ def add_to_rc_file(script_path: Path, prog_name: str, shell: Literal["bash", "zs
         config_line = f'[ -f "{script_path}" ] && . "{script_path}"'
         comment = f"# Load {prog_name} completion"
     elif shell == "zsh":
+        if _detect_omz_completions_dir():
+            return False
         rc_file = Path.home() / ".zshrc"
         completion_dir = script_path.parent
         config_line = f"fpath=({completion_dir} $fpath)"
@@ -91,14 +126,19 @@ def add_to_rc_file(script_path: Path, prog_name: str, shell: Literal["bash", "zs
             return False
         elif config_line in content:
             return False
-        needs_newline = content and not content.endswith("\n")
     else:
-        needs_newline = False
+        content = ""
 
-    with rc_file.open("a") as f:
-        if needs_newline:
-            f.write("\n")
-        f.write(f"{comment}\n{config_line}\n")
+    if shell == "zsh":
+        # Prepend to ensure fpath is set before any compinit call
+        rc_file.write_text(f"{comment}\n{config_line}\n{content}")
+    else:
+        # Bash: append
+        needs_newline = content and not content.endswith("\n")
+        with rc_file.open("a") as f:
+            if needs_newline:
+                f.write("\n")
+            f.write(f"{comment}\n{config_line}\n")
 
     return True
 
@@ -158,7 +198,10 @@ def create_install_completion_command(
         print(f"✓ Completion script installed to {install_path}")
 
         if shell == "zsh":
-            if add_to_startup:
+            if _detect_omz_completions_dir():
+                print("✓ Detected oh-my-zsh: completions directory is already in $fpath.")
+                print("\nRestart your shell or run: exec zsh")
+            elif add_to_startup:
                 zshrc = Path.home() / ".zshrc"
                 completion_dir = install_path.parent
                 print(f"✓ Added {completion_dir} to fpath in {zshrc}")

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2356,7 +2356,7 @@ class App:
             Shell type for completion. If not specified, attempts to auto-detect current shell.
         output : Path | None
             Output path for the completion script. If not specified, uses shell-specific default:
-            - zsh: ~/.zsh/completions/_<prog_name>
+            - zsh: ~/.zsh/completions/_<prog_name> (or $ZSH_CUSTOM/completions/_<prog_name> with oh-my-zsh)
             - bash: ~/.local/share/bash-completion/completions/<prog_name>
             - fish: ~/.config/fish/completions/<prog_name>.fish
         add_to_startup : bool

--- a/tests/completion/test_install.py
+++ b/tests/completion/test_install.py
@@ -15,7 +15,17 @@ def temp_home(tmp_path, monkeypatch):
         monkeypatch.setenv("USERPROFILE", str(tmp_path))
     else:
         monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("ZSH", raising=False)
     return tmp_path
+
+
+@pytest.fixture
+def omz_dir(temp_home, monkeypatch):
+    """Create a fake oh-my-zsh installation with $ZSH set."""
+    omz = temp_home / ".oh-my-zsh"
+    (omz / "custom").mkdir(parents=True)
+    monkeypatch.setenv("ZSH", str(omz))
+    return omz
 
 
 def test_install_completion_bash_add_to_startup_true(temp_home):
@@ -323,3 +333,97 @@ def test_install_completion_command_fish(temp_home, monkeypatch, capsys):
     assert "Completion script installed" in captured.out
     assert "automatically loaded in fish" in captured.out
     assert "source ~/.config/fish/config.fish" in captured.out
+
+
+def test_install_completion_zsh_ohmyzsh_default_path(omz_dir):
+    """Test that $ZSH set with valid dir installs to $ZSH/custom/completions/_testapp."""
+    app = App(name="testapp")
+    install_path = app.install_completion(shell="zsh", add_to_startup=True)
+
+    assert install_path == omz_dir / "custom" / "completions" / "_testapp"
+    assert install_path.exists()
+
+
+def test_install_completion_zsh_ohmyzsh_zsh_custom_env(omz_dir, temp_home, monkeypatch):
+    """Test that $ZSH_CUSTOM takes precedence over $ZSH/custom."""
+    custom_dir = temp_home / "my-custom-omz"
+    custom_dir.mkdir()
+    monkeypatch.setenv("ZSH_CUSTOM", str(custom_dir))
+
+    app = App(name="testapp")
+    install_path = app.install_completion(shell="zsh", add_to_startup=True)
+
+    assert install_path == custom_dir / "completions" / "_testapp"
+    assert install_path.exists()
+
+
+def test_install_completion_zsh_ohmyzsh_no_zshrc_modification(omz_dir, temp_home):
+    """Test that .zshrc is not created/modified when oh-my-zsh detected."""
+    zshrc = temp_home / ".zshrc"
+    app = App(name="testapp")
+    app.install_completion(shell="zsh", add_to_startup=True)
+
+    assert not zshrc.exists()
+
+
+def test_install_completion_zsh_ohmyzsh_dir_missing(temp_home, monkeypatch):
+    """Test that $ZSH pointing to nonexistent dir falls back to vanilla path."""
+    monkeypatch.setenv("ZSH", str(temp_home / "nonexistent"))
+
+    app = App(name="testapp")
+    install_path = app.install_completion(shell="zsh", add_to_startup=False)
+
+    expected = temp_home / ".zsh" / "completions" / "_testapp"
+    assert install_path == expected
+    assert install_path.exists()
+
+
+def test_install_completion_zsh_add_to_startup_prepends(temp_home):
+    """Test that for vanilla zsh, fpath line appears before existing .zshrc content."""
+    app = App(name="testapp")
+    zshrc = temp_home / ".zshrc"
+
+    existing_content = "# Existing config\nautoload -Uz compinit && compinit\n"
+    zshrc.write_text(existing_content)
+
+    app.install_completion(shell="zsh", add_to_startup=True)
+
+    zshrc_content = zshrc.read_text()
+    fpath_pos = zshrc_content.index("fpath=")
+    existing_pos = zshrc_content.index("# Existing config")
+    assert fpath_pos < existing_pos, "fpath line should be prepended before existing content"
+
+
+def test_install_completion_zsh_ohmyzsh_message(omz_dir, monkeypatch, capsys):
+    """Test that printed output mentions oh-my-zsh and doesn't mention .zshrc."""
+    app = App(name="testapp")
+    app.register_install_completion_command(add_to_startup=True)
+
+    monkeypatch.setattr("cyclopts.completion.detect.detect_shell", lambda: "zsh")
+
+    with patch("sys.exit"):
+        try:
+            app(["--install-completion"], exit_on_error=False)
+        except SystemExit:
+            pass
+
+    captured = capsys.readouterr()
+    assert "oh-my-zsh" in captured.out
+    assert ".zshrc" not in captured.out
+    assert "exec zsh" in captured.out
+
+
+def test_install_completion_bash_add_to_startup_appends(temp_home):
+    """Regression test: bash still appends to .bashrc."""
+    app = App(name="testapp")
+    bashrc = temp_home / ".bashrc"
+
+    existing_content = "# Existing bash config\nexport PATH=/usr/local/bin:$PATH\n"
+    bashrc.write_text(existing_content)
+
+    app.install_completion(shell="bash", add_to_startup=True)
+
+    bashrc_content = bashrc.read_text()
+    existing_pos = bashrc_content.index("# Existing bash config")
+    completion_pos = bashrc_content.index("# Load testapp completion")
+    assert existing_pos < completion_pos, "bash completion should be appended after existing content"


### PR DESCRIPTION
My solution to the discussion [here](https://github.com/BrianPugh/cyclopts/issues/89#issuecomment-3977173517).

> I'm using oh-my-zsh and I had to move the completion script from the default install location ~/.zsh/completions to "$ZSH_CUSTOM"/completions. I also removed the call to compinit from my .zshrc. This was on my WSL2 installation. Everything works great now.

I want Cyclopts to "just work" for the majority of users, and that seems like changing the install locaiton for oh-my-zsh users. It's a small amount of code and not much of a maintenance burden. Shell completion is always tricky, and so it's nice if the user doesn't have to think about it too much.

@onyx-and-iris I was wondering if you could try/review this? Thanks!