### PR TITLE
Convenience Types: `NormFloat`, `SignedNormFloat`, `PercentInt`

### DIFF
--- a/cyclopts/types.py
+++ b/cyclopts/types.py
@@ -78,7 +78,7 @@ __all__ = [
     "HexUInt64",
     "NormFloat",
     "SignedNormFloat",
-    "PercentageInt",
+    "PercentInt",
     # Json,
     "Json",
     # Web
@@ -269,7 +269,7 @@ NormFloat = Annotated[float, Parameter(validator=validators.Number(gte=0, lte=1)
 SignedNormFloat = Annotated[float, Parameter(validator=validators.Number(gte=-1, lte=1))]
 "A float in the range ``[-1, 1]``."
 
-PercentageInt = Annotated[int, Parameter(validator=validators.Number(gte=0, lte=100))]
+PercentInt = Annotated[int, Parameter(validator=validators.Number(gte=0, lte=100))]
 "An int in the range ``[0, 100]``."
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2187,7 +2187,7 @@ All of these types will also work on sequence of numbers (e.g. ``tuple[int, int]
 
 .. autodata:: cyclopts.types.NonPositiveInt
 
-.. autodata:: cyclopts.types.PercentageInt
+.. autodata:: cyclopts.types.PercentInt
 
 .. autodata:: cyclopts.types.UInt8
 

--- a/tests/types/test_types_number.py
+++ b/tests/types/test_types_number.py
@@ -10,7 +10,7 @@ from cyclopts.types import (
     HexUInt32,
     HexUInt64,
     NormFloat,
-    PercentageInt,
+    PercentInt,
     SignedNormFloat,
     UInt8,
 )
@@ -134,9 +134,9 @@ def test_signed_norm_float(app, assert_parse_args):
         app.parse_args("1.1", exit_on_error=False)
 
 
-def test_percentage_int(app, assert_parse_args):
+def test_percent_int(app, assert_parse_args):
     @app.default
-    def default(val: PercentageInt):
+    def default(val: PercentInt):
         pass
 
     assert_parse_args(default, "0", 0)


### PR DESCRIPTION
- NormFloat - A float in the range `[0, 1]`
- SignedNormFloat - A float in the range `[-1, 1]`
- PercentInt - An int in the range `[0, 100]`