### PR TITLE
Preserve docstring examples in help text

### DIFF
--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -49,11 +49,25 @@ def docstring_parse(doc: str | None, format: str):
         cleaned_doc = short + "\n\n" + short_description_and_maybe_remainder[1]
 
     res = docstring_parser.parse(cleaned_doc)
+    example_sections = [
+        _format_docstring_example(meta.description or meta.snippet, format)
+        for meta in res.meta
+        if meta.args == ["examples"] and (meta.description or meta.snippet)
+    ]
+    if example_sections:
+        sections = [res.long_description or "", *example_sections]
+        res.long_description = "\n\n".join(section for section in sections if section)
 
     # Ensure a short description exists if there's a long description
     assert not res.long_description or res.short_description
 
     return res
+
+
+def _format_docstring_example(example: str, format: str) -> str:
+    heading = "Examples::" if format in ("restructuredtext", "rst") else "Examples:"
+    indented_example = "\n".join(f"    {line}" if line else "" for line in example.splitlines())
+    return f"{heading}\n\n{indented_example}"
 
 
 def _text_factory():

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -220,6 +220,26 @@ def test_format_commands_docstring_multi_line_pep0257(app, console):
     )
 
 
+def test_help_docstring_examples_section(app, console):
+    @app.command
+    def foo():
+        """Run foo.
+
+        This command demonstrates an example in a Google-style docstring.
+
+        Example:
+            app foo --name Alice
+        """
+
+    with console.capture() as capture:
+        app.help_print("foo", console=console)
+
+    actual = capture.get()
+    assert "This command demonstrates an example in a Google-style docstring." in actual
+    assert "Examples:" in actual
+    assert "app foo --name Alice" in actual
+
+
 def test_format_commands_no_show(app, console, assert_parse_args):
     @app.command
     def foo():


### PR DESCRIPTION
## Summary
- Re-inject `Example`/`Examples` sections parsed by `docstring_parser` into the rendered long description.
- Format preserved examples as examples blocks so CLI help output includes them.
- Add regression coverage for Google-style docstring examples in command help.

Fixes #477.

## Tests
- `python3.12 -m venv .venv`
- `python -m pip install -e ' .[dev]'`
- `pytest tests/test_help.py::test_help_docstring_examples_section -q`
- `python -m py_compile cyclopts/help/help.py`

Note: while sanity-checking nearby pre-existing help panel tests under the freshly resolved Python 3.12 environment, `tests/test_help.py::test_format_commands_docstring` fails because current dependency resolution installs `rich==15.0.0`, which changes panel width rendering. The new regression test passes.