### PR TITLE
Add more rich formatting to `CycloptsError` printing.

### DIFF
--- a/cyclopts/__init__.pyi
+++ b/cyclopts/__init__.pyi
@@ -22,6 +22,7 @@ from cyclopts.exceptions import DocstringError as DocstringError
 from cyclopts.exceptions import MissingArgumentError as MissingArgumentError
 from cyclopts.exceptions import MixedArgumentError as MixedArgumentError
 from cyclopts.exceptions import RepeatArgumentError as RepeatArgumentError
+from cyclopts.exceptions import RequiresEqualsError as RequiresEqualsError
 from cyclopts.exceptions import UnknownCommandError as UnknownCommandError
 from cyclopts.exceptions import UnknownOptionError as UnknownOptionError
 from cyclopts.exceptions import UnusedCliTokensError as UnusedCliTokensError

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -155,8 +155,9 @@ class ValidationError(CycloptsError):
     value: Any = cyclopts.utils.UNSET
     """Converted value that failed validation."""
 
-    def __str__(self):
-        message = ""
+    def _segments(self) -> Iterator[tuple[str, str]]:
+        body: list[tuple[str, str]] = []
+
         if self.argument:
             value = self.argument.value if self.value is cyclopts.utils.UNSET else self.value
             try:
@@ -166,23 +167,46 @@ class ValidationError(CycloptsError):
             else:
                 provided_by = "" if not token.source or token.source == "cli" else f" provided by {token.source}"
                 name = token.keyword if token.keyword else self.argument.name.lstrip("-").upper()
-                message = f'Invalid value "{value}" for {name}{provided_by}.'
+                body.append(('Invalid value "', ""))
+                body.append((f"{value}", _STYLE_VALUE))
+                body.append(('" for ', ""))
+                body.append((name, _STYLE_NAME))
+                if provided_by:
+                    body.append((provided_by, _STYLE_DIM))
+                body.append((".", ""))
         elif self.group:
             if self.group.name:
-                message = f"Invalid values for group {self.group.name}."
+                body.append(("Invalid values for group ", ""))
+                body.append((self.group.name, _STYLE_NAME))
+                body.append((".", ""))
         elif self.command_chain:
-            message = f'Invalid values for command "{self.command_chain[-1]}".'
+            body.append(('Invalid values for command "', ""))
+            body.append((self.command_chain[-1], _STYLE_NAME))
+            body.append(('".', ""))
         else:
             raise NotImplementedError
 
-        cyclopts_message = f"{super().__str__()}{message}"
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
+        yield from body
+
+        cyclopts_message_nonempty = bool(prefix) or bool(body)
         if self.exception_message:
-            if cyclopts_message:
-                return f"{cyclopts_message} {self.exception_message}"
-            else:
-                return self.exception_message
-        else:
-            return cyclopts_message
+            if cyclopts_message_nonempty:
+                yield " ", ""
+            yield self.exception_message, ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -198,12 +222,21 @@ class UnknownOptionError(CycloptsError):
     argument_collection: "ArgumentCollection"
     """Argument collection of plausible options."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         value = self.token.keyword or self.token.value
+
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
+
+        yield 'Unknown option: "', ""
+        yield value, _STYLE_VALUE
         if self.token.source == "cli":
-            response = f'Unknown option: "{value}".'
+            yield '".', ""
         else:
-            response = f'Unknown option: "{value}" from {self.token.source}.'
+            yield '"', ""
+            yield f" from {self.token.source}", _STYLE_DIM
+            yield ".", ""
 
         if keyword := self.token.keyword or self.token.value:
             import difflib
@@ -212,9 +245,20 @@ class UnknownOptionError(CycloptsError):
 
             close_matches = difflib.get_close_matches(keyword, candidates, n=1, cutoff=0.6)
             if close_matches:
-                response += f" Did you mean {close_matches[0]}?"
+                yield " Did you mean ", ""
+                yield close_matches[0], _STYLE_SUGGESTION
+                yield "?", ""
 
-        return super().__str__() + response
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -339,49 +383,73 @@ class CoercionError(CycloptsError):
 class UnknownCommandError(CycloptsError):
     """CLI token combination did not yield a valid command."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.unused_tokens
         token = self.unused_tokens[0]
-        response = f'Unknown command "{token}".'
 
-        if self.app and self.app._commands:
-            import difflib
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
 
-            # Resolve CommandSpec and filter visible commands
-            visible_commands = []
-            for name, app_or_spec in self.app._commands.items():
-                if name in self.app._help_flags or name in self.app._version_flags:
-                    continue
+        yield 'Unknown command "', ""
+        yield token, _STYLE_VALUE
+        yield '".', ""
 
-                # Resolve CommandSpec to App
-                subapp = app_or_spec.resolve(self.app) if isinstance(app_or_spec, CommandSpec) else app_or_spec
+        if not (self.app and self.app._commands):
+            return
 
-                if not isinstance(subapp, type(self.app)):
-                    continue
+        import difflib
 
-                if subapp.show:
-                    visible_commands.append(name)
+        visible_commands: list[str] = []
+        for name, app_or_spec in self.app._commands.items():
+            if name in self.app._help_flags or name in self.app._version_flags:
+                continue
 
-            close_matches = difflib.get_close_matches(
-                token,
-                visible_commands,
-                n=1,
-                cutoff=0.6,
-            )
-            if close_matches:
-                response += f' Did you mean "{close_matches[0]}"?'
+            subapp = app_or_spec.resolve(self.app) if isinstance(app_or_spec, CommandSpec) else app_or_spec
 
-            # The following is a heuristic to be "maximally helpful" to someone who may have
-            # forgotten a command in their CLI call.
-            max_commands = 8
-            available_commands = [name for name in visible_commands if not name.startswith("-")]
-            if available_commands:
-                if len(available_commands) > max_commands:
-                    response += f" Available commands: {', '.join(available_commands[:max_commands])}, ..."
-                else:
-                    response += f" Available commands: {', '.join(available_commands)}."
+            if not isinstance(subapp, type(self.app)):
+                continue
 
-        return super().__str__() + response
+            if subapp.show:
+                visible_commands.append(name)
+
+        close_matches = difflib.get_close_matches(token, visible_commands, n=1, cutoff=0.6)
+        if close_matches:
+            yield ' Did you mean "', ""
+            yield close_matches[0], _STYLE_SUGGESTION
+            yield '"?', ""
+
+        # Heuristic: list the visible commands to help users who forgot the command name.
+        max_commands = 8
+        available_commands = [name for name in visible_commands if not name.startswith("-")]
+        if not available_commands:
+            return
+
+        yield " Available commands: ", ""
+        if len(available_commands) > max_commands:
+            shown = available_commands[:max_commands]
+            for i, name in enumerate(shown):
+                if i:
+                    yield ", ", ""
+                yield name, _STYLE_CHOICE
+            yield ", ...", ""
+        else:
+            for i, name in enumerate(available_commands):
+                if i:
+                    yield ", ", ""
+                yield name, _STYLE_CHOICE
+            yield ".", ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -403,9 +471,8 @@ class MissingArgumentError(CycloptsError):
     keyword: str | None = None
     """The keyword that was used when the error was raised (e.g., '-o' instead of '--option')."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
-        strings = []
         count, _ = self.argument.token_count()
         if count == 0:
             required_string = "flag required"
@@ -418,15 +485,14 @@ class MissingArgumentError(CycloptsError):
             received_count = len(self.tokens_so_far) % count
             only_got_string = f" Only got {received_count}." if received_count else ""
 
-        close_match_string = ""
+        close_match: str | None = None
         if self.unused_tokens and self.argument.field_info.is_keyword:
             import difflib
 
             candidates = [x for x in self.unused_tokens if is_option_like(x)]
-
-            close_matches = difflib.get_close_matches(self.argument.name, candidates, n=1, cutoff=0.6)
-            if close_matches and close_matches[0] not in self.argument.names:
-                close_match_string = f"Did you mean {self.argument.name} instead of {close_matches[0]}?"
+            matches = difflib.get_close_matches(self.argument.name, candidates, n=1, cutoff=0.6)
+            if matches and matches[0] not in self.argument.names:
+                close_match = matches[0]
 
         param_name = self.argument.name
         if self.keyword is not None:
@@ -437,20 +503,39 @@ class MissingArgumentError(CycloptsError):
                     param_name = token.keyword
                     break
 
-        if self.command_chain:
-            strings.append(
-                f'Command "{" ".join(self.command_chain)}" parameter {param_name} {required_string}.{only_got_string}'
-            )
-        else:
-            strings.append(f"Parameter {param_name} {required_string}.{only_got_string}")
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
 
-        if close_match_string:
-            strings.append(close_match_string)
+        if self.command_chain:
+            yield 'Command "', ""
+            yield " ".join(self.command_chain), _STYLE_NAME
+            yield '" parameter ', ""
+        else:
+            yield "Parameter ", ""
+        yield param_name, _STYLE_NAME
+        yield f" {required_string}.{only_got_string}", ""
+
+        if close_match is not None:
+            yield " Did you mean ", ""
+            yield self.argument.name, _STYLE_SUGGESTION
+            yield " instead of ", ""
+            yield close_match, _STYLE_VALUE
+            yield "?", ""
 
         if self.verbose:
-            strings.append(f" Parsed: {self.tokens_so_far}.")
+            yield f"  Parsed: {self.tokens_so_far}.", ""
 
-        return super().__str__() + " ".join(strings)
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -461,7 +546,7 @@ class ConsumeMultipleError(MissingArgumentError):
     max_allowed: int | None = None
     actual_count: int = 0
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
         param_name = self.keyword or self.argument.name
 
@@ -470,12 +555,19 @@ class ConsumeMultipleError(MissingArgumentError):
         else:
             constraint = f"accepts at most {self.max_allowed}"
 
-        if self.command_chain:
-            base = f'Command "{" ".join(self.command_chain)}" parameter {param_name} {constraint} elements. Got {self.actual_count}.'
-        else:
-            base = f"Parameter {param_name} {constraint} elements. Got {self.actual_count}."
+        # Skip MissingArgumentError.__str__ chain; we want just the base verbose prefix.
+        prefix = CycloptsError.__str__(self)
+        if prefix:
+            yield prefix, ""
 
-        return CycloptsError.__str__(self) + base
+        if self.command_chain:
+            yield 'Command "', ""
+            yield " ".join(self.command_chain), _STYLE_NAME
+            yield '" parameter ', ""
+        else:
+            yield "Parameter ", ""
+        yield param_name, _STYLE_NAME
+        yield f" {constraint} elements. Got {self.actual_count}.", ""
 
 
 @define(kw_only=True)
@@ -485,10 +577,28 @@ class RequiresEqualsError(CycloptsError):
     keyword: str | None = None
     """The keyword that was used (e.g., '--name')."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
         param_name = self.keyword or self.argument.name
-        return super().__str__() + f"Parameter {param_name} requires a value assigned with `=`. Use {param_name}=VALUE."
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
+        yield "Parameter ", ""
+        yield param_name, _STYLE_NAME
+        yield " requires a value assigned with `=`. Use ", ""
+        yield param_name, _STYLE_NAME
+        yield "=VALUE.", ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -498,8 +608,24 @@ class RepeatArgumentError(CycloptsError):
     token: "Token"
     """The repeated token."""
 
+    def _segments(self) -> Iterator[tuple[str, str]]:
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
+        yield "Parameter ", ""
+        yield self.token.keyword or "", _STYLE_NAME
+        yield " specified multiple times.", ""
+
     def __str__(self):
-        return super().__str__() + f"Parameter {self.token.keyword} specified multiple times."
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -509,27 +635,63 @@ class ArgumentOrderError(CycloptsError):
     token: str
     prior_positional_or_keyword_supplied_as_keyword_arguments: list["Argument"]
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
         plural = len(self.prior_positional_or_keyword_supplied_as_keyword_arguments) > 1
         display_name = next((x.keyword for x in self.argument.tokens if x.keyword), self.argument.name).lstrip("-")
-        prior_display_names = [
-            x.tokens[0].keyword for x in self.prior_positional_or_keyword_supplied_as_keyword_arguments
-        ]
-        if len(prior_display_names) == 1:
-            prior_display_names = prior_display_names[0]
+        prior_list = [x.tokens[0].keyword for x in self.prior_positional_or_keyword_supplied_as_keyword_arguments]
+        prior_display = prior_list[0] if len(prior_list) == 1 else prior_list
 
-        return (
-            super().__str__()
-            + f'Cannot specify token "{self.token}" positionally for parameter {display_name} due to previously specified keyword{"s" if plural else ""} {prior_display_names}. {prior_display_names} must either be passed positionally, or "{self.token}" must be passed as a keyword to {self.argument.name}.'
-        )
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
+        yield 'Cannot specify token "', ""
+        yield self.token, _STYLE_VALUE
+        yield '" positionally for parameter ', ""
+        yield display_name, _STYLE_NAME
+        yield f" due to previously specified keyword{'s' if plural else ''} ", ""
+        yield f"{prior_display}", _STYLE_NAME
+        yield ". ", ""
+        yield f"{prior_display}", _STYLE_NAME
+        yield ' must either be passed positionally, or "', ""
+        yield self.token, _STYLE_VALUE
+        yield '" must be passed as a keyword to ', ""
+        yield self.argument.name, _STYLE_NAME
+        yield ".", ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
 class MixedArgumentError(CycloptsError):
     """Cannot supply keywords and non-keywords to the same argument."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
         display_name = next((x.keyword for x in self.argument.tokens if x.keyword), self.argument.name)
-        return super().__str__() + f"Cannot supply keyword & non-keyword arguments to {display_name}."
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
+        yield "Cannot supply keyword & non-keyword arguments to ", ""
+        yield display_name, _STYLE_NAME
+        yield ".", ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -609,11 +609,14 @@ class RepeatArgumentError(CycloptsError):
     """The repeated token."""
 
     def _segments(self) -> Iterator[tuple[str, str]]:
+        # Invariant: positional duplication is routed to UnusedCliTokensError by the binder,
+        # so any token reaching this error path was matched by keyword.
+        assert self.token.keyword is not None
         prefix = super().__str__()
         if prefix:
             yield prefix, ""
         yield "Parameter ", ""
-        yield self.token.keyword or "", _STYLE_NAME
+        yield self.token.keyword, _STYLE_NAME
         yield " specified multiple times.", ""
 
     def __str__(self):

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -145,7 +145,9 @@ class CycloptsError(Exception):
     def __rich__(self) -> "Text":
         from rich.text import Text
 
-        out = Text()
+        # style="default" prevents the enclosing panel's border style (e.g. "red")
+        # from bleeding through into unstyled body segments.
+        out = Text(style="default")
         for text, style in self._segments():
             out.append(text, style=style or None)
         return out

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -115,26 +115,40 @@ class CycloptsError(Exception):
     console: Optional["Console"] = field(default=None, kw_only=True)
     """:class:`~rich.console.Console` to display runtime errors."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
+        """Yield (text, style) pairs that compose the error message.
+
+        Drives both ``__str__`` (joins text) and ``__rich__`` (applies styles).
+        Empty string in the style position means "no styling". Subclasses
+        override to add their body, typically prefixing with
+        ``yield from super()._segments()`` to include the verbose preamble.
+        """
         if self.msg is not None:
-            return self.msg
+            yield self.msg, ""
+            return
 
-        strings = []
-        if self.verbose:
-            strings.append(type(self).__name__)
-            if self.target:
-                file, lineno = _get_function_info(self.target)
-                strings.append(f'Function defined in file "{file}", line {lineno}:')
-                strings.append(f"    {self.target.__name__}{inspect.signature(self.target)}")
-            if self.root_input_tokens is not None:
-                strings.append(f"Root Input Tokens: {self.root_input_tokens}")
-        else:
-            pass
+        if not self.verbose:
+            return
 
-        if strings:
-            return "\n".join(strings) + "\n"
-        else:
-            return ""
+        strings = [type(self).__name__]
+        if self.target:
+            file, lineno = _get_function_info(self.target)
+            strings.append(f'Function defined in file "{file}", line {lineno}:')
+            strings.append(f"    {self.target.__name__}{inspect.signature(self.target)}")
+        if self.root_input_tokens is not None:
+            strings.append(f"Root Input Tokens: {self.root_input_tokens}")
+        yield "\n".join(strings) + "\n", ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 @define(kw_only=True)
@@ -186,27 +200,14 @@ class ValidationError(CycloptsError):
         else:
             raise NotImplementedError
 
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        preamble = list(super()._segments())
+        yield from preamble
         yield from body
 
-        cyclopts_message_nonempty = bool(prefix) or bool(body)
         if self.exception_message:
-            if cyclopts_message_nonempty:
+            if preamble or body:
                 yield " ", ""
             yield self.exception_message, ""
-
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
 
 
 @define(kw_only=True)
@@ -227,9 +228,7 @@ class UnknownOptionError(CycloptsError):
         # Option-like values (start with '-') are self-delimiting; quoting them is noise.
         quoted = not is_option_like(value)
 
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
 
         yield ('Unknown option: "' if quoted else "Unknown option: "), ""
         yield value, _STYLE_VALUE
@@ -252,17 +251,6 @@ class UnknownOptionError(CycloptsError):
                 yield " Did you mean ", ""
                 yield close_matches[0], _STYLE_SUGGESTION
                 yield "?", ""
-
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
 
 
 @define(kw_only=True)
@@ -307,9 +295,7 @@ class CoercionError(CycloptsError):
         assert self.argument is not None
         assert self.target_type is not None
 
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
 
         choice_strs: list[str] | None = None
         plain_choices: list[str] | None = None
@@ -372,17 +358,6 @@ class CoercionError(CycloptsError):
         yield self.token.value, _STYLE_VALUE
         yield f'" into {target_type_name}.', ""
 
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
-
 
 class UnknownCommandError(CycloptsError):
     """CLI token combination did not yield a valid command."""
@@ -391,9 +366,7 @@ class UnknownCommandError(CycloptsError):
         assert self.unused_tokens
         token = self.unused_tokens[0]
 
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
 
         yield 'Unknown command "', ""
         yield token, _STYLE_VALUE
@@ -444,25 +417,15 @@ class UnknownCommandError(CycloptsError):
                 yield name, _STYLE_CHOICE
             yield ".", ""
 
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
-
 
 @define(kw_only=True)
 class UnusedCliTokensError(CycloptsError):
     """Not all CLI tokens were used as expected."""
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.unused_tokens is not None
-        return super().__str__() + f"Unused Tokens: {self.unused_tokens}."
+        yield from super()._segments()
+        yield f"Unused Tokens: {self.unused_tokens}.", ""
 
 
 @define(kw_only=True)
@@ -507,9 +470,7 @@ class MissingArgumentError(CycloptsError):
                     param_name = token.keyword
                     break
 
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
 
         if self.command_chain:
             yield 'Command "', ""
@@ -530,17 +491,6 @@ class MissingArgumentError(CycloptsError):
         if self.verbose:
             yield f"  Parsed: {self.tokens_so_far}.", ""
 
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
-
 
 @define(kw_only=True)
 class ConsumeMultipleError(MissingArgumentError):
@@ -559,10 +509,8 @@ class ConsumeMultipleError(MissingArgumentError):
         else:
             constraint = f"accepts at most {self.max_allowed}"
 
-        # Skip MissingArgumentError.__str__ chain; we want just the base verbose prefix.
-        prefix = CycloptsError.__str__(self)
-        if prefix:
-            yield prefix, ""
+        # Skip MissingArgumentError._segments; we want just the base verbose preamble.
+        yield from CycloptsError._segments(self)
 
         if self.command_chain:
             yield 'Command "', ""
@@ -584,25 +532,12 @@ class RequiresEqualsError(CycloptsError):
     def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
         param_name = self.keyword or self.argument.name
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
         yield "Parameter ", ""
         yield param_name, _STYLE_NAME
         yield " requires a value assigned with `=`. Use ", ""
         yield param_name, _STYLE_NAME
         yield "=VALUE.", ""
-
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
 
 
 @define(kw_only=True)
@@ -616,23 +551,10 @@ class RepeatArgumentError(CycloptsError):
         # Invariant: positional duplication is routed to UnusedCliTokensError by the binder,
         # so any token reaching this error path was matched by keyword.
         assert self.token.keyword is not None
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
         yield "Parameter ", ""
         yield self.token.keyword, _STYLE_NAME
         yield " specified multiple times.", ""
-
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
 
 
 @define(kw_only=True)
@@ -649,9 +571,7 @@ class ArgumentOrderError(CycloptsError):
         prior_list = [x.tokens[0].keyword for x in self.prior_positional_or_keyword_supplied_as_keyword_arguments]
         prior_display = prior_list[0] if len(prior_list) == 1 else prior_list
 
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
         yield 'Cannot specify token "', ""
         yield self.token, _STYLE_VALUE
         yield '" positionally for parameter ', ""
@@ -666,17 +586,6 @@ class ArgumentOrderError(CycloptsError):
         yield self.argument.name, _STYLE_NAME
         yield ".", ""
 
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out
-
 
 @define(kw_only=True)
 class MixedArgumentError(CycloptsError):
@@ -685,20 +594,7 @@ class MixedArgumentError(CycloptsError):
     def _segments(self) -> Iterator[tuple[str, str]]:
         assert self.argument is not None
         display_name = next((x.keyword for x in self.argument.tokens if x.keyword), self.argument.name)
-        prefix = super().__str__()
-        if prefix:
-            yield prefix, ""
+        yield from super()._segments()
         yield "Cannot supply keyword & non-keyword arguments to ", ""
         yield display_name, _STYLE_NAME
         yield ".", ""
-
-    def __str__(self):
-        return "".join(text for text, _ in self._segments())
-
-    def __rich__(self) -> "Text":
-        from rich.text import Text
-
-        out = Text()
-        for text, style in self._segments():
-            out.append(text, style=style or None)
-        return out

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -224,17 +224,21 @@ class UnknownOptionError(CycloptsError):
 
     def _segments(self) -> Iterator[tuple[str, str]]:
         value = self.token.keyword or self.token.value
+        # Option-like values (start with '-') are self-delimiting; quoting them is noise.
+        quoted = not is_option_like(value)
 
         prefix = super().__str__()
         if prefix:
             yield prefix, ""
 
-        yield 'Unknown option: "', ""
+        yield ('Unknown option: "' if quoted else "Unknown option: "), ""
         yield value, _STYLE_VALUE
+        close = '"' if quoted else ""
         if self.token.source == "cli":
-            yield '".', ""
+            yield f"{close}.", ""
         else:
-            yield '"', ""
+            if close:
+                yield close, ""
             yield f" from {self.token.source}", _STYLE_DIM
             yield ".", ""
 

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -1,6 +1,6 @@
 import inspect
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from enum import Enum
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Literal, Optional, get_args, get_origin
@@ -16,9 +16,19 @@ from cyclopts.utils import is_option_like, json_decode_error_verbosifier
 
 if TYPE_CHECKING:
     from rich.console import Console
+    from rich.text import Text
 
     from cyclopts.argument import Argument, ArgumentCollection
     from cyclopts.core import App
+
+
+# Rich style palette for error messages. Kept conservative; this is error
+# output, not a TUI. Empty string in a segment means "no styling".
+_STYLE_VALUE = "bold red"  # offending user-supplied value
+_STYLE_NAME = "bold"  # parameter / command name
+_STYLE_CHOICE = "cyan"  # valid choices in "Choose from:" lists
+_STYLE_SUGGESTION = "bold green"  # "Did you mean ..." suggestion
+_STYLE_DIM = "dim"  # source suffixes like " from <CONFIG>"
 
 
 __all__ = [
@@ -221,25 +231,37 @@ class CoercionError(CycloptsError):
     Intended type to coerce into.
     """
 
-    def __str__(self):
+    def _segments(self) -> Iterator[tuple[str, str]]:
+        """Yield (text, style) pairs that compose the error message.
+
+        Empty string in the style position means "no styling". Drives both
+        ``__str__`` (which joins the text) and ``__rich__`` (which applies
+        the styles).
+        """
+        # Branch 1: explicit msg override. Yield exactly what str() would
+        # produce as a single unstyled segment -- user content stays plain.
         if self.msg is not None:
             if not self.token or self.token.keyword is None:
-                return self.msg
+                yield self.msg, ""
             else:
-                return f"Invalid value for {self.token.keyword}: {self.msg}"
-        else:
-            # If a JsonDecodeError, try and verbosify it.
-            if isinstance(self.__cause__, json.JSONDecodeError):
-                msg = json_decode_error_verbosifier(self.__cause__)  # pyright: ignore[reportArgumentType]
-                if not self.token or self.token.keyword is None:
-                    return msg
-                else:
-                    return f"Invalid value for {self.token.keyword}: {msg}"
+                yield f"Invalid value for {self.token.keyword}: {self.msg}", ""
+            return
+
+        # Branch 2: JSONDecodeError verbosifier path. Plain, like branch 1.
+        if isinstance(self.__cause__, json.JSONDecodeError):
+            verbosified = json_decode_error_verbosifier(self.__cause__)  # pyright: ignore[reportArgumentType]
+            if not self.token or self.token.keyword is None:
+                yield verbosified, ""
+            else:
+                yield f"Invalid value for {self.token.keyword}: {verbosified}", ""
+            return
 
         assert self.argument is not None
         assert self.target_type is not None
 
-        msg = super().__str__()
+        prefix = super().__str__()
+        if prefix:
+            yield prefix, ""
 
         choice_strs: list[str] | None = None
         plain_choices: list[str] | None = None
@@ -253,37 +275,65 @@ class CoercionError(CycloptsError):
             choice_strs = [f'"{x}"' for x in members]
             plain_choices = members
 
+        # Branch 3: Literal/Enum with a token -- "Choose from" + suggestion.
         if choice_strs is not None and self.token is not None:
             name = self.token.keyword if self.token.keyword else self.argument.name.lstrip("-").upper()
-            src_suffix = "" if self.token.source in ("", "cli") else f" from {self.token.source}"
-            msg += f'Invalid value "{self.token.value}" for {name}{src_suffix}. Choose from: {", ".join(choice_strs)}.'
+            yield 'Invalid value "', ""
+            yield self.token.value, _STYLE_VALUE
+            yield '" for ', ""
+            yield name, _STYLE_NAME
+            if self.token.source not in ("", "cli"):
+                yield f" from {self.token.source}", _STYLE_DIM
+            yield ". Choose from: ", ""
+            for i, choice in enumerate(choice_strs):
+                if i:
+                    yield ", ", ""
+                yield choice, _STYLE_CHOICE
+            yield ".", ""
 
             import difflib
 
             close = difflib.get_close_matches(self.token.value, plain_choices or [], n=1, cutoff=0.6)
             if close:
-                msg += f' Did you mean "{close[0]}"?'
-            return msg
+                yield ' Did you mean "', ""
+                yield close[0], _STYLE_SUGGESTION
+                yield '"?', ""
+            return
 
+        # Branch 4: fallback -- "unable to convert ... into <type>".
         target_type_name = (
             get_hint_name(self.target_type) if choice_strs is None else f"one of {{{', '.join(choice_strs)}}}"
         )
 
         if not self.token:
-            msg += f"Invalid value for {self.argument.name}: unable to convert value to {target_type_name}."
-        elif self.token.keyword is None:
-            positional_name = self.argument.name.lstrip("-").upper()
-            if self.token.source == "" or self.token.source == "cli":
-                msg += f'Invalid value for {positional_name}: unable to convert "{self.token.value}" into {target_type_name}.'
-            else:
-                msg += f'Invalid value for {positional_name} from {self.token.source}: unable to convert "{self.token.value}" into {target_type_name}.'
-        else:
-            if self.token.source == "" or self.token.source == "cli":
-                msg += f'Invalid value for {self.token.keyword}: unable to convert "{self.token.value}" into {target_type_name}.'
-            else:
-                msg += f'Invalid value for {self.token.keyword} from {self.token.source}: unable to convert "{self.token.value}" into {target_type_name}.'
+            yield "Invalid value for ", ""
+            yield self.argument.name, _STYLE_NAME
+            yield f": unable to convert value to {target_type_name}.", ""
+            return
 
-        return msg
+        if self.token.keyword is None:
+            display_name = self.argument.name.lstrip("-").upper()
+        else:
+            display_name = self.token.keyword
+
+        yield "Invalid value for ", ""
+        yield display_name, _STYLE_NAME
+        if self.token.source not in ("", "cli"):
+            yield f" from {self.token.source}", _STYLE_DIM
+        yield ': unable to convert "', ""
+        yield self.token.value, _STYLE_VALUE
+        yield f'" into {target_type_name}.', ""
+
+    def __str__(self):
+        return "".join(text for text, _ in self._segments())
+
+    def __rich__(self) -> "Text":
+        from rich.text import Text
+
+        out = Text()
+        for text, style in self._segments():
+            out.append(text, style=style or None)
+        return out
 
 
 class UnknownCommandError(CycloptsError):

--- a/cyclopts/panel.py
+++ b/cyclopts/panel.py
@@ -35,8 +35,13 @@ def CycloptsPanel(message: Any, title: str = "Error", style: str = "red") -> "Pa
     from rich.panel import Panel
     from rich.text import Text
 
+    if hasattr(message, "__rich__") or hasattr(message, "__rich_console__"):
+        renderable = message
+    else:
+        renderable = Text(str(message), "default")
+
     panel = Panel(
-        Text(str(message), "default"),
+        renderable,
         title=title,
         style=style,
         box=box.ROUNDED,

--- a/cyclopts/panel.py
+++ b/cyclopts/panel.py
@@ -35,7 +35,7 @@ def CycloptsPanel(message: Any, title: str = "Error", style: str = "red") -> "Pa
     from rich.panel import Panel
     from rich.text import Text
 
-    if hasattr(message, "__rich__") or hasattr(message, "__rich_console__"):
+    if callable(getattr(message, "__rich__", None)) or callable(getattr(message, "__rich_console__", None)):
         renderable = message
     else:
         renderable = Text(str(message), "default")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,12 @@ def console():
 
 
 @pytest.fixture
+def rich_console():
+    """Console that emits ANSI escapes -- for asserting styled output."""
+    return Console(width=70, force_terminal=True, highlight=False, color_system="truecolor", legacy_windows=False)
+
+
+@pytest.fixture
 def normalize_trailing_whitespace():
     """Remove trailing whitespace from each line while preserving line breaks.
 

--- a/tests/test_bind_boolean_flag.py
+++ b/tests/test_bind_boolean_flag.py
@@ -105,7 +105,7 @@ def test_boolean_flag_app_parameter_default(app, assert_parse_args):
 
     with pytest.raises(UnknownOptionError) as e:
         app.parse_args("--no-my-flag", exit_on_error=False)
-    assert str(e.value) == 'Unknown option: "--no-my-flag". Did you mean --my-flag?'
+    assert str(e.value) == "Unknown option: --no-my-flag. Did you mean --my-flag?"
 
 
 def test_boolean_flag_app_parameter_negative(app, assert_parse_args):

--- a/tests/test_bind_no_parse.py
+++ b/tests/test_bind_no_parse.py
@@ -159,6 +159,6 @@ def test_no_parse_did_you_mean_excludes_non_parsed(app):
 
     # The error message should NOT suggest "--verbose" since it has parse=False
     error_message = str(e.value)
-    assert 'Unknown option: "--verbose"' in error_message
+    assert "Unknown option: --verbose" in error_message
     # Should NOT have "Did you mean" since there's no valid similar option
     assert "Did you mean" not in error_message

--- a/tests/test_bind_typed_dict.py
+++ b/tests/test_bind_typed_dict.py
@@ -236,7 +236,7 @@ def test_bind_typed_dict_extra_field(app, console):
     expected = dedent(
         """\
         ╭─ Error ────────────────────────────────────────────────────────────╮
-        │ Unknown option: "--d.extra-key".                                   │
+        │ Unknown option: --d.extra-key.                                     │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -1,0 +1,494 @@
+"""Rich-formatted output tests for cyclopts exceptions."""
+
+import re
+from io import StringIO
+from typing import Literal
+from unittest.mock import Mock
+
+import pytest
+
+import cyclopts
+from cyclopts import (
+    Argument,
+    ArgumentOrderError,
+    CoercionError,
+    MissingArgumentError,
+    MixedArgumentError,
+    Parameter,
+    RepeatArgumentError,
+    RequiresEqualsError,
+    Token,
+    UnknownCommandError,
+    UnknownOptionError,
+    ValidationError,
+)
+from cyclopts._convert import convert
+from cyclopts.panel import CycloptsPanel
+from cyclopts.utils import default_name_transform
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _provoke_coercion_error(*args, **kwargs) -> CoercionError:
+    """Provoke a CoercionError the way the production code path would, then
+    attach a mocked argument so the exception is fully populated.
+    """
+    mock_argument = Mock()
+    mock_argument.name = "mocked_argument_name"
+    mock_argument.parameter.name_transform = default_name_transform
+    kwargs.setdefault("name_transform", default_name_transform)
+    try:
+        convert(*args, **kwargs)
+    except CoercionError as e:
+        e.argument = mock_argument
+        e.verbose = False  # strip the multi-line debug prefix so tests stay focused
+        return e
+    raise AssertionError("convert() did not raise CoercionError")
+
+
+def _spans(text) -> list[tuple[str, str | None]]:
+    """Extract (text, style) pairs from a rich.text.Text object.
+
+    rich's Text stores styles as Spans that index into a flat plain string;
+    we slice the plain string by each span. Gaps between spans are emitted
+    as (text, None) entries so callers can see un-styled regions in order.
+    """
+    plain = text.plain
+    out: list[tuple[str, str | None]] = []
+    cursor = 0
+    for span in text.spans:
+        if span.start > cursor:
+            out.append((plain[cursor : span.start], None))
+        out.append((plain[span.start : span.end], str(span.style)))
+        cursor = span.end
+    if cursor < len(plain):
+        out.append((plain[cursor:], None))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# __str__ unchanged: parity assertions on a few representative cases.
+# ---------------------------------------------------------------------------
+
+
+def test_str_parity_literal_with_suggestion():
+    e = _provoke_coercion_error(Literal["pishock", "openshock"], ["pisock"])
+    assert str(e) == (
+        'Invalid value "pisock" for MOCKED_ARGUMENT_NAME. Choose from: "pishock", "openshock". Did you mean "pishock"?'
+    )
+
+
+def test_str_parity_literal_keyword_non_cli_source():
+    e = _provoke_coercion_error(
+        Literal["foo", "bar", 3],
+        [Token(keyword="--MY-KEYWORD", value="invalid-choice", source="TEST")],
+    )
+    assert str(e) == 'Invalid value "invalid-choice" for --MY-KEYWORD from TEST. Choose from: "foo", "bar", 3.'
+
+
+def test_str_parity_fallback_int_conversion():
+    e = _provoke_coercion_error(int, ["abc"])
+    assert str(e) == 'Invalid value for MOCKED_ARGUMENT_NAME: unable to convert "abc" into int.'
+
+
+def test_str_parity_msg_override_no_keyword():
+    e = CoercionError(msg="custom error")
+    assert str(e) == "custom error"
+
+
+def test_str_parity_msg_override_with_keyword():
+    e = CoercionError(msg="custom error", token=Token(keyword="--flag", value="x"))
+    assert str(e) == "Invalid value for --flag: custom error"
+
+
+# ---------------------------------------------------------------------------
+# __rich__ spans: per-branch verification.
+# ---------------------------------------------------------------------------
+
+
+def test_rich_literal_branch_styles_value_name_choices_suggestion():
+    e = _provoke_coercion_error(Literal["pishock", "openshock"], ["pisock"])
+    spans = _spans(e.__rich__())
+
+    # Value, name, each choice, and the suggestion are styled.
+    assert ("pisock", "bold red") in spans
+    assert ("MOCKED_ARGUMENT_NAME", "bold") in spans
+    assert ('"pishock"', "cyan") in spans
+    assert ('"openshock"', "cyan") in spans
+    assert ("pishock", "bold green") in spans
+
+
+def test_rich_literal_branch_no_suggestion_omits_did_you_mean():
+    e = _provoke_coercion_error(Literal["pishock", "openshock"], ["auth"])
+    rich_text = e.__rich__()
+    assert "Did you mean" not in rich_text.plain
+    styles = [str(s.style) for s in rich_text.spans]
+    assert "bold green" not in styles
+
+
+def test_rich_literal_branch_dims_non_cli_source():
+    e = _provoke_coercion_error(
+        Literal["foo", "bar"],
+        [Token(value="bad", source="CONFIG")],
+    )
+    spans = _spans(e.__rich__())
+    assert (" from CONFIG", "dim") in spans
+
+
+def test_rich_literal_branch_uses_keyword_as_name_when_present():
+    e = _provoke_coercion_error(
+        Literal["foo", "bar"],
+        [Token(keyword="--my-flag", value="bad")],
+    )
+    spans = _spans(e.__rich__())
+    assert ("--my-flag", "bold") in spans
+    # MOCKED_ARGUMENT_NAME should NOT appear when keyword is present.
+    plain = e.__rich__().plain
+    assert "MOCKED_ARGUMENT_NAME" not in plain
+
+
+def test_rich_fallback_branch_styles_value_and_name():
+    e = _provoke_coercion_error(int, ["abc"])
+    spans = _spans(e.__rich__())
+    assert ("MOCKED_ARGUMENT_NAME", "bold") in spans
+    assert ("abc", "bold red") in spans
+
+
+def test_rich_fallback_branch_dims_non_cli_source():
+    e = _provoke_coercion_error(int, [Token(value="abc", source="ENV")])
+    spans = _spans(e.__rich__())
+    assert (" from ENV", "dim") in spans
+    assert ("abc", "bold red") in spans
+
+
+def test_rich_msg_override_yields_unstyled():
+    e = CoercionError(msg="custom error", token=Token(keyword="--flag", value="x"))
+    rich_text = e.__rich__()
+    assert rich_text.plain == "Invalid value for --flag: custom error"
+    # No styled spans -- override stays plain.
+    assert all(s.style is None or str(s.style) == "" for s in rich_text.spans)
+
+
+# ---------------------------------------------------------------------------
+# ANSI smoke test: end-to-end render through CycloptsPanel.
+# ---------------------------------------------------------------------------
+
+
+def test_panel_renders_rich_styles_when_color_enabled(rich_console):
+    """End-to-end: CycloptsPanel + truecolor console emits ANSI for styled spans."""
+    e = _provoke_coercion_error(Literal["pishock", "openshock"], ["pisock"])
+    buf = StringIO()
+    rich_console.file = buf
+    rich_console.print(CycloptsPanel(e))
+    output = buf.getvalue()
+
+    # ANSI escapes are present -- the panel didn't flatten styling away.
+    assert "\x1b[" in output
+    # Plain text (with ANSI stripped) is intact end-to-end.
+    plain = _strip_ansi(output)
+    assert 'Invalid value "pisock"' in plain
+    assert 'Did you mean "pishock"?' in plain
+
+
+def test_panel_renders_plain_when_color_disabled(console):
+    """Existing snapshot-style test: color_system=None strips styles cleanly."""
+    e = _provoke_coercion_error(Literal["pishock", "openshock"], ["pisock"])
+    buf = StringIO()
+    console.file = buf
+    console.print(CycloptsPanel(e))
+    output = buf.getvalue()
+
+    assert "\x1b[" not in output
+    assert 'Invalid value "pisock" for MOCKED_ARGUMENT_NAME' in output
+    assert 'Did you mean "pishock"?' in output
+
+
+# ---------------------------------------------------------------------------
+# UnknownCommandError
+# ---------------------------------------------------------------------------
+
+
+def _provoke_unknown_command(commands: list[str], typed: str) -> UnknownCommandError:
+    """Build an app, register `commands`, then run with `typed` to provoke the error."""
+    app = cyclopts.App(result_action="return_value")
+    for name in commands:
+        app.command(name=name)(lambda: None)
+    with pytest.raises(UnknownCommandError) as ei:
+        app.parse_args(typed, exit_on_error=False)
+    e = ei.value
+    e.verbose = False
+    return e
+
+
+def test_unknown_command_str_parity_with_suggestion_and_list():
+    e = _provoke_unknown_command(["mad-command"], "bad-command")
+    assert str(e) == 'Unknown command "bad-command". Did you mean "mad-command"? Available commands: mad-command.'
+
+
+def test_unknown_command_str_parity_ellipsis():
+    e = _provoke_unknown_command([f"cmd{i}" for i in range(1, 10)], "cmd")
+    assert str(e) == (
+        'Unknown command "cmd". Did you mean "cmd9"? '
+        "Available commands: cmd1, cmd2, cmd3, cmd4, cmd5, cmd6, cmd7, cmd8, ..."
+    )
+
+
+def test_unknown_command_str_parity_no_suggestion():
+    e = _provoke_unknown_command(["foo"], "zzz")
+    assert str(e) == 'Unknown command "zzz". Available commands: foo.'
+
+
+def test_unknown_command_rich_styles_token_suggestion_and_commands():
+    e = _provoke_unknown_command(["mad-command", "other-command"], "bad-command")
+    spans = _spans(e.__rich__())
+    assert ("bad-command", "bold red") in spans
+    assert ("mad-command", "bold green") in spans
+    # Both commands are listed and styled.
+    assert ("mad-command", "cyan") in spans
+    assert ("other-command", "cyan") in spans
+
+
+def test_unknown_command_rich_no_suggestion_omits_did_you_mean():
+    e = _provoke_unknown_command(["foo"], "zzz")
+    rich_text = e.__rich__()
+    assert "Did you mean" not in rich_text.plain
+    styles = [str(s.style) for s in rich_text.spans]
+    assert "bold green" not in styles
+
+
+def test_unknown_command_rich_ellipsis_truncates_styled_list():
+    e = _provoke_unknown_command([f"cmd{i}" for i in range(1, 10)], "cmd")
+    spans = _spans(e.__rich__())
+    # First 8 commands appear as cyan-styled spans; cmd9 does NOT (truncated).
+    cyan_texts = [text for text, style in spans if style == "cyan"]
+    assert "cmd1" in cyan_texts
+    assert "cmd8" in cyan_texts
+    assert "cmd9" not in cyan_texts
+    # Ellipsis tail is plain.
+    plain = e.__rich__().plain
+    assert plain.endswith(", ...")
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: UnknownOptionError
+# ---------------------------------------------------------------------------
+
+
+def _provoke_app_exception(exc_cls, app: cyclopts.App, argv: str):
+    """Run app and capture an exception of type `exc_cls`."""
+    with pytest.raises(exc_cls) as ei:
+        app.parse_args(argv, exit_on_error=False)
+    e = ei.value
+    e.verbose = False
+    return e
+
+
+def _make_unknown_option_app() -> cyclopts.App:
+    """An app where `--no-my-flag` is unknown but `--my-flag` is a close match."""
+    app = cyclopts.App(result_action="return_value", default_parameter=Parameter(negative=""))
+
+    @app.default
+    def main(my_flag: bool = True):
+        pass
+
+    return app
+
+
+def test_unknown_option_str_parity_cli_with_suggestion():
+    e = _provoke_app_exception(UnknownOptionError, _make_unknown_option_app(), "--no-my-flag")
+    assert str(e) == 'Unknown option: "--no-my-flag". Did you mean --my-flag?'
+
+
+def test_unknown_option_rich_styles_token_and_suggestion():
+    e = _provoke_app_exception(UnknownOptionError, _make_unknown_option_app(), "--no-my-flag")
+    spans = _spans(e.__rich__())
+    assert ("--no-my-flag", "bold red") in spans
+    assert ("--my-flag", "bold green") in spans
+
+
+def test_unknown_option_rich_dims_non_cli_source():
+    e = UnknownOptionError(
+        token=Token(keyword="--bogus", value="x", source="ENV"),
+        argument_collection=Mock(__iter__=lambda self: iter([])),
+    )
+    e.verbose = False
+    spans = _spans(e.__rich__())
+    assert ("--bogus", "bold red") in spans
+    assert (" from ENV", "dim") in spans
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: MissingArgumentError + ConsumeMultipleError
+# ---------------------------------------------------------------------------
+
+
+def test_missing_argument_str_parity_with_command_chain():
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command
+    def foo(bar: int):
+        pass
+
+    e = _provoke_app_exception(MissingArgumentError, app, "foo")
+    assert str(e) == 'Command "foo" parameter --bar requires an argument.'
+
+
+def test_missing_argument_rich_styles_command_and_param():
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command
+    def foo(bar: int):
+        pass
+
+    e = _provoke_app_exception(MissingArgumentError, app, "foo")
+    spans = _spans(e.__rich__())
+    assert ("foo", "bold") in spans
+    assert ("--bar", "bold") in spans
+
+
+def test_missing_argument_rich_styles_did_you_mean_suggestion_and_typo():
+    """`Did you mean --foo instead of --boo?` -- correct is suggestion, typo is value."""
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command
+    def some_command(*, foo: int):
+        pass
+
+    e = _provoke_app_exception(MissingArgumentError, app, "some-command --boo 123")
+    spans = _spans(e.__rich__())
+    # Correct option (suggestion) is bold green; user's typo is bold red.
+    assert ("--foo", "bold green") in spans
+    assert ("--boo", "bold red") in spans
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: ValidationError
+# ---------------------------------------------------------------------------
+
+
+def test_validation_error_str_parity_with_argument_and_source():
+    """Mirrors test_exceptions_validation_error_non_cli_single_keyword."""
+
+    def positive_validator(type_, value):
+        if value <= 0:
+            raise ValueError("Value must be positive.")
+
+    argument = Argument(
+        hint=int,
+        parameter=Parameter(name=("--bar",), validator=positive_validator),
+        tokens=[Token(value="-2", source="test")],
+    )
+    with pytest.raises(ValidationError) as ei:
+        argument.convert_and_validate()
+    e = ei.value
+    e.verbose = False
+
+    assert str(e) == 'Invalid value "-2" for BAR provided by test. Value must be positive.'
+
+
+def test_validation_error_rich_styles_value_name_source_and_appended_message():
+    def positive_validator(type_, value):
+        if value <= 0:
+            raise ValueError("Value must be positive.")
+
+    argument = Argument(
+        hint=int,
+        parameter=Parameter(name=("--bar",), validator=positive_validator),
+        tokens=[Token(value="-2", source="test")],
+    )
+    with pytest.raises(ValidationError) as ei:
+        argument.convert_and_validate()
+    e = ei.value
+    e.verbose = False
+    spans = _spans(e.__rich__())
+
+    assert ("-2", "bold red") in spans
+    assert ("BAR", "bold") in spans
+    assert (" provided by test", "dim") in spans
+    # Appended exception_message stays plain.
+    assert "Value must be positive." in e.__rich__().plain
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: small one-line classes
+# ---------------------------------------------------------------------------
+
+
+def test_repeat_argument_error_rich_styles_keyword():
+    app = cyclopts.App(result_action="return_value")
+
+    @app.default
+    def main(a):
+        pass
+
+    e = _provoke_app_exception(RepeatArgumentError, app, "--a=1 --a=2")
+    assert str(e) == "Parameter --a specified multiple times."
+    spans = _spans(e.__rich__())
+    assert ("--a", "bold") in spans
+
+
+def test_requires_equals_error_rich_styles_keyword_twice():
+    e = RequiresEqualsError(
+        keyword="--name",
+        argument=Mock(name="--name"),
+    )
+    e.verbose = False
+    assert str(e) == "Parameter --name requires a value assigned with `=`. Use --name=VALUE."
+    spans = _spans(e.__rich__())
+    # The keyword appears twice in the message, both styled bold.
+    bold_names = [text for text, style in spans if style == "bold"]
+    assert bold_names == ["--name", "--name"]
+
+
+def test_mixed_argument_error_rich_styles_display_name():
+    app = cyclopts.App(result_action="return_value")
+
+    @app.default
+    def foo(bar: int | dict):
+        pass
+
+    e = _provoke_app_exception(MixedArgumentError, app, "--bar 5 --bar.baz fizz")
+    assert str(e) == "Cannot supply keyword & non-keyword arguments to --bar."
+    spans = _spans(e.__rich__())
+    assert ("--bar", "bold") in spans
+
+
+def test_argument_order_error_singular_str_parity_and_styling():
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command
+    def foo(a, b, c):
+        pass
+
+    e = _provoke_app_exception(ArgumentOrderError, app, "foo --b=5 1 2")
+    assert str(e) == (
+        'Cannot specify token "2" positionally for parameter c due to '
+        "previously specified keyword --b. --b must either be passed positionally, "
+        'or "2" must be passed as a keyword to --c.'
+    )
+    spans = _spans(e.__rich__())
+    # Token appears twice (bold red), display_name once (bold), prior keyword twice (bold),
+    # argument.name once (bold).
+    red_tokens = [text for text, style in spans if style == "bold red"]
+    assert red_tokens == ["2", "2"]
+    bold_names = [text for text, style in spans if style == "bold"]
+    # display_name "c", prior "--b" twice, argument.name "--c"
+    assert bold_names == ["c", "--b", "--b", "--c"]
+
+
+def test_argument_order_error_plural_styles_list_literal():
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command
+    def foo(a, b, c):
+        pass
+
+    e = _provoke_app_exception(ArgumentOrderError, app, "foo --a=1 --b=5 3")
+    spans = _spans(e.__rich__())
+    # The list literal "['--a', '--b']" appears twice, styled as a single bold span each time.
+    bold_strs = [text for text, style in spans if style == "bold"]
+    assert bold_strs.count("['--a', '--b']") == 2

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -300,7 +300,7 @@ def _make_unknown_option_app() -> cyclopts.App:
 
 def test_unknown_option_str_parity_cli_with_suggestion():
     e = _provoke_app_exception(UnknownOptionError, _make_unknown_option_app(), "--no-my-flag")
-    assert str(e) == 'Unknown option: "--no-my-flag". Did you mean --my-flag?'
+    assert str(e) == "Unknown option: --no-my-flag. Did you mean --my-flag?"
 
 
 def test_unknown_option_rich_styles_token_and_suggestion():

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,57 @@
+import textwrap
+from io import StringIO
+
+from rich.console import Console
+from rich.text import Text
+
+from cyclopts.panel import CycloptsPanel
+
+
+def _render(panel) -> str:
+    buf = StringIO()
+    console = Console(file=buf, width=70, force_terminal=True, highlight=False, color_system=None, legacy_windows=False)
+    console.print(panel)
+    return buf.getvalue()
+
+
+def test_cyclopts_panel_stringifies_plain_message():
+    """A plain object without rich-protocol attrs is rendered via str()."""
+    output = _render(CycloptsPanel("hello world"))
+    expected = textwrap.dedent(
+        """\
+        ╭─ Error ────────────────────────────────────────────────────────────╮
+        │ hello world                                                        │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert output == expected
+
+
+def test_cyclopts_panel_passes_through_rich_renderable():
+    """A message implementing __rich__ is passed through unwrapped."""
+
+    class HasRich:
+        def __str__(self) -> str:
+            return "string fallback"
+
+        def __rich__(self) -> Text:
+            return Text("rich body")
+
+    output = _render(CycloptsPanel(HasRich()))
+    assert "rich body" in output
+    assert "string fallback" not in output
+
+
+def test_cyclopts_panel_passes_through_rich_console_renderable():
+    """A message implementing __rich_console__ is also passed through."""
+
+    class HasRichConsole:
+        def __str__(self) -> str:
+            return "string fallback"
+
+        def __rich_console__(self, console, options):
+            yield Text("console body")
+
+    output = _render(CycloptsPanel(HasRichConsole()))
+    assert "console body" in output
+    assert "string fallback" not in output


### PR DESCRIPTION
Follow up from discussion in #806.


Before:
<img width="641" height="66" alt="Screenshot 2026-05-16 at 3 43 05 PM" src="https://github.com/user-attachments/assets/b31d9e21-d9fd-41f2-9406-c12928f656a1" />

After:
<img width="635" height="51" alt="Screenshot 2026-05-16 at 3 42 18 PM" src="https://github.com/user-attachments/assets/7f7533ac-52e3-4d6e-a1f0-da96ee6810b0" />

