### PR TITLE
bugfix: Don't allow keyword/positional interleaving with positional-only arguments.

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -88,8 +88,26 @@ def _parse_kw_and_flags(
     *,
     end_of_options_delimiter: str = "--",
     stop_at_first_unknown: bool = False,
-):
+) -> tuple[list[str], int | None]:
+    """Extract keyword arguments and flags from the token stream.
+
+    Returns
+    -------
+    unused_tokens: list[str]
+        Tokens not consumed by any keyword or flag.
+    contiguous_positional_count: int | None
+        Number of leading contiguous non-option tokens before the first gap
+        caused by keyword extraction. ``None`` if all non-option tokens are
+        contiguous (i.e. no keywords were interleaved among positional tokens).
+
+        For example, given ``a b c --bar 8 --baz 10 d``, the unused tokens are
+        ``['a', 'b', 'c', 'd']`` with original indices ``[0, 1, 2, 6]``.
+        The gap between indices 2 and 6 yields ``contiguous_positional_count=3``.
+        This is used by ``_parse_pos`` to prevent positional-only list parameters
+        from consuming tokens that appeared after keyword arguments.
+    """
     unused_tokens, positional_only_tokens = [], []
+    unused_token_original_indices: list[int] = []
     skip_next_iterations = 0
     if end_of_options_delimiter:
         try:
@@ -109,8 +127,10 @@ def _parse_kw_and_flags(
             if stop_at_first_unknown:
                 # Stop parsing and return all remaining tokens as unused
                 unused_tokens.extend(tokens[i:])
+                unused_token_original_indices.extend(range(i, len(tokens)))
                 break
             unused_tokens.append(token)
+            unused_token_original_indices.append(i)
             continue
 
         cli_values: list[str] = []
@@ -176,8 +196,9 @@ def _parse_kw_and_flags(
                         # Unknown flag
                         if stop_at_first_unknown:
                             unused_tokens.extend(tokens[i:])
-                            return unused_tokens
+                            return unused_tokens, None
                         unused_tokens.append(test_flag)
+                        unused_token_original_indices.append(i)
                         position += 1
 
                 if not matches:
@@ -187,8 +208,9 @@ def _parse_kw_and_flags(
                 if stop_at_first_unknown:
                     # Unknown option, stop parsing and return all remaining tokens
                     unused_tokens.extend(tokens[i:])
-                    return unused_tokens
+                    return unused_tokens, None
                 unused_tokens.append(token)
+                unused_token_original_indices.append(i)
                 continue
         for match_index, match in enumerate(matches):
             # For GNU-style combined options, add the attached value only when processing
@@ -339,8 +361,18 @@ def _parse_kw_and_flags(
                             CliToken(keyword=match.matched_token, value=cli_value, index=index, keys=match.keys)
                         )
 
+    # Compute the number of contiguous positional (non-option-like) unused tokens
+    # before the first gap caused by keyword extraction. This prevents positional-only
+    # list parameters from consuming tokens that appeared after keyword arguments.
+    # Only set when a gap is detected; None means no gap (all tokens are contiguous).
+    contiguous_positional_count: int | None = None
+    for j in range(1, len(unused_token_original_indices)):
+        if unused_token_original_indices[j] != unused_token_original_indices[j - 1] + 1:
+            contiguous_positional_count = j
+            break
+
     unused_tokens.extend(positional_only_tokens)
-    return unused_tokens
+    return unused_tokens, contiguous_positional_count
 
 
 def _future_positional_only_token_count(argument_collection: ArgumentCollection, starting_index: int) -> int:
@@ -372,7 +404,26 @@ def _parse_pos(
     tokens: list[str],
     *,
     end_of_options_delimiter: str = "--",
+    contiguous_positional_count: int | None = None,
 ) -> list[str]:
+    """Assign positional tokens to positional parameters.
+
+    Parameters
+    ----------
+    argument_collection: ArgumentCollection
+        Arguments whose keyword/flag tokens have already been consumed.
+    tokens: list[str]
+        Unused tokens from ``_parse_kw_and_flags``.
+    end_of_options_delimiter: str
+        Delimiter after which all tokens are forced positional.
+    contiguous_positional_count: int | None
+        If not ``None``, the number of leading contiguous positional tokens
+        that were adjacent in the original CLI input (before keyword extraction
+        created a gap). Used to cap how many tokens a ``POSITIONAL_ONLY``
+        list/iterable parameter may consume, preventing it from greedily
+        swallowing tokens that originally appeared after keyword arguments.
+        See ``_parse_kw_and_flags`` for how this value is computed.
+    """
     prior_positional_or_keyword_supplied_as_keyword_arguments = []
 
     if not tokens:
@@ -413,6 +464,13 @@ def _parse_pos(
 
             # Need to see how many tokens we need to leave for subsequent POSITIONAL_ONLY parameters.
             n_tokens_to_leave = _future_positional_only_token_count(argument_collection, i + 1)
+
+            # Cap at the contiguous positional count to prevent consuming tokens
+            # that appeared after keyword arguments (issue #763).
+            if contiguous_positional_count is not None:
+                n_tokens_to_leave = max(
+                    n_tokens_to_leave, len(tokens_and_force_positional) - contiguous_positional_count
+                )
         else:
             n_tokens_to_leave = 0
 
@@ -519,11 +577,14 @@ def create_bound_arguments(
     unused_tokens = tokens
 
     try:
-        unused_tokens = _parse_kw_and_flags(
+        unused_tokens, contiguous_positional_count = _parse_kw_and_flags(
             argument_collection, unused_tokens, end_of_options_delimiter=end_of_options_delimiter
         )
         unused_tokens = _parse_pos(
-            argument_collection, unused_tokens, end_of_options_delimiter=end_of_options_delimiter
+            argument_collection,
+            unused_tokens,
+            end_of_options_delimiter=end_of_options_delimiter,
+            contiguous_positional_count=contiguous_positional_count,
         )
 
         _parse_env(argument_collection)

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1165,7 +1165,7 @@ class App:
 
                 # Try to consume tokens with this meta app's parameters
                 # stop_at_first_unknown=True ensures we only consume contiguous leading options
-                unused_tokens = _parse_kw_and_flags(
+                unused_tokens, _ = _parse_kw_and_flags(
                     argument_collection,
                     unused_tokens,
                     end_of_options_delimiter=end_of_options_delimiter,

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -983,7 +983,7 @@ def test_positional_only_list_interleaved_with_keywords_error(app):
     def main(foo: list[str] | None = None, /, *, bar: int = 0, baz: int = 0):
         pass
 
-    with pytest.raises((ArgumentOrderError, UnusedCliTokensError)):
+    with pytest.raises(UnusedCliTokensError):
         app.parse_args("a b c --bar 8 --baz 10 d", print_error=False, exit_on_error=False)
 
 
@@ -1015,3 +1015,39 @@ def test_positional_only_list_keywords_first(app):
     _, actual_bind, _ = app.parse_args("--bar 8 --baz 10 a b c d", print_error=False, exit_on_error=False)
     assert actual_bind.args == (["a", "b", "c", "d"],)
     assert actual_bind.kwargs == {"bar": 8, "baz": 10}
+
+
+def test_positional_only_list_interleaved_with_delimiter(app):
+    """Tokens after -- should still be consumed even with interleaving before the delimiter.
+
+    Regression test for issue #763.
+    """
+
+    @app.default
+    def main(foo: list[str] | None = None, /, *, bar: int = 0):
+        pass
+
+    _, actual_bind, _ = app.parse_args("a b --bar 8 -- d e", print_error=False, exit_on_error=False)
+    assert actual_bind.args == (["a", "b", "d", "e"],)
+    assert actual_bind.kwargs == {"bar": 8}
+
+
+def test_positional_only_list_and_scalar_interleaved_error(app):
+    """Multiple positional-only params (list + scalar) should also reject interleaving.
+
+    Regression test for issue #763.
+    """
+    from pathlib import Path
+
+    @app.default
+    def main(inputs: list[str], output: Path, /, *, verbose: bool = False):
+        pass
+
+    # Non-interleaved: should work
+    _, actual_bind, _ = app.parse_args("a b c out.csv --verbose", print_error=False, exit_on_error=False)
+    assert actual_bind.args == (["a", "b", "c"], Path("out.csv"))
+    assert actual_bind.kwargs == {"verbose": True}
+
+    # Interleaved: should error
+    with pytest.raises(UnusedCliTokensError):
+        app.parse_args("a b --verbose c out.csv", print_error=False, exit_on_error=False)


### PR DESCRIPTION
Addresses #763. @ShaiAvr can you please give this a try, thanks! After this PR  I think i'll do a patch release, and then tackle #765 in another PR for a feature release.