### PR TITLE
Allow `CycloptsError.msg` to be a `rich.Text` object. Expose our stylings.

### DIFF
--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -456,7 +456,11 @@ class UnknownCommandError(CycloptsError):
             subapp_id = id(subapp)
             if subapp_id not in seen_subapps:
                 seen_subapps.add(subapp_id)
-                if token in subapp.synonym:  # pyright: ignore[reportOperatorIssue]
+                synonym = subapp.synonym
+                if isinstance(synonym, str):
+                    if token == synonym:
+                        synonym_matches.append(name)
+                elif synonym and token in synonym:
                     synonym_matches.append(name)
 
         if synonym_matches:

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -83,16 +83,17 @@ class CycloptsError(Exception):
     """
     If set, override automatic message generation.
 
-    A :class:`str` is parsed as `Rich console markup
-    <https://rich.readthedocs.io/en/stable/markup.html>`_, so custom errors
-    can match the built-in styling::
+    A :class:`str` is rendered as literal text. To apply styling, pass a
+    :class:`rich.text.Text` instance — either constructed from `Rich
+    console markup <https://rich.readthedocs.io/en/stable/markup.html>`_::
 
-        raise CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
+        from rich.text import Text
+        raise CycloptsError(msg=Text.from_markup("Invalid value [bold red]foo[/]."))
 
-    For full control, pass a :class:`rich.text.Text` instance. Reuse the
-    built-in palette — :data:`STYLE_OFFENDING_VALUE`, :data:`STYLE_NAME`,
+    or assembled directly using the built-in palette
+    (:data:`STYLE_OFFENDING_VALUE`, :data:`STYLE_NAME`,
     :data:`STYLE_VALID_CHOICE`, :data:`STYLE_SUGGESTION`,
-    :data:`STYLE_SOURCE` — to keep custom errors visually consistent with
+    :data:`STYLE_SOURCE`) to keep custom errors visually consistent with
     the framework's output::
 
         from rich.text import Text
@@ -145,17 +146,17 @@ class CycloptsError(Exception):
     """:class:`~rich.console.Console` to display runtime errors."""
 
     def _resolved_msg(self) -> "Text":
-        """Resolve ``self.msg`` (str | Text) into a Rich ``Text`` instance."""
-        from rich.errors import MarkupError
+        """Resolve ``self.msg`` (str | Text) into a Rich ``Text`` instance.
+
+        Strings are wrapped as literal text -- only ``Text`` instances carry
+        styling, so the caller opts in by constructing one explicitly.
+        """
         from rich.text import Text
 
         assert self.msg is not None
         if isinstance(self.msg, Text):
             return self.msg
-        try:
-            return Text.from_markup(self.msg)
-        except MarkupError:
-            return Text(self.msg)
+        return Text(self.msg)
 
     def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         """Yield segments that compose the error message.

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -83,16 +83,26 @@ class CycloptsError(Exception):
     """
     If set, override automatic message generation.
 
-    A plain :class:`str` is interpreted as Rich console markup so custom
-    errors can match the built-in styling::
+    A :class:`str` is parsed as `Rich console markup
+    <https://rich.readthedocs.io/en/stable/markup.html>`_, so custom errors
+    can match the built-in styling::
 
         raise CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
 
-    Malformed markup falls back to literal rendering. Pass a
-    :class:`rich.text.Text` instance for full control — see
-    :data:`STYLE_OFFENDING_VALUE`, :data:`STYLE_NAME`, :data:`STYLE_VALID_CHOICE`,
-    :data:`STYLE_SUGGESTION`, and :data:`STYLE_SOURCE` for the palette used
-    by the built-in messages.
+    For full control, pass a :class:`rich.text.Text` instance. Reuse the
+    built-in palette — :data:`STYLE_OFFENDING_VALUE`, :data:`STYLE_NAME`,
+    :data:`STYLE_VALID_CHOICE`, :data:`STYLE_SUGGESTION`,
+    :data:`STYLE_SOURCE` — to keep custom errors visually consistent with
+    the framework's output::
+
+        from rich.text import Text
+        from cyclopts.exceptions import STYLE_NAME, STYLE_OFFENDING_VALUE
+
+        t = Text("Invalid value ")
+        t.append("foo", style=STYLE_OFFENDING_VALUE)
+        t.append(" for ")
+        t.append("--name", style=STYLE_NAME)
+        raise CycloptsError(msg=t)
     """
 
     verbose: bool = True

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -22,13 +22,16 @@ if TYPE_CHECKING:
     from cyclopts.core import App
 
 
-# Rich style palette for error messages. Kept conservative; this is error
-# output, not a TUI. Empty string in a segment means "no styling".
-_STYLE_VALUE = "bold red"  # offending user-supplied value
-_STYLE_NAME = "bold"  # parameter / command name
-_STYLE_CHOICE = "cyan"  # valid choices in "Choose from:" lists
-_STYLE_SUGGESTION = "bold green"  # "Did you mean ..." suggestion
-_STYLE_DIM = "dim"  # source suffixes like " from <CONFIG>"
+STYLE_OFFENDING_VALUE = "bold red"
+"""Rich style for an offending user-supplied value."""
+STYLE_NAME = "bold"
+"""Rich style for a parameter, option, or command name."""
+STYLE_VALID_CHOICE = "cyan"
+"""Rich style for valid choices in ``Choose from:`` lists."""
+STYLE_SUGGESTION = "bold green"
+"""Rich style for ``Did you mean ...`` suggestions."""
+STYLE_SOURCE = "dim"
+"""Rich style for source suffixes like ``from <CONFIG>``."""
 
 
 __all__ = [
@@ -46,6 +49,11 @@ __all__ = [
     "UnusedCliTokensError",
     "ValidationError",
     "CombinedShortOptionError",
+    "STYLE_OFFENDING_VALUE",
+    "STYLE_NAME",
+    "STYLE_VALID_CHOICE",
+    "STYLE_SUGGESTION",
+    "STYLE_SOURCE",
 ]
 
 
@@ -71,9 +79,20 @@ class CycloptsError(Exception):
     As CycloptsErrors bubble up the Cyclopts call-stack, more information is added to it.
     """
 
-    msg: str | None = None
+    msg: "str | Text | None" = None
     """
     If set, override automatic message generation.
+
+    A plain :class:`str` is interpreted as Rich console markup so custom
+    errors can match the built-in styling::
+
+        raise CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
+
+    Malformed markup falls back to literal rendering. Pass a
+    :class:`rich.text.Text` instance for full control — see
+    :data:`STYLE_OFFENDING_VALUE`, :data:`STYLE_NAME`, :data:`STYLE_VALID_CHOICE`,
+    :data:`STYLE_SUGGESTION`, and :data:`STYLE_SOURCE` for the palette used
+    by the built-in messages.
     """
 
     verbose: bool = True
@@ -115,16 +134,30 @@ class CycloptsError(Exception):
     console: Optional["Console"] = field(default=None, kw_only=True)
     """:class:`~rich.console.Console` to display runtime errors."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
-        """Yield (text, style) pairs that compose the error message.
+    def _resolved_msg(self) -> "Text":
+        """Resolve ``self.msg`` (str | Text) into a Rich ``Text`` instance."""
+        from rich.errors import MarkupError
+        from rich.text import Text
 
-        Drives both ``__str__`` (joins text) and ``__rich__`` (applies styles).
-        Empty string in the style position means "no styling". Subclasses
-        override to add their body, typically prefixing with
+        assert self.msg is not None
+        if isinstance(self.msg, Text):
+            return self.msg
+        try:
+            return Text.from_markup(self.msg)
+        except MarkupError:
+            return Text(self.msg)
+
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
+        """Yield segments that compose the error message.
+
+        Each item is either a ``(text, style)`` tuple (empty string = no
+        styling) or a pre-rendered :class:`rich.text.Text`. Drives both
+        ``__str__`` (joins plain text) and ``__rich__`` (applies styles).
+        Subclasses override to add their body, typically prefixing with
         ``yield from super()._segments()`` to include the verbose preamble.
         """
         if self.msg is not None:
-            yield self.msg, ""
+            yield self._resolved_msg()
             return
 
         if not self.verbose:
@@ -140,7 +173,13 @@ class CycloptsError(Exception):
         yield "\n".join(strings) + "\n", ""
 
     def __str__(self):
-        return "".join(text for text, _ in self._segments())
+        parts: list[str] = []
+        for item in self._segments():
+            if isinstance(item, tuple):
+                parts.append(item[0])
+            else:
+                parts.append(item.plain)
+        return "".join(parts)
 
     def __rich__(self) -> "Text":
         from rich.text import Text
@@ -148,8 +187,12 @@ class CycloptsError(Exception):
         # style="default" prevents the enclosing panel's border style (e.g. "red")
         # from bleeding through into unstyled body segments.
         out = Text(style="default")
-        for text, style in self._segments():
-            out.append(text, style=style or None)
+        for item in self._segments():
+            if isinstance(item, tuple):
+                text, style = item
+                out.append(text, style=style or None)
+            else:
+                out.append_text(item)
         return out
 
 
@@ -171,7 +214,7 @@ class ValidationError(CycloptsError):
     value: Any = cyclopts.utils.UNSET
     """Converted value that failed validation."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         body: list[tuple[str, str]] = []
 
         if self.argument:
@@ -184,20 +227,20 @@ class ValidationError(CycloptsError):
                 provided_by = "" if not token.source or token.source == "cli" else f" provided by {token.source}"
                 name = token.keyword if token.keyword else self.argument.name.lstrip("-").upper()
                 body.append(('Invalid value "', ""))
-                body.append((f"{value}", _STYLE_VALUE))
+                body.append((f"{value}", STYLE_OFFENDING_VALUE))
                 body.append(('" for ', ""))
-                body.append((name, _STYLE_NAME))
+                body.append((name, STYLE_NAME))
                 if provided_by:
-                    body.append((provided_by, _STYLE_DIM))
+                    body.append((provided_by, STYLE_SOURCE))
                 body.append((".", ""))
         elif self.group:
             if self.group.name:
                 body.append(("Invalid values for group ", ""))
-                body.append((self.group.name, _STYLE_NAME))
+                body.append((self.group.name, STYLE_NAME))
                 body.append((".", ""))
         elif self.command_chain:
             body.append(('Invalid values for command "', ""))
-            body.append((self.command_chain[-1], _STYLE_NAME))
+            body.append((self.command_chain[-1], STYLE_NAME))
             body.append(('".', ""))
         else:
             raise NotImplementedError
@@ -225,7 +268,7 @@ class UnknownOptionError(CycloptsError):
     argument_collection: "ArgumentCollection"
     """Argument collection of plausible options."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         value = self.token.keyword or self.token.value
         # Option-like values (start with '-') are self-delimiting; quoting them is noise.
         quoted = not is_option_like(value)
@@ -233,14 +276,14 @@ class UnknownOptionError(CycloptsError):
         yield from super()._segments()
 
         yield ('Unknown option: "' if quoted else "Unknown option: "), ""
-        yield value, _STYLE_VALUE
+        yield value, STYLE_OFFENDING_VALUE
         close = '"' if quoted else ""
         if self.token.source == "cli":
             yield f"{close}.", ""
         else:
             if close:
                 yield close, ""
-            yield f" from {self.token.source}", _STYLE_DIM
+            yield f" from {self.token.source}", STYLE_SOURCE
             yield ".", ""
 
         if keyword := self.token.keyword or self.token.value:
@@ -251,7 +294,7 @@ class UnknownOptionError(CycloptsError):
             close_matches = difflib.get_close_matches(keyword, candidates, n=1, cutoff=0.6)
             if close_matches:
                 yield " Did you mean ", ""
-                yield close_matches[0], _STYLE_SUGGESTION
+                yield close_matches[0], STYLE_SUGGESTION
                 yield "?", ""
 
 
@@ -269,20 +312,23 @@ class CoercionError(CycloptsError):
     Intended type to coerce into.
     """
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
-        """Yield (text, style) pairs that compose the error message.
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
+        """Yield segments that compose the error message.
 
-        Empty string in the style position means "no styling". Drives both
-        ``__str__`` (which joins the text) and ``__rich__`` (which applies
-        the styles).
+        Tuples are ``(text, style)`` pairs; ``Text`` items are emitted
+        verbatim (so user-supplied Rich markup / ``Text`` is preserved).
         """
-        # Branch 1: explicit msg override. Yield exactly what str() would
-        # produce as a single unstyled segment -- user content stays plain.
+        # Branch 1: explicit msg override. User-supplied markup is preserved;
+        # the framework wraps it with the standard prefix when a keyword exists.
         if self.msg is not None:
+            msg_text = self._resolved_msg()
             if not self.token or self.token.keyword is None:
-                yield self.msg, ""
+                yield msg_text
             else:
-                yield f"Invalid value for {self.token.keyword}: {self.msg}", ""
+                from rich.text import Text
+
+                prefix = Text(f"Invalid value for {self.token.keyword}: ")
+                yield prefix + msg_text
             return
 
         # Branch 2: JSONDecodeError verbosifier path. Plain, like branch 1.
@@ -315,16 +361,16 @@ class CoercionError(CycloptsError):
         if choice_strs is not None and self.token is not None:
             name = self.token.keyword if self.token.keyword else self.argument.name.lstrip("-").upper()
             yield 'Invalid value "', ""
-            yield self.token.value, _STYLE_VALUE
+            yield self.token.value, STYLE_OFFENDING_VALUE
             yield '" for ', ""
-            yield name, _STYLE_NAME
+            yield name, STYLE_NAME
             if self.token.source not in ("", "cli"):
-                yield f" from {self.token.source}", _STYLE_DIM
+                yield f" from {self.token.source}", STYLE_SOURCE
             yield ". Choose from: ", ""
             for i, choice in enumerate(choice_strs):
                 if i:
                     yield ", ", ""
-                yield choice, _STYLE_CHOICE
+                yield choice, STYLE_VALID_CHOICE
             yield ".", ""
 
             import difflib
@@ -332,7 +378,7 @@ class CoercionError(CycloptsError):
             close = difflib.get_close_matches(self.token.value, plain_choices or [], n=1, cutoff=0.6)
             if close:
                 yield ' Did you mean "', ""
-                yield close[0], _STYLE_SUGGESTION
+                yield close[0], STYLE_SUGGESTION
                 yield '"?', ""
             return
 
@@ -343,7 +389,7 @@ class CoercionError(CycloptsError):
 
         if not self.token:
             yield "Invalid value for ", ""
-            yield self.argument.name, _STYLE_NAME
+            yield self.argument.name, STYLE_NAME
             yield f": unable to convert value to {target_type_name}.", ""
             return
 
@@ -353,25 +399,25 @@ class CoercionError(CycloptsError):
             display_name = self.token.keyword
 
         yield "Invalid value for ", ""
-        yield display_name, _STYLE_NAME
+        yield display_name, STYLE_NAME
         if self.token.source not in ("", "cli"):
-            yield f" from {self.token.source}", _STYLE_DIM
+            yield f" from {self.token.source}", STYLE_SOURCE
         yield ': unable to convert "', ""
-        yield self.token.value, _STYLE_VALUE
+        yield self.token.value, STYLE_OFFENDING_VALUE
         yield f'" into {target_type_name}.', ""
 
 
 class UnknownCommandError(CycloptsError):
     """CLI token combination did not yield a valid command."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.unused_tokens
         token = self.unused_tokens[0]
 
         yield from super()._segments()
 
         yield 'Unknown command "', ""
-        yield token, _STYLE_VALUE
+        yield token, STYLE_OFFENDING_VALUE
         yield '".', ""
 
         if not (self.app and self.app._commands):
@@ -395,7 +441,7 @@ class UnknownCommandError(CycloptsError):
         close_matches = difflib.get_close_matches(token, visible_commands, n=1, cutoff=0.6)
         if close_matches:
             yield ' Did you mean "', ""
-            yield close_matches[0], _STYLE_SUGGESTION
+            yield close_matches[0], STYLE_SUGGESTION
             yield '"?', ""
 
         # Heuristic: list the visible commands to help users who forgot the command name.
@@ -410,13 +456,13 @@ class UnknownCommandError(CycloptsError):
             for i, name in enumerate(shown):
                 if i:
                     yield ", ", ""
-                yield name, _STYLE_CHOICE
+                yield name, STYLE_VALID_CHOICE
             yield ", ...", ""
         else:
             for i, name in enumerate(available_commands):
                 if i:
                     yield ", ", ""
-                yield name, _STYLE_CHOICE
+                yield name, STYLE_VALID_CHOICE
             yield ".", ""
 
 
@@ -424,7 +470,7 @@ class UnknownCommandError(CycloptsError):
 class UnusedCliTokensError(CycloptsError):
     """Not all CLI tokens were used as expected."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.unused_tokens is not None
         yield from super()._segments()
         yield f"Unused Tokens: {self.unused_tokens}.", ""
@@ -440,7 +486,7 @@ class MissingArgumentError(CycloptsError):
     keyword: str | None = None
     """The keyword that was used when the error was raised (e.g., '-o' instead of '--option')."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.argument is not None
         count, _ = self.argument.token_count()
         if count == 0:
@@ -476,18 +522,18 @@ class MissingArgumentError(CycloptsError):
 
         if self.command_chain:
             yield 'Command "', ""
-            yield " ".join(self.command_chain), _STYLE_NAME
+            yield " ".join(self.command_chain), STYLE_NAME
             yield '" parameter ', ""
         else:
             yield "Parameter ", ""
-        yield param_name, _STYLE_NAME
+        yield param_name, STYLE_NAME
         yield f" {required_string}.{only_got_string}", ""
 
         if close_match is not None:
             yield " Did you mean ", ""
-            yield self.argument.name, _STYLE_SUGGESTION
+            yield self.argument.name, STYLE_SUGGESTION
             yield " instead of ", ""
-            yield close_match, _STYLE_VALUE
+            yield close_match, STYLE_OFFENDING_VALUE
             yield "?", ""
 
         if self.verbose:
@@ -502,7 +548,7 @@ class ConsumeMultipleError(MissingArgumentError):
     max_allowed: int | None = None
     actual_count: int = 0
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.argument is not None
         param_name = self.keyword or self.argument.name
 
@@ -516,11 +562,11 @@ class ConsumeMultipleError(MissingArgumentError):
 
         if self.command_chain:
             yield 'Command "', ""
-            yield " ".join(self.command_chain), _STYLE_NAME
+            yield " ".join(self.command_chain), STYLE_NAME
             yield '" parameter ', ""
         else:
             yield "Parameter ", ""
-        yield param_name, _STYLE_NAME
+        yield param_name, STYLE_NAME
         yield f" {constraint} elements. Got {self.actual_count}.", ""
 
 
@@ -531,14 +577,14 @@ class RequiresEqualsError(CycloptsError):
     keyword: str | None = None
     """The keyword that was used (e.g., '--name')."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.argument is not None
         param_name = self.keyword or self.argument.name
         yield from super()._segments()
         yield "Parameter ", ""
-        yield param_name, _STYLE_NAME
+        yield param_name, STYLE_NAME
         yield " requires a value assigned with `=`. Use ", ""
-        yield param_name, _STYLE_NAME
+        yield param_name, STYLE_NAME
         yield "=VALUE.", ""
 
 
@@ -549,13 +595,13 @@ class RepeatArgumentError(CycloptsError):
     token: "Token"
     """The repeated token."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         # Invariant: positional duplication is routed to UnusedCliTokensError by the binder,
         # so any token reaching this error path was matched by keyword.
         assert self.token.keyword is not None
         yield from super()._segments()
         yield "Parameter ", ""
-        yield self.token.keyword, _STYLE_NAME
+        yield self.token.keyword, STYLE_NAME
         yield " specified multiple times.", ""
 
 
@@ -566,7 +612,7 @@ class ArgumentOrderError(CycloptsError):
     token: str
     prior_positional_or_keyword_supplied_as_keyword_arguments: list["Argument"]
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.argument is not None
         plural = len(self.prior_positional_or_keyword_supplied_as_keyword_arguments) > 1
         display_name = next((x.keyword for x in self.argument.tokens if x.keyword), self.argument.name).lstrip("-")
@@ -575,17 +621,17 @@ class ArgumentOrderError(CycloptsError):
 
         yield from super()._segments()
         yield 'Cannot specify token "', ""
-        yield self.token, _STYLE_VALUE
+        yield self.token, STYLE_OFFENDING_VALUE
         yield '" positionally for parameter ', ""
-        yield display_name, _STYLE_NAME
+        yield display_name, STYLE_NAME
         yield f" due to previously specified keyword{'s' if plural else ''} ", ""
-        yield f"{prior_display}", _STYLE_NAME
+        yield f"{prior_display}", STYLE_NAME
         yield ". ", ""
-        yield f"{prior_display}", _STYLE_NAME
+        yield f"{prior_display}", STYLE_NAME
         yield ' must either be passed positionally, or "', ""
-        yield self.token, _STYLE_VALUE
+        yield self.token, STYLE_OFFENDING_VALUE
         yield '" must be passed as a keyword to ', ""
-        yield self.argument.name, _STYLE_NAME
+        yield self.argument.name, STYLE_NAME
         yield ".", ""
 
 
@@ -593,10 +639,10 @@ class ArgumentOrderError(CycloptsError):
 class MixedArgumentError(CycloptsError):
     """Cannot supply keywords and non-keywords to the same argument."""
 
-    def _segments(self) -> Iterator[tuple[str, str]]:
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
         assert self.argument is not None
         display_name = next((x.keyword for x in self.argument.tokens if x.keyword), self.argument.name)
         yield from super()._segments()
         yield "Cannot supply keyword & non-keyword arguments to ", ""
-        yield display_name, _STYLE_NAME
+        yield display_name, STYLE_NAME
         yield ".", ""

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2677,3 +2677,41 @@ Exceptions
 .. autoexception:: cyclopts.EditorDidNotChangeError
    :show-inheritance:
    :members:
+
+^^^^^^^^^^^^^^^^^^^^^
+Styling Custom Errors
+^^^^^^^^^^^^^^^^^^^^^
+
+The :attr:`~cyclopts.CycloptsError.msg` attribute accepts either a string
+(parsed as `Rich console markup <https://rich.readthedocs.io/en/stable/markup.html>`_)
+or a :class:`rich.text.Text` instance. Malformed markup falls back to literal
+rendering, so existing plain-string messages continue to work unchanged.
+
+.. code-block:: python
+
+   from cyclopts import CycloptsError
+
+   # Rich markup in a plain string.
+   raise CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
+
+For full control (overlapping spans, dynamic content, etc.), construct a
+:class:`rich.text.Text` directly and reuse Cyclopts' built-in style palette
+so custom errors visually match the framework's output:
+
+.. code-block:: python
+
+   from rich.text import Text
+   from cyclopts import CycloptsError
+   from cyclopts.exceptions import STYLE_NAME, STYLE_OFFENDING_VALUE
+
+   t = Text("Invalid value ")
+   t.append("foo", style=STYLE_OFFENDING_VALUE)
+   t.append(" for ")
+   t.append("--name", style=STYLE_NAME)
+   raise CycloptsError(msg=t)
+
+.. autodata:: cyclopts.exceptions.STYLE_OFFENDING_VALUE
+.. autodata:: cyclopts.exceptions.STYLE_NAME
+.. autodata:: cyclopts.exceptions.STYLE_VALID_CHOICE
+.. autodata:: cyclopts.exceptions.STYLE_SUGGESTION
+.. autodata:: cyclopts.exceptions.STYLE_SOURCE

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2678,37 +2678,12 @@ Exceptions
    :show-inheritance:
    :members:
 
-^^^^^^^^^^^^^^^^^^^^^
-Styling Custom Errors
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
+Style Constants
+^^^^^^^^^^^^^^^
 
-The :attr:`~cyclopts.CycloptsError.msg` attribute accepts either a string
-(parsed as `Rich console markup <https://rich.readthedocs.io/en/stable/markup.html>`_)
-or a :class:`rich.text.Text` instance. Malformed markup falls back to literal
-rendering, so existing plain-string messages continue to work unchanged.
-
-.. code-block:: python
-
-   from cyclopts import CycloptsError
-
-   # Rich markup in a plain string.
-   raise CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
-
-For full control (overlapping spans, dynamic content, etc.), construct a
-:class:`rich.text.Text` directly and reuse Cyclopts' built-in style palette
-so custom errors visually match the framework's output:
-
-.. code-block:: python
-
-   from rich.text import Text
-   from cyclopts import CycloptsError
-   from cyclopts.exceptions import STYLE_NAME, STYLE_OFFENDING_VALUE
-
-   t = Text("Invalid value ")
-   t.append("foo", style=STYLE_OFFENDING_VALUE)
-   t.append(" for ")
-   t.append("--name", style=STYLE_NAME)
-   raise CycloptsError(msg=t)
+Palette used by the built-in error messages. See
+:attr:`CycloptsError.msg <cyclopts.CycloptsError.msg>` for example usage.
 
 .. autodata:: cyclopts.exceptions.STYLE_OFFENDING_VALUE
 .. autodata:: cyclopts.exceptions.STYLE_NAME

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -247,7 +247,7 @@ Finally, if you would like to register an **additional** name to the Cyclopts-de
 --------
 Synonyms
 --------
-A common CLI problem is remembering subcommand synonyms. Did this CLI's developer decide to call it  ``remove``, ``uninstall``, or ``delete``?
+A common CLI problem is remembering subcommand synonyms. Did this CLI's developer decide to call it ``remove``, ``uninstall``, or ``delete``?
 
 The :attr:`~.App.synonym` field declares **alternate names** that trigger a "Did you mean..."
 suggestion **without** registering the command under those names.

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -6,6 +6,7 @@ from typing import Literal
 from unittest.mock import Mock
 
 import pytest
+from rich.console import Console
 
 import cyclopts
 from cyclopts import (
@@ -458,8 +459,6 @@ def test_unknown_command_synonym_dedupes_across_aliases():
 
 def test_synonym_not_in_help_output():
     """Synonyms should not appear in --help output."""
-    from rich.console import Console
-
     buf = StringIO()
     console = Console(file=buf, force_terminal=False, width=200)
     app = cyclopts.App(name="myapp", result_action="return_value", console=console)

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -174,26 +174,8 @@ def test_rich_msg_override_yields_unstyled():
 
 
 # ---------------------------------------------------------------------------
-# msg styling: markup strings and Text instances (issue #813).
+# msg styling: Text instances opt into styling; plain str stays literal (#813).
 # ---------------------------------------------------------------------------
-
-
-def test_msg_markup_string_styles_applied_in_rich():
-    from cyclopts import CycloptsError
-
-    e = CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
-    rich_text = e.__rich__()
-    assert rich_text.plain == "Invalid value foo for --name."
-    spans = _spans(rich_text)
-    assert ("foo", "bold red") in spans
-    assert ("--name", "bold") in spans
-
-
-def test_msg_markup_string_str_returns_plain_text():
-    from cyclopts import CycloptsError
-
-    e = CycloptsError(msg="[bold]hello[/] [red]world[/]")
-    assert str(e) == "hello world"
 
 
 def test_msg_text_instance_preserved_in_rich():
@@ -214,22 +196,24 @@ def test_msg_text_instance_preserved_in_rich():
     assert ("--name", "bold") in spans
 
 
-def test_msg_markup_in_coercion_error_with_keyword():
-    e = CoercionError(msg="[bold red]bad[/]", token=Token(keyword="--flag", value="x"))
+def test_msg_text_from_markup_in_coercion_error_with_keyword():
+    from rich.text import Text
+
+    e = CoercionError(msg=Text.from_markup("[bold red]bad[/]"), token=Token(keyword="--flag", value="x"))
     rich_text = e.__rich__()
     assert rich_text.plain == "Invalid value for --flag: bad"
     spans = _spans(rich_text)
     assert ("bad", "bold red") in spans
 
 
-def test_msg_malformed_markup_falls_back_to_literal():
+def test_msg_plain_string_with_brackets_renders_literally():
+    """Backwards-compat: strings are never parsed as Rich markup."""
     from cyclopts import CycloptsError
 
-    # Unbalanced bracket would raise MarkupError; should render literally.
-    e = CycloptsError(msg="error at [foo")
-    assert str(e) == "error at [foo"
+    e = CycloptsError(msg="error in [section] config")
+    assert str(e) == "error in [section] config"
     rich_text = e.__rich__()
-    assert rich_text.plain == "error at [foo"
+    assert rich_text.plain == "error in [section] config"
 
 
 def test_msg_plain_string_with_no_markup_unchanged():

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -174,6 +174,93 @@ def test_rich_msg_override_yields_unstyled():
 
 
 # ---------------------------------------------------------------------------
+# msg styling: markup strings and Text instances (issue #813).
+# ---------------------------------------------------------------------------
+
+
+def test_msg_markup_string_styles_applied_in_rich():
+    from cyclopts import CycloptsError
+
+    e = CycloptsError(msg="Invalid value [bold red]foo[/] for [bold]--name[/].")
+    rich_text = e.__rich__()
+    assert rich_text.plain == "Invalid value foo for --name."
+    spans = _spans(rich_text)
+    assert ("foo", "bold red") in spans
+    assert ("--name", "bold") in spans
+
+
+def test_msg_markup_string_str_returns_plain_text():
+    from cyclopts import CycloptsError
+
+    e = CycloptsError(msg="[bold]hello[/] [red]world[/]")
+    assert str(e) == "hello world"
+
+
+def test_msg_text_instance_preserved_in_rich():
+    from rich.text import Text
+
+    from cyclopts import CycloptsError
+    from cyclopts.exceptions import STYLE_NAME, STYLE_OFFENDING_VALUE
+
+    t = Text("Invalid value ")
+    t.append("foo", style=STYLE_OFFENDING_VALUE)
+    t.append(" for ")
+    t.append("--name", style=STYLE_NAME)
+    e = CycloptsError(msg=t)
+    rich_text = e.__rich__()
+    assert rich_text.plain == "Invalid value foo for --name"
+    spans = _spans(rich_text)
+    assert ("foo", "bold red") in spans
+    assert ("--name", "bold") in spans
+
+
+def test_msg_markup_in_coercion_error_with_keyword():
+    e = CoercionError(msg="[bold red]bad[/]", token=Token(keyword="--flag", value="x"))
+    rich_text = e.__rich__()
+    assert rich_text.plain == "Invalid value for --flag: bad"
+    spans = _spans(rich_text)
+    assert ("bad", "bold red") in spans
+
+
+def test_msg_malformed_markup_falls_back_to_literal():
+    from cyclopts import CycloptsError
+
+    # Unbalanced bracket would raise MarkupError; should render literally.
+    e = CycloptsError(msg="error at [foo")
+    assert str(e) == "error at [foo"
+    rich_text = e.__rich__()
+    assert rich_text.plain == "error at [foo"
+
+
+def test_msg_plain_string_with_no_markup_unchanged():
+    from cyclopts import CycloptsError
+
+    e = CycloptsError(msg="just a plain message")
+    assert str(e) == "just a plain message"
+    rich_text = e.__rich__()
+    assert rich_text.plain == "just a plain message"
+    # No styled spans -- nothing to highlight.
+    assert all(s.style is None or str(s.style) == "" for s in rich_text.spans)
+
+
+def test_style_constants_match_builtin_palette():
+    """Public style constants should match what the built-in messages emit."""
+    from cyclopts.exceptions import (
+        STYLE_NAME,
+        STYLE_OFFENDING_VALUE,
+        STYLE_SOURCE,
+        STYLE_SUGGESTION,
+        STYLE_VALID_CHOICE,
+    )
+
+    assert STYLE_OFFENDING_VALUE == "bold red"
+    assert STYLE_NAME == "bold"
+    assert STYLE_VALID_CHOICE == "cyan"
+    assert STYLE_SUGGESTION == "bold green"
+    assert STYLE_SOURCE == "dim"
+
+
+# ---------------------------------------------------------------------------
 # ANSI smoke test: end-to-end render through CycloptsPanel.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -467,7 +467,7 @@ def test_synonym_not_in_help_output():
     output = _strip_ansi(buf.getvalue())
     assert "uninstall" in output
     assert "remove" not in output
-    assert " rm " not in output
+    assert re.search(r"\brm\b", output) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
@seowalex can you give this a try? Basically `CycloptsError.msg` can now be a `rich.Text` object; we also expose the rich stylings Cyclopts uses. You still have to parse the message yourself, but hopefully this enough to get you what you want!

demo:
```python
"""Demo for https://github.com/BrianPugh/cyclopts/issues/813.

uv run python issue-813-demo.py deploy-styled              # built-in cyclopts error
uv run python issue-813-demo.py deploy-plain bogus         # custom, unstyled (pre-#813)
uv run python issue-813-demo.py deploy-styled bogus        # custom, styled  (post-#813)
"""

from typing import Annotated

from rich.text import Text

from cyclopts import App, CycloptsError, Parameter
from cyclopts.exceptions import STYLE_NAME, STYLE_OFFENDING_VALUE, STYLE_VALID_CHOICE

VALID_ENVS = ("dev", "staging", "prod")


def _choices_phrase() -> str:
    return ", ".join(f'"{e}"' for e in VALID_ENVS)


def validate_env_plain(type_, value: str) -> None:
    """Pre-#813: a plain-string CycloptsError. Renders unstyled."""
    if value not in VALID_ENVS:
        raise CycloptsError(msg=f'Invalid value "{value}" for ENV. Choose from: {_choices_phrase()}.')


def validate_env_styled(type_, value: str) -> None:
    """Post-#813: a styled Text using cyclopts' public palette."""
    if value not in VALID_ENVS:
        t = Text("Invalid value ")
        t.append(f'"{value}"', style=STYLE_OFFENDING_VALUE)
        t.append(" for ")
        t.append("ENV", style=STYLE_NAME)
        t.append(". Choose from: ")
        for i, choice in enumerate(VALID_ENVS):
            if i:
                t.append(", ")
            t.append(f'"{choice}"', style=STYLE_VALID_CHOICE)
        t.append(".")
        raise CycloptsError(msg=t)


app = App(name="deployer", help="Mock deployment CLI for issue #813.")


@app.command(name="deploy-plain")
def deploy_plain(env: Annotated[str, Parameter(validator=validate_env_plain)]) -> None:
    """Deploy to ENV. Bad input raises a plain-string CycloptsError (pre-#813)."""
    print(f"Deploying to {env}...")


@app.command(name="deploy-styled")
def deploy_styled(env: Annotated[str, Parameter(validator=validate_env_styled)]) -> None:
    """Deploy to ENV. Bad input raises a styled CycloptsError (post-#813)."""
    print(f"Deploying to {env}...")


if __name__ == "__main__":
    app()
```

Output:
<img width="536" height="188" alt="Screenshot 2026-05-20 at 11 03 18 AM" src="https://github.com/user-attachments/assets/4ea0bbe9-3858-48a9-809d-ced3316a474a" />

Addresses issue #813 
