### PR TITLE
docs: add missing typer Option imports in flag negation examples

### DIFF
--- a/docs/source/vs_typer/flag_negation/README.rst
+++ b/docs/source/vs_typer/flag_negation/README.rst
@@ -26,6 +26,7 @@ Overriding the option's name will disable Typer's negative-flag generation logic
 
    import typer
    from typing import Annotated
+   from typer import Option
 
    typer_app = typer.Typer()
 
@@ -44,6 +45,8 @@ To use a different negative flag, you can supply the name after a slash in your 
 .. code-block:: python
 
    import typer
+   from typing import Annotated
+   from typer import Option
 
    typer_app = typer.Typer()
 


### PR DESCRIPTION
Two code blocks in `docs/source/vs_typer/flag_negation/README.rst` use `Option` from typer without importing it, and the third block also lacks `from typing import Annotated`. Both examples would raise `NameError: name 'Option' is not defined` if run as-is.

Added `from typer import Option` (and `from typing import Annotated` where missing) to the two affected blocks.