### PR TITLE
Add PyPI publish attestations to releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,5 +21,5 @@ jobs:
           fetch-depth: 0  # Needed for hatch-vcs to get version from git tags
       - uses: astral-sh/setup-uv@v7
       - run: uv build
-      - run: uv publish
+      - uses: pypa/gh-action-pypi-publish@v1.14.0
         if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
### Summary

Hi! This switches the release upload step from `uv publish` to `pypa/gh-action-pypi-publish@v1.14.0`.

Cyclopts already publishes from GitHub Actions using PyPI Trusted Publishing/OIDC. Using the official PyPA publish action should preserve that flow while generating PyPI publish attestations by default. Those attestations bind each uploaded distribution to the GitHub Actions workflow that published it, giving PyPI and downstream users stronger provenance for the release artifacts.

### Possible follow-ups

I kept this PR intentionally small for reviewability, but I noticed a few related release-hardening opportunities while looking at the workflow:

- Pin GitHub Actions to full commit SHAs. GitHub recommends this in its [Actions security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), since tags can move or be compromised.
- Avoid cache use in the release/publish flow, which reduces cache-poisoning risk around artifacts being published to PyPI.
- Split build and publish into separate jobs, so `id-token: write` is only available in the final upload job.

Happy to make any of these changes here or in follow-up PRs, whichever you prefer.

### Testing

Not run; workflow-only change.