### PR TITLE
Harden PyPI publish workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,19 +7,35 @@ on:
       - "v*.*.*"
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
-    environment:
-      name: pypi
-      url: https://pypi.org/p/cyclopts
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Needed for hatch-vcs to get version from git tags
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
       - run: uv build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cyclopts
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@v1.14.0
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,7 @@ jobs:
 
   publish:
     needs: build
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -38,4 +39,3 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@v1.14.0
-        if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,5 +21,5 @@ jobs:
           fetch-depth: 0  # Needed for hatch-vcs to get version from git tags
       - uses: astral-sh/setup-uv@v7
       - run: uv build
-      - run: uv publish
+      - uses: pypa/gh-action-pypi-publish@v1.14.0
         if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
## Summary

Stacked on top of #828.

- Split the release workflow into separate `build` and `publish` jobs
  - Keeps package building separate from the job that can mint a PyPI trusted publishing token
  - Follows PyPA's recommendation to separate building from publishing
- Scope `id-token: write` to the `publish` job only
  - Ensures OIDC publishing privileges are only available at the point of upload to PyPI
- Pass built distributions through GitHub Actions artifacts
- Disable `setup-uv` caching in the release build path
  - Defense-in-depth measure; avoids building release artifacts from cache state that could be potentially poisoned by other workflow runs