### PR TITLE
Implement `__cyclopts_returncode__` protocol

### DIFF
--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "RequiresEqualsError",
     "Parameter",
     "ResultAction",
+    "resolve_returncode",
     "UnknownOptionError",
     "UnusedCliTokensError",
     "UNSET",
@@ -48,7 +49,7 @@ __all__ = [
 
 from cyclopts._convert import convert
 from cyclopts._env_var import env_var_split
-from cyclopts._result_action import ResultAction
+from cyclopts._result_action import ResultAction, resolve_returncode
 from cyclopts._run import run
 from cyclopts.argument import Argument, ArgumentCollection
 from cyclopts.core import App

--- a/cyclopts/_result_action.py
+++ b/cyclopts/_result_action.py
@@ -28,6 +28,34 @@ ResultActionSingle = (
 ResultAction = ResultActionSingle | Iterable[ResultActionSingle]
 
 
+def resolve_returncode(result: Any, default: int = 0) -> int:
+    """Resolve the return code for ``result``.
+
+    If ``result`` defines ``__cyclopts_returncode__`` (a zero-argument callable),
+    its value is used. Otherwise ``default`` is returned.
+
+    Custom ``result_action`` callables can use this helper to honor the
+    ``__cyclopts_returncode__`` protocol consistently with the built-in actions.
+
+    Parameters
+    ----------
+    result : Any
+        The command's return value.
+    default : int
+        Fallback exit code when ``result`` doesn't define a callable
+        ``__cyclopts_returncode__``. Defaults to ``0``.
+
+    Returns
+    -------
+    int
+        The resolved return code.
+    """
+    returncode_fn = getattr(result, "__cyclopts_returncode__", None)
+    if callable(returncode_fn):
+        return cast(int, returncode_fn())
+    return default
+
+
 def handle_result_action(
     result: Any,
     action: ResultAction,
@@ -72,9 +100,9 @@ def handle_result_action(
                 sys.exit(result)
             elif result is not None:
                 print_fn(result)
-                sys.exit(0)
+                sys.exit(resolve_returncode(result))
             else:
-                sys.exit(0)
+                sys.exit(resolve_returncode(result))
         case "return_value":
             return result
         case "call_if_callable":
@@ -87,7 +115,7 @@ def handle_result_action(
             elif isinstance(result, int):
                 sys.exit(result)
             else:
-                sys.exit(0)
+                sys.exit(resolve_returncode(result))
         case "print_non_int_return_int_as_exit_code":
             if isinstance(result, bool):
                 return 0 if result else 1
@@ -95,23 +123,23 @@ def handle_result_action(
                 return result
             elif result is not None:
                 print_fn(result)
-                return 0
+                return resolve_returncode(result)
             else:
-                return 0
+                return resolve_returncode(result)
         case "print_str_return_int_as_exit_code":
             if isinstance(result, str):
                 print_fn(result)
-                return 0
+                return resolve_returncode(result)
             elif isinstance(result, bool):
                 return 0 if result else 1
             elif isinstance(result, int):
                 return result
             else:
-                return 0
+                return resolve_returncode(result)
         case "print_str_return_zero":
             if isinstance(result, str):
                 print_fn(result)
-            return 0
+            return resolve_returncode(result)
         case "print_non_none_return_int_as_exit_code":
             if result is not None:
                 print_fn(result)
@@ -119,29 +147,29 @@ def handle_result_action(
                 return 0 if result else 1
             elif isinstance(result, int):
                 return result
-            return 0
+            return resolve_returncode(result)
         case "print_non_none_return_zero":
             if result is not None:
                 print_fn(result)
-            return 0
+            return resolve_returncode(result)
         case "return_int_as_exit_code_else_zero":
             if isinstance(result, bool):
                 return 0 if result else 1
             elif isinstance(result, int):
                 return result
             else:
-                return 0
+                return resolve_returncode(result)
         case "return_none":
             return None
         case "return_zero":
-            return 0
+            return resolve_returncode(result)
         case "print_return_zero":
             print_fn(result)
-            return 0
+            return resolve_returncode(result)
         case "sys_exit_zero":
-            sys.exit(0)
+            sys.exit(resolve_returncode(result))
         case "print_sys_exit_zero":
             print_fn(result)
-            sys.exit(0)
+            sys.exit(resolve_returncode(result))
         case _:
             raise ValueError

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -636,9 +636,11 @@ API
                 sys.exit(result)
             elif result is not None:
                 print(result)
-                sys.exit(0)
+                sys.exit(resolve_returncode(result))
             else:
-                sys.exit(0)
+                sys.exit(resolve_returncode(result))
+
+         See :ref:`Custom Return Code Protocol <custom-return-code-protocol>` for :func:`~cyclopts.resolve_returncode`.
 
       **"return_value"**
 
@@ -669,7 +671,7 @@ API
             elif isinstance(result, int):
                 sys.exit(result)
             else:
-                sys.exit(0)
+                sys.exit(resolve_returncode(result))
 
       **"print_non_int_return_int_as_exit_code"**
 
@@ -683,9 +685,9 @@ API
                 return result
             elif result is not None:
                 print(result)
-                return 0
+                return resolve_returncode(result)
             else:
-                return 0
+                return resolve_returncode(result)
 
       **"print_str_return_int_as_exit_code"**
 
@@ -695,13 +697,13 @@ API
 
             if isinstance(result, str):
                 print(result)
-                return 0
+                return resolve_returncode(result)
             elif isinstance(result, bool):
                 return 0 if result else 1  # i.e. True is success
             elif isinstance(result, int):
                 return result
             else:
-                return 0
+                return resolve_returncode(result)
 
       **"print_str_return_zero"**
 
@@ -711,7 +713,7 @@ API
 
             if isinstance(result, str):
                 print(result)
-            return 0
+            return resolve_returncode(result)
 
       **"print_non_none_return_int_as_exit_code"**
 
@@ -725,7 +727,7 @@ API
                 return 0 if result else 1  # i.e. True is success
             elif isinstance(result, int):
                 return result
-            return 0
+            return resolve_returncode(result)
 
       **"print_non_none_return_zero"**
 
@@ -735,7 +737,7 @@ API
 
             if result is not None:
                 print(result)
-            return 0
+            return resolve_returncode(result)
 
       **"return_int_as_exit_code_else_zero"**
 
@@ -748,7 +750,7 @@ API
             elif isinstance(result, int):
                 return result
             else:
-                return 0
+                return resolve_returncode(result)
 
       **"return_none"**
 
@@ -764,7 +766,7 @@ API
 
          .. code-block:: python
 
-            return 0
+            return resolve_returncode(result)
 
       **"print_return_zero"**
 
@@ -773,7 +775,7 @@ API
          .. code-block:: python
 
             print(result)
-            return 0
+            return resolve_returncode(result)
 
       **"sys_exit_zero"**
 
@@ -781,7 +783,7 @@ API
 
          .. code-block:: python
 
-            sys.exit(0)
+            sys.exit(resolve_returncode(result))
 
       **"print_sys_exit_zero"**
 
@@ -790,7 +792,7 @@ API
          .. code-block:: python
 
             print(result)
-            sys.exit(0)
+            sys.exit(resolve_returncode(result))
 
       **Custom Callable**
 
@@ -1986,6 +1988,8 @@ API
 .. autofunction:: cyclopts.edit
 
 .. autofunction:: cyclopts.run
+
+.. autofunction:: cyclopts.resolve_returncode
 
 .. autoclass:: cyclopts.CycloptsPanel
 

--- a/docs/source/packaging.rst
+++ b/docs/source/packaging.rst
@@ -115,5 +115,79 @@ When using Cyclopts as a CLI application, command return values are automaticall
 This default behavior makes Cyclopts applications work consistently whether run directly as scripts or installed via `console_scripts entry points <https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts>`_. The :attr:`~cyclopts.App.result_action` can be customized if different behavior is needed:
 
 
+.. _custom-return-code-protocol:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Custom Return Code Protocol
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Whenever a built-in :attr:`~cyclopts.App.result_action` would otherwise use ``0`` as the exit code, Cyclopts checks the return value for a ``__cyclopts_returncode__`` method. If present, its return value is used as the exit code instead. This lets returned objects describe their own success/failure without forcing the CLI layer to translate them.
+
+A common use case is a CLI that wraps a library and returns rich result objects directly, deferring presentation to the object's ``__rich__`` method:
+
+.. code-block:: python
+
+   from cyclopts import App
+
+
+   class HealthCheck:
+       def __init__(self, service: str, healthy: bool):
+           self.service = service
+           self.healthy = healthy
+
+       def __rich__(self) -> str:
+           status = "[green]OK[/green]" if self.healthy else "[red]FAIL[/red]"
+           return f"{self.service}: {status}"
+
+       def __cyclopts_returncode__(self) -> int:
+           return 0 if self.healthy else 1
+
+
+   app = App()
+
+
+   @app.command
+   def check(service: str) -> HealthCheck:
+       """Check the health of a service."""
+       return HealthCheck(service, healthy=ping(service))
+
+
+   app()
+
+.. code-block:: console
+
+   $ my-script check database; echo "exit=$?"
+   database: OK
+   exit=0
+
+   $ my-script check cache; echo "exit=$?"
+   cache: FAIL
+   exit=1
+
+The protocol is opt-in: objects that don't define ``__cyclopts_returncode__`` continue to use the previous ``0`` default. The method must be a zero-argument callable that returns an :class:`int`; non-callable attributes are ignored. Branches that derive their exit code from an :class:`int` or :class:`bool` return value (e.g. ``sys.exit(result)``) ignore the protocol — return an integer/bool directly to set those exit codes.
+
+Custom ``result_action`` callables can opt into the same protocol via :func:`cyclopts.resolve_returncode`:
+
+.. code-block:: python
+
+   import sys
+   from typing import Any
+
+   from cyclopts import App, resolve_returncode
+
+
+   def result_action(result: Any) -> None:
+       if isinstance(result, bool):
+           sys.exit(0 if result else 1)
+       if isinstance(result, int):
+           sys.exit(result)
+       if result is not None:
+           print(result)
+       sys.exit(resolve_returncode(result))
+
+
+   app = App(result_action=result_action)
+
+
 .. _Poetry: https://python-poetry.org
 .. _entrypoint: https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points

--- a/tests/test_result_action.py
+++ b/tests/test_result_action.py
@@ -1327,3 +1327,294 @@ def test_result_action_call_if_callable_composition(monkeypatch):
 
     assert buf.getvalue() == "Hey Jude.\n"
     assert exit_code == 0
+
+
+# ==============================================================================
+# __cyclopts_returncode__ tests
+# ==============================================================================
+
+
+class _CustomResult:
+    """Result object that advertises a custom return code via __cyclopts_returncode__."""
+
+    def __init__(self, message: str = "custom", returncode: int = 7):
+        self.message = message
+        self._returncode = returncode
+
+    def __cyclopts_returncode__(self) -> int:
+        return self._returncode
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def test_cyclopts_returncode_print_non_int_sys_exit(monkeypatch):
+    """print_non_int_sys_exit honors __cyclopts_returncode__ for non-int results."""
+    app = App(result_action="print_non_int_sys_exit")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult("hi", returncode=7)
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        app(["run"])
+
+    assert exit_code == 7
+    assert buf.getvalue() == "hi\n"
+
+
+def test_cyclopts_returncode_sys_exit(monkeypatch):
+    """sys_exit honors __cyclopts_returncode__ for non-int results."""
+    app = App(result_action="sys_exit")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=3)
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        app(["run"])
+
+    assert exit_code == 3
+    assert buf.getvalue() == ""
+
+
+def test_cyclopts_returncode_print_non_int_return_int_as_exit_code():
+    """print_non_int_return_int_as_exit_code honors __cyclopts_returncode__."""
+    app = App(result_action="print_non_int_return_int_as_exit_code")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult("hello", returncode=4)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 4
+    assert buf.getvalue() == "hello\n"
+
+
+def test_cyclopts_returncode_print_str_return_int_as_exit_code_for_str_subclass():
+    """print_str_return_int_as_exit_code honors __cyclopts_returncode__ on str subclasses."""
+
+    class CustomStr(str):
+        def __cyclopts_returncode__(self) -> int:
+            return 9
+
+    app = App(result_action="print_str_return_int_as_exit_code")
+
+    @app.command
+    def run() -> CustomStr:
+        return CustomStr("hello")
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 9
+    assert buf.getvalue() == "hello\n"
+
+
+def test_cyclopts_returncode_print_str_return_int_as_exit_code_for_other():
+    """print_str_return_int_as_exit_code honors __cyclopts_returncode__ for non-str/int results."""
+    app = App(result_action="print_str_return_int_as_exit_code")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=5)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 5
+    assert buf.getvalue() == ""  # non-str silently ignored for printing
+
+
+def test_cyclopts_returncode_print_str_return_zero():
+    """print_str_return_zero honors __cyclopts_returncode__."""
+    app = App(result_action="print_str_return_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=6)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 6
+
+
+def test_cyclopts_returncode_print_non_none_return_int_as_exit_code():
+    """print_non_none_return_int_as_exit_code honors __cyclopts_returncode__."""
+    app = App(result_action="print_non_none_return_int_as_exit_code")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult("hi", returncode=8)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 8
+    assert buf.getvalue() == "hi\n"
+
+
+def test_cyclopts_returncode_print_non_none_return_zero():
+    """print_non_none_return_zero honors __cyclopts_returncode__."""
+    app = App(result_action="print_non_none_return_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult("hi", returncode=2)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 2
+    assert buf.getvalue() == "hi\n"
+
+
+def test_cyclopts_returncode_return_int_as_exit_code_else_zero():
+    """return_int_as_exit_code_else_zero honors __cyclopts_returncode__."""
+    app = App(result_action="return_int_as_exit_code_else_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=11)
+
+    result = app(["run"])
+    assert result == 11
+
+
+def test_cyclopts_returncode_return_zero():
+    """return_zero honors __cyclopts_returncode__."""
+    app = App(result_action="return_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=12)
+
+    result = app(["run"])
+    assert result == 12
+
+
+def test_cyclopts_returncode_print_return_zero():
+    """print_return_zero honors __cyclopts_returncode__."""
+    app = App(result_action="print_return_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult("hello", returncode=13)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 13
+    assert buf.getvalue() == "hello\n"
+
+
+def test_cyclopts_returncode_sys_exit_zero(monkeypatch):
+    """sys_exit_zero honors __cyclopts_returncode__."""
+    app = App(result_action="sys_exit_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=14)
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    app(["run"])
+
+    assert exit_code == 14
+
+
+def test_cyclopts_returncode_print_sys_exit_zero(monkeypatch):
+    """print_sys_exit_zero honors __cyclopts_returncode__."""
+    app = App(result_action="print_sys_exit_zero")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult("hi", returncode=15)
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        app(["run"])
+
+    assert exit_code == 15
+    assert buf.getvalue() == "hi\n"
+
+
+def test_cyclopts_returncode_falls_back_to_zero_when_not_callable():
+    """__cyclopts_returncode__ is ignored when not callable (fall back to 0)."""
+
+    class BadResult:
+        __cyclopts_returncode__ = 42  # not callable
+
+        def __str__(self) -> str:
+            return "bad"
+
+    app = App(result_action="print_non_int_return_int_as_exit_code")
+
+    @app.command
+    def run() -> BadResult:
+        return BadResult()
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["run"])
+
+    assert result == 0
+    assert buf.getvalue() == "bad\n"
+
+
+def test_cyclopts_returncode_default_zero_when_not_defined():
+    """Results without __cyclopts_returncode__ continue to use 0 as default."""
+    app = App(result_action="print_non_int_return_int_as_exit_code")
+
+    @app.command
+    def greet(name: str) -> str:
+        return f"Hello {name}!"
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["greet", "Alice"])
+
+    assert result == 0
+    assert buf.getvalue() == "Hello Alice!\n"


### PR DESCRIPTION
Addresses #804. While the usage is a bit niche, the maintenance burden on Cyclopts is very low, and I like to err on the side of making things easier/cleaner/elegant for the developer whenever possible.