### PR TITLE
Introduce `App.synonym` for additional "Did you mean..." triggers.

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -330,6 +330,18 @@ class App:
         kw_only=True,
     )
 
+    synonym: None | str | tuple[str, ...] = field(
+        default=None,
+        converter=_app_str_tuple_converter,
+        kw_only=True,
+    )
+    """Alternate command names that are NOT runnable but trigger a "Did you mean..." suggestion.
+
+    Unlike :attr:`alias`, synonyms do not register the command under additional names. They exist
+    purely to guide users who type a semantically-equivalent but orthographically-dissimilar token
+    (e.g., ``remove`` when the command is ``uninstall``).
+    """
+
     default_command: Callable[..., Any] | None = field(default=None, converter=_validate_default_command, kw_only=True)
     default_parameter: Parameter | None = field(default=None, kw_only=True)
 

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -377,9 +377,10 @@ class UnknownCommandError(CycloptsError):
         if not (self.app and self.app._commands):
             return
 
-        import difflib
-
         visible_commands: list[str] = []
+        synonym_matches: list[str] = []
+        seen_subapps: set[int] = set()
+
         for name, app_or_spec in self.app._commands.items():
             if name in self.app._help_flags or name in self.app._version_flags:
                 continue
@@ -389,14 +390,40 @@ class UnknownCommandError(CycloptsError):
             if not isinstance(subapp, type(self.app)):
                 continue
 
-            if subapp.show:
-                visible_commands.append(name)
+            if not subapp.show:
+                continue
 
-        close_matches = difflib.get_close_matches(token, visible_commands, n=1, cutoff=0.6)
-        if close_matches:
-            yield ' Did you mean "', ""
-            yield close_matches[0], _STYLE_SUGGESTION
-            yield '"?', ""
+            visible_commands.append(name)
+
+            # First registration of this subapp is its primary name; only check synonyms once per subapp.
+            subapp_id = id(subapp)
+            if subapp_id not in seen_subapps:
+                seen_subapps.add(subapp_id)
+                if token in subapp.synonym:  # pyright: ignore[reportOperatorIssue]
+                    synonym_matches.append(name)
+
+        if synonym_matches:
+            yield " Did you mean ", ""
+            for i, match in enumerate(synonym_matches):
+                if i > 0:
+                    if len(synonym_matches) == 2:
+                        yield " or ", ""
+                    elif i == len(synonym_matches) - 1:
+                        yield ", or ", ""
+                    else:
+                        yield ", ", ""
+                yield '"', ""
+                yield match, _STYLE_SUGGESTION
+                yield '"', ""
+            yield "?", ""
+        else:
+            import difflib
+
+            close_matches = difflib.get_close_matches(token, visible_commands, n=1, cutoff=0.6)
+            if close_matches:
+                yield ' Did you mean "', ""
+                yield close_matches[0], _STYLE_SUGGESTION
+                yield '"?', ""
 
         # Heuristic: list the visible commands to help users who forgot the command name.
         max_commands = 8

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -72,6 +72,40 @@ API
          $ my-script bar
          Running bar.
 
+   .. attribute:: synonym
+      :type: Optional[Union[str, Iterable[str]]]
+      :value: None
+
+      Alternate names that trigger a "Did you mean..." suggestion when typed, but do **not**
+      register the command under those names.
+
+      Unlike :attr:`.alias`, synonyms are not runnable and are hidden from ``--help``.
+      They exist to guide users who type a semantically equivalent but orthographically
+      dissimilar token that Cyclopts' fuzzy matcher would otherwise miss (e.g., ``remove``
+      when the command is ``uninstall``).
+
+      .. code-block:: python
+
+         from cyclopts import App
+
+         app = App()
+
+         @app.command(synonym=["remove", "rm"])
+         def uninstall(name: str):
+             print(f"uninstalling {name}")
+
+         app()
+
+      .. code-block:: console
+
+         $ my-script uninstall mypackage
+         uninstalling mypackage
+
+         $ my-script remove mypackage
+         Unknown command "remove". Did you mean "uninstall"? Available commands: uninstall.
+
+      See :ref:`Synonyms` for details.
+
    .. attribute:: help
       :type: Optional[str]
       :value: None

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -242,6 +242,69 @@ Finally, if you would like to register an **additional** name to the Cyclopts-de
     $ my-script bar
     Running bar.
 
+.. _Synonyms:
+
+--------
+Synonyms
+--------
+A common CLI problem is remembering subcommand synonyms. Did this CLI's developer decide to call it  ``remove``, ``uninstall``, or ``delete``?
+
+The :attr:`~.App.synonym` field declares **alternate names** that trigger a "Did you mean..."
+suggestion **without** registering the command under those names.
+It accepts either a single :obj:`str` or an iterable of strings:
+
+.. code-block:: python
+
+    from cyclopts import App
+
+    app = App()
+
+    @app.command(synonym="add")               # single string
+    def install(name: str): ...
+
+    @app.command(synonym=["remove", "rm"])    # list of strings
+    def uninstall(name: str):
+        print(f"uninstalling {name}")
+
+    app()
+
+.. code-block:: console
+
+    $ my-script uninstall mypackage
+    uninstalling mypackage
+
+    $ my-script remove mypackage
+    ╭─ Error ────────────────────────────────────────────────────────────────────╮
+    │ Unknown command "remove". Did you mean "uninstall"? Available commands:    │
+    │ uninstall.                                                                 │
+    ╰────────────────────────────────────────────────────────────────────────────╯
+
+Synonyms differ from :attr:`~.App.alias` in two important ways:
+
+* **Synonyms are not runnable.** ``my-script remove`` raises an error; it doesn't invoke ``uninstall``.
+  Use :attr:`~.App.alias` when you want the command to be callable under multiple names.
+* **Synonyms are hidden from** ``--help``. They exist only to guide users who type the "wrong" word.
+
+If two commands declare the same synonym, both are suggested:
+
+.. code-block:: python
+
+    @app.command(synonym="erase")
+    def uninstall(name: str): ...
+
+    @app.command(synonym="erase")
+    def purge(name: str): ...
+
+.. code-block:: console
+
+    $ my-script erase mypackage
+    ╭─ Error ────────────────────────────────────────────────────────────────────╮
+    │ Unknown command "erase". Did you mean "uninstall" or "purge"? ...          │
+    ╰────────────────────────────────────────────────────────────────────────────╯
+
+When a typed token is not declared as any synonym, Cyclopts falls back to its standard
+typo-fuzzy-match suggestion.
+
 -----------
 Adding Help
 -----------

--- a/tests/test_exceptions_rich.py
+++ b/tests/test_exceptions_rich.py
@@ -274,6 +274,133 @@ def test_unknown_command_rich_ellipsis_truncates_styled_list():
 
 
 # ---------------------------------------------------------------------------
+# UnknownCommandError synonym suggestions
+# ---------------------------------------------------------------------------
+
+
+def _provoke_unknown_with_synonyms(commands: list[tuple[str, list[str]]], typed: str) -> UnknownCommandError:
+    """Build an app where each command optionally declares synonyms, then provoke an unknown-command error.
+
+    `commands` is a list of (name, synonyms) pairs.
+    """
+    app = cyclopts.App(result_action="return_value")
+    for name, synonyms in commands:
+        app.command(name=name, synonym=synonyms)(lambda: None)
+    with pytest.raises(UnknownCommandError) as ei:
+        app.parse_args(typed, exit_on_error=False)
+    e = ei.value
+    e.verbose = False
+    return e
+
+
+def test_unknown_command_synonym_single_match():
+    """A single declared synonym yields a 'Did you mean...' suggestion for that command."""
+    e = _provoke_unknown_with_synonyms([("uninstall", ["remove", "rm"])], "remove")
+    assert str(e) == 'Unknown command "remove". Did you mean "uninstall"? Available commands: uninstall.'
+
+
+def test_unknown_command_synonym_rich_styles_suggestion():
+    """The suggested command name is styled as a suggestion (bold green)."""
+    e = _provoke_unknown_with_synonyms([("uninstall", ["remove"])], "remove")
+    spans = _spans(e.__rich__())
+    assert ("remove", "bold red") in spans
+    assert ("uninstall", "bold green") in spans
+
+
+def test_unknown_command_synonym_two_targets():
+    """When two commands declare the same synonym, both are suggested with 'or'."""
+    e = _provoke_unknown_with_synonyms(
+        [("uninstall", ["remove"]), ("delete", ["remove"])],
+        "remove",
+    )
+    assert str(e) == (
+        'Unknown command "remove". Did you mean "uninstall" or "delete"? Available commands: uninstall, delete.'
+    )
+
+
+def test_unknown_command_synonym_three_targets_uses_oxford_or():
+    """Three or more matches use comma separation and a final ', or'."""
+    e = _provoke_unknown_with_synonyms(
+        [("uninstall", ["remove"]), ("delete", ["remove"]), ("purge", ["remove"])],
+        "remove",
+    )
+    plain = e.__rich__().plain
+    assert 'Did you mean "uninstall", "delete", or "purge"?' in plain
+
+
+def test_unknown_command_synonym_falls_back_to_difflib_when_no_match():
+    """When the token does not match any synonym, the existing difflib path still runs."""
+    e = _provoke_unknown_with_synonyms([("mad-command", ["nope"])], "bad-command")
+    # difflib fuzzy match still kicks in because no synonym matched.
+    assert 'Did you mean "mad-command"?' in str(e)
+
+
+def test_unknown_command_synonym_does_not_register_as_runnable():
+    """A synonym must not make the command runnable under that name."""
+    app = cyclopts.App(result_action="return_value")
+    app.command(name="uninstall", synonym=["remove"])(lambda: None)
+    # The synonym is NOT in the registered commands dict.
+    assert "remove" not in app
+    assert "uninstall" in app
+
+
+def test_unknown_command_synonym_shadowed_by_real_command():
+    """If a real command shares a name with another command's synonym, the real command wins."""
+    real_called = []
+    synonym_called = []
+
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(name="remove")
+    def remove_cmd():
+        real_called.append(True)
+
+    @app.command(name="uninstall", synonym=["remove"])
+    def uninstall_cmd():
+        synonym_called.append(True)
+
+    app("remove", exit_on_error=False)
+    assert real_called == [True]
+    assert synonym_called == []
+
+
+def test_unknown_command_synonym_no_match_no_suggestion():
+    """If neither synonym nor difflib finds anything, no 'Did you mean' is emitted."""
+    e = _provoke_unknown_with_synonyms([("uninstall", ["remove"])], "totally-different-zzz")
+    assert "Did you mean" not in str(e)
+
+
+def test_unknown_command_synonym_dedupes_across_aliases():
+    """A subapp registered under multiple names (via alias) should only be suggested once."""
+    app = cyclopts.App(result_action="return_value")
+    app.command(name="uninstall", alias=["delete-it", "rm-it"], synonym=["remove"])(lambda: None)
+    with pytest.raises(UnknownCommandError) as ei:
+        app.parse_args("remove", exit_on_error=False)
+    e = ei.value
+    e.verbose = False
+    plain = e.__rich__().plain
+    # Suggestion mentions the primary name once, not all three aliases.
+    assert 'Did you mean "uninstall"?' in plain
+    assert "delete-it" not in plain.split("Available commands:")[0]
+    assert "rm-it" not in plain.split("Available commands:")[0]
+
+
+def test_synonym_not_in_help_output():
+    """Synonyms should not appear in --help output."""
+    from rich.console import Console
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=200)
+    app = cyclopts.App(name="myapp", result_action="return_value", console=console)
+    app.command(name="uninstall", synonym=["remove", "rm"])(lambda: None)
+    app.help_print(console=console)
+    output = _strip_ansi(buf.getvalue())
+    assert "uninstall" in output
+    assert "remove" not in output
+    assert " rm " not in output
+
+
+# ---------------------------------------------------------------------------
 # Phase 4: UnknownOptionError
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
A common CLI problem is remembering subcommand synonyms. Did this CLI's developer decide to call it  `remove`, `uninstall`, or `delete`?

The `.App.synonym` field declares **alternate names** that trigger a "Did you mean..."suggestion **without** registering the command under those names. It accepts either a single `str` or an iterable of strings:

```python
from cyclopts import App

app = App()

@app.command(synonym="add")               # single string
def install(name: str): ...

@app.command(synonym=["remove", "rm"])    # list of strings
def uninstall(name: str):
    print(f"uninstalling {name}")

app()
```

```bash
$ my-script uninstall mypackage
uninstalling mypackage

$ my-script remove mypackage
╭─ Error ────────────────────────────────────────────────────────────────────╮
│ Unknown command "remove". Did you mean "uninstall"? Available commands:    │
│ uninstall.                                                                 │
╰────────────────────────────────────────────────────────────────────────────╯
```

Synonyms differ from `App.alias` in two important ways:

* **Synonyms are not runnable.** ``my-script remove`` raises an error; it doesn't invoke ``uninstall``.
  Use `App.alias` when you want the command to be callable under multiple names.
* **Synonyms are hidden from** ``--help``. They exist only to guide users who type the "wrong" word.

If two commands declare the same synonym, both are suggested:

```python
@app.command(synonym="erase")
def uninstall(name: str): ...

@app.command(synonym="erase")
def purge(name: str): ...
```

```bash
$ my-script erase mypackage
╭─ Error ────────────────────────────────────────────────────────────────────╮
│ Unknown command "erase". Did you mean "uninstall" or "purge"? ...          │
╰────────────────────────────────────────────────────────────────────────────╯
```

When a typed token is not declared as any synonym, Cyclopts falls back to its standard typo-fuzzy-match suggestion.

## Release Notes
* `App.synonym` declares alternate command name(s) that trigger a "Did you mean..." suggestion **without** registering the command under those names. Useful when a user types a semantically-equivalent word (e.g. `remove` vs `uninstall`) that the built-in fuzzy matcher would miss because the words aren't spelled similarly. Accepts a single `str` or an iterable of strings. Synonyms are not runnable and are hidden from `--help`.
  ```python
  @app.command(synonym=["remove", "rm"])
  def uninstall(name: str): ...
  ```
  ```console
  $ my-script remove mypackage
  Unknown command "remove". Did you mean "uninstall"? Available commands: uninstall.
  ```
  If multiple commands declare the same synonym, all matching commands are suggested (`Did you mean "uninstall" or "purge"?`).