### PR TITLE
fix zsh completion recursion when `prog_name` matches a builtin helper

### DIFF
--- a/cyclopts/completion/install.py
+++ b/cyclopts/completion/install.py
@@ -62,14 +62,17 @@ def get_default_completion_path(shell: Literal["zsh", "bash", "fish"], prog_name
     """
     home = Path.home()
     if shell == "zsh":
+        # Namespace the file as ``_cyclopts_<prog>`` so the autoload entry
+        # doesn't shadow zsh helpers (``_files``, ``_directories``, etc.) when
+        # ``<prog>`` happens to match one.
         omz_completions = _detect_omz_completions_dir()
         if omz_completions is not None:
             omz_completions.mkdir(parents=True, exist_ok=True)
-            return omz_completions / f"_{prog_name}"
+            return omz_completions / f"_cyclopts_{prog_name}"
         # Vanilla zsh fallback
         zsh_completions = home / ".zsh" / "completions"
         zsh_completions.mkdir(parents=True, exist_ok=True)
-        return zsh_completions / f"_{prog_name}"
+        return zsh_completions / f"_cyclopts_{prog_name}"
     elif shell == "bash":
         bash_completions = home / ".local" / "share" / "bash-completion" / "completions"
         bash_completions.mkdir(parents=True, exist_ok=True)

--- a/cyclopts/completion/zsh.py
+++ b/cyclopts/completion/zsh.py
@@ -52,10 +52,15 @@ def generate_completion_script(app: "App", prog_name: str) -> str:
 
     completion_data = extract_completion_data(app)
 
+    # Namespace the function (and the install file) as ``_cyclopts_<prog>`` so
+    # that command names which happen to match a zsh completion helper —
+    # ``files``, ``directories``, ``describe``, etc. — don't shadow the builtin
+    # when compinit autoloads our script. Plain ``_<prog>`` would otherwise
+    # recurse on internal ``_files`` / ``_directories`` calls.
     lines = [
         f"#compdef {prog_name}",
         "",
-        f"_{prog_name}() {{",
+        f"_cyclopts_{prog_name}() {{",
         "  local line state",
         "",
     ]

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2462,7 +2462,7 @@ class App:
             Shell type for completion. If not specified, attempts to auto-detect current shell.
         output : Path | None
             Output path for the completion script. If not specified, uses shell-specific default:
-            - zsh: ~/.zsh/completions/_<prog_name> (or $ZSH_CUSTOM/completions/_<prog_name> with oh-my-zsh)
+            - zsh: ~/.zsh/completions/_cyclopts_<prog_name> (or $ZSH_CUSTOM/completions/_cyclopts_<prog_name> with oh-my-zsh)
             - bash: ~/.local/share/bash-completion/completions/<prog_name>
             - fish: ~/.config/fish/completions/<prog_name>.fish
         add_to_startup : bool

--- a/docs/source/shell_completion.rst
+++ b/docs/source/shell_completion.rst
@@ -104,7 +104,7 @@ For programmatic control, use :meth:`App.install_completion <cyclopts.App.instal
 Default Installation Paths
 ---------------------------
 
-- **Zsh**: ``~/.zsh/completions/_<app_name>``
+- **Zsh**: ``~/.zsh/completions/_cyclopts_<app_name>``
 - **Bash**: ``~/.local/share/bash-completion/completions/<app_name>``
 - **Fish**: ``~/.config/fish/completions/<app_name>.fish``
 

--- a/tests/completion/conftest.py
+++ b/tests/completion/conftest.py
@@ -294,7 +294,7 @@ class ZshCompletionTester(CompletionTesterBase):
 
     def validate_script_syntax(self) -> bool:
         with tempfile.TemporaryDirectory() as tmpdir:
-            comp_file = Path(tmpdir) / f"_{self.prog_name}"
+            comp_file = Path(tmpdir) / f"_cyclopts_{self.prog_name}"
             comp_file.write_text(self.completion_script)
             result = subprocess.run(
                 ["zsh", "-n", str(comp_file)],
@@ -312,7 +312,7 @@ class ZshCompletionTester(CompletionTesterBase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             td = Path(tmpdir)
-            (td / f"_{self.prog_name}").write_text(self.completion_script)
+            (td / f"_cyclopts_{self.prog_name}").write_text(self.completion_script)
 
             (td / ".zshrc").write_text(
                 "PROMPT='ZTEST> '\n"

--- a/tests/completion/test_install.py
+++ b/tests/completion/test_install.py
@@ -336,11 +336,11 @@ def test_install_completion_command_fish(temp_home, monkeypatch, capsys):
 
 
 def test_install_completion_zsh_ohmyzsh_default_path(omz_dir):
-    """Test that $ZSH set with valid dir installs to $ZSH/custom/completions/_testapp."""
+    """Test that $ZSH set with valid dir installs to $ZSH/custom/completions/_cyclopts_testapp."""
     app = App(name="testapp")
     install_path = app.install_completion(shell="zsh", add_to_startup=True)
 
-    assert install_path == omz_dir / "custom" / "completions" / "_testapp"
+    assert install_path == omz_dir / "custom" / "completions" / "_cyclopts_testapp"
     assert install_path.exists()
 
 
@@ -353,7 +353,7 @@ def test_install_completion_zsh_ohmyzsh_zsh_custom_env(omz_dir, temp_home, monke
     app = App(name="testapp")
     install_path = app.install_completion(shell="zsh", add_to_startup=True)
 
-    assert install_path == custom_dir / "completions" / "_testapp"
+    assert install_path == custom_dir / "completions" / "_cyclopts_testapp"
     assert install_path.exists()
 
 
@@ -373,7 +373,7 @@ def test_install_completion_zsh_ohmyzsh_dir_missing(temp_home, monkeypatch):
     app = App(name="testapp")
     install_path = app.install_completion(shell="zsh", add_to_startup=False)
 
-    expected = temp_home / ".zsh" / "completions" / "_testapp"
+    expected = temp_home / ".zsh" / "completions" / "_cyclopts_testapp"
     assert install_path == expected
     assert install_path.exists()
 

--- a/tests/completion/test_zsh.py
+++ b/tests/completion/test_zsh.py
@@ -1167,6 +1167,13 @@ def test_collection_option_repeats(zsh_tester):
     Without ``*`` prefix on the spec, zsh would refuse to complete a second
     ``--file`` value, breaking the natural ``--file a --file b --file c``
     usage of collection-typed parameters.
+
+    Doubles as a regression test for issue #821: prog_name ``files`` happens
+    to match zsh's built-in ``_files`` completion helper, so the generated
+    autoload entry must be namespaced (e.g. ``_cyclopts_files``) — otherwise
+    ``_arguments``'s ``:file:_files`` action recurses into our own function
+    and zsh hits its recursion limit (visible on macOS as a captured error
+    string, fatal pty EOF on aarch64 Linux/Nix).
     """
     import os
     import tempfile
@@ -1187,7 +1194,10 @@ def test_collection_option_repeats(zsh_tester):
             completions = tester.get_completions("files --file first.txt --file ")
         finally:
             os.chdir(cwd)
-    assert completions, f"expected file completion on second --file, got {completions!r}"
+    # Assert the actual file appears — not just *some* output. Without a
+    # tight assertion zsh's "recursion limit exceeded" error gets scraped
+    # as a "completion" and the test silently passes.
+    assert "first.txt" in completions, f"expected 'first.txt' in file completion on second --file, got {completions!r}"
 
 
 def test_multiple_iterable_positionals_emit_one_rest_spec(zsh_tester):


### PR DESCRIPTION
The generated zsh autoload entry was named `_<prog>`, which shadows zsh's builtin `_files` / `_directories` / `_arguments` / ... helpers when `<prog>` happens to match one. `_arguments`'s `:file:_files` action then recurses back into our own function instead of the real builtin — on macOS this surfaces as a "recursion limit exceeded" message that gets scraped as a phantom completion (test silently passed); on aarch64 Linux under Nix the pty closes and pexpect sees EOF (issue #821).

Namespace the autoloaded function and install path as `_cyclopts_<prog>` so internal helper calls always resolve to the real zsh builtins.

Tighten `test_collection_option_repeats` to assert that `first.txt` appears in the completion list — the previous `assert completions` was satisfied by the recursion-error text and masked the bug.

Fixes #821. @PerchunPak can you confirm this on your side?