### PR TITLE
Fix `ValueError` when parsing pre-release Pydantic versions

### DIFF
--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -52,7 +52,7 @@ from cyclopts.field_info import (
 )
 from cyclopts.parameter import ITERATIVE_BOOL_IMPLICIT_VALUE, Parameter
 from cyclopts.token import Token
-from cyclopts.utils import UNSET, grouper, is_builtin
+from cyclopts.utils import UNSET, grouper, is_builtin, parse_version
 
 from .utils import (
     enum_flag_from_dict,
@@ -786,10 +786,12 @@ class Argument:
         """
         assert isinstance(self.parameter.validator, tuple)
 
+        # Only use pydantic validation if pydantic v2+ is available.
+        # Pydantic v1 has an incompatible API (e.g. no TypeAdapter).
         if "pydantic" in sys.modules:
             import pydantic
 
-            pydantic_version = tuple(int(x) for x in pydantic.__version__.split("."))
+            pydantic_version = parse_version(pydantic.__version__)
             if pydantic_version < (2,):
                 pydantic = None
         else:

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -451,6 +451,22 @@ def create_error_console_from_console(console: "Console") -> "Console":
     )
 
 
+def parse_version(version_string: str) -> tuple[int, ...]:
+    """Parse a PEP 440 version string into a tuple of ints, stripping pre-release suffixes.
+
+    Parameters
+    ----------
+    version_string: str
+        A version string like ``"2.11.2"`` or ``"2.0.0b2"``.
+
+    Returns
+    -------
+    tuple[int, ...]
+        Tuple of the numeric components, e.g. ``(2, 11, 2)`` or ``(2, 0, 0)``.
+    """
+    return tuple(int(m.group()) for x in version_string.split(".") if (m := re.match(r"\d+", x)))
+
+
 def import_app(module_path: str):
     """Import a Cyclopts App from a module path.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cyclopts.utils import Sentinel, _pascal_to_snake, grouper
+from cyclopts.utils import Sentinel, _pascal_to_snake, grouper, parse_version
 
 
 def test_grouper():
@@ -75,3 +75,18 @@ def test_pascal_to_snake(input_str, expected):
     - Converts all characters to lowercase
     """
     assert _pascal_to_snake(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "version_string,expected",
+    [
+        ("2.11.2", (2, 11, 2)),
+        ("2.0.0b2", (2, 0, 0)),
+        ("2.11.0a1", (2, 11, 0)),
+        ("3.0.0rc1", (3, 0, 0)),
+        ("1.10.19", (1, 10, 19)),
+        ("2.0.0.dev1", (2, 0, 0)),
+    ],
+)
+def test_parse_version(version_string, expected):
+    assert parse_version(version_string) == expected


### PR DESCRIPTION
Fixes #774