### PR TITLE
New Attribute: `Parameter.short_alias` to automatically generate short aliases for parameters.

### DIFF
--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -375,9 +375,7 @@ class ArgumentCollection(list[Argument]):
         # Phase 1 here reserves explicit shorts and records eligibility; the actual short is
         # generated in phase 2 (see ``_from_callable``) once every explicit short is known,
         # so an earlier parameter's auto short can't shadow a later parameter's explicit one.
-        if pending_short_aliases is not None and reserve_short_alias(
-            argument, immediate_parameter, used_short_aliases, top_level=not keys
-        ):
+        if pending_short_aliases is not None and reserve_short_alias(argument, immediate_parameter, used_short_aliases):
             pending_short_aliases.append((argument, field_info))
 
         if positional_index is not None:

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -480,12 +480,12 @@ class ArgumentCollection(list[Argument]):
                 }
             else:
                 subkey_docstring_lookup = None
-            auto_alias = field_info.kind is field_info.KEYWORD_ONLY or (
+            short_alias = field_info.kind is field_info.KEYWORD_ONLY or (
                 field_info.kind is field_info.POSITIONAL_OR_KEYWORD and not has_star and not field_info.required
             )
             field_parameters: list[Parameter | None] = [
                 Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
-                None if auto_alias else Parameter(auto_alias=False),
+                None if short_alias else Parameter(short_alias=False),
             ]
             iparam_argument_collection = cls._from_type(
                 field_info,

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -14,7 +14,6 @@ from cyclopts.exceptions import (
     UnknownOptionError,
 )
 from cyclopts.field_info import (
-    FieldInfo,
     signature_parameters,
 )
 from cyclopts.group import Group
@@ -244,7 +243,7 @@ class ArgumentCollection(list[Argument]):
         docstring_lookup: dict[tuple[str, ...], Parameter] | None = None,
         positional_index: int | None = None,
         used_short_aliases: set[str] | None = None,
-        pending_short_aliases: list[tuple["Argument", FieldInfo]] | None = None,
+        pending_short_aliases: list["Argument"] | None = None,
         _resolve_groups: bool = True,
     ):
         from cyclopts.parameter import get_parameters
@@ -378,7 +377,7 @@ class ArgumentCollection(list[Argument]):
         # ``_from_callable``) once every explicit short is known, so an earlier parameter's
         # auto short can't shadow a later parameter's explicit one.
         if pending_short_aliases is not None and reserve_short_alias(argument, immediate_parameter, used_short_aliases):
-            pending_short_aliases.append((argument, field_info))
+            pending_short_aliases.append(argument)
 
         if positional_index is not None:
             if not argument._accepts_keywords or argument._enum_flag_type:
@@ -477,7 +476,7 @@ class ArgumentCollection(list[Argument]):
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
         used_short_aliases: set[str] = set(reserved or ())
-        pending_short_aliases: list[tuple[Argument, FieldInfo]] = []
+        pending_short_aliases: list[Argument] = []
         for field_info in signature_parameters(func).values():
             if parse_docstring:
                 subkey_docstring_lookup = {
@@ -509,8 +508,8 @@ class ArgumentCollection(list[Argument]):
         # Phase 2: now that every explicit short flag has been reserved, generate auto
         # shorts in tree order (first-wins). Deferring to here ensures an explicit alias
         # on a later parameter is never shadowed by an earlier parameter's auto short.
-        for argument, field_info in pending_short_aliases:
-            shorts = generate_short_alias(argument, field_info, used_short_aliases)
+        for argument in pending_short_aliases:
+            shorts = generate_short_alias(argument, used_short_aliases)
             if shorts:
                 assert isinstance(argument.parameter.name, tuple)
                 argument.parameter = Parameter.combine(

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -370,8 +370,8 @@ class ArgumentCollection(list[Argument]):
         argument = Argument(field_info=field_info, parameter=cparam, keys=keys, hint=hint)
 
         # Auto-generate a short alias (e.g. ``-e`` for ``--env``), appended as a standalone
-        # flag. Gated to top-level (or explicitly opted-in) input-binding parameters so that
-        # promoted containers and nested fields don't silently claim or namespace letters.
+        # flag. Gated to root-namespace (or explicitly opted-in) input-binding parameters so
+        # that promoted containers and dotted nested fields don't silently claim letters.
         # Phase 1 here reserves explicit shorts and records eligibility; the actual short is
         # generated in phase 2 (see ``_from_callable``) once every explicit short is known,
         # so an earlier parameter's auto short can't shadow a later parameter's explicit one.
@@ -483,19 +483,11 @@ class ArgumentCollection(list[Argument]):
                 }
             else:
                 subkey_docstring_lookup = None
-            # Any parameter that exposes a ``--long`` keyword form is short-eligible; the
-            # short flag is just a shorthand for that long flag. Purely-positional kinds
-            # (positional-only, ``*args``, ``**kwargs``) have no long form, so no short.
-            short_alias = field_info.kind in (field_info.POSITIONAL_OR_KEYWORD, field_info.KEYWORD_ONLY)
-            field_parameters: list[Parameter | None] = [
-                Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
-                None if short_alias else Parameter(short_alias=False),
-            ]
             iparam_argument_collection = cls._from_type(
                 field_info,
                 (),
                 *default_parameters,
-                *field_parameters,
+                Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
                 group_lookup=group_lookup,
                 group_arguments=group_arguments,
                 group_parameters=group_parameters,

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -14,6 +14,7 @@ from cyclopts.exceptions import (
     UnknownOptionError,
 )
 from cyclopts.field_info import (
+    FieldInfo,
     signature_parameters,
 )
 from cyclopts.group import Group
@@ -243,7 +244,7 @@ class ArgumentCollection(list[Argument]):
         docstring_lookup: dict[tuple[str, ...], Parameter] | None = None,
         positional_index: int | None = None,
         used_short_aliases: set[str] | None = None,
-        pending_short_aliases: list[tuple["Argument", Any]] | None = None,
+        pending_short_aliases: list[tuple["Argument", FieldInfo]] | None = None,
         _resolve_groups: bool = True,
     ):
         from cyclopts.parameter import get_parameters
@@ -475,7 +476,7 @@ class ArgumentCollection(list[Argument]):
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
         used_short_aliases: set[str] = set(reserved or ())
-        pending_short_aliases: list[tuple[Argument, Any]] = []
+        pending_short_aliases: list[tuple[Argument, FieldInfo]] = []
         for field_info in signature_parameters(func).values():
             if parse_docstring:
                 subkey_docstring_lookup = {

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -27,7 +27,8 @@ from .utils import (
     PARAMETER_SUBKEY_BLOCKER,
     extract_docstring_help,
     generate_short_alias,
-    reserve_short_alias,
+    is_short_alias_eligible,
+    reserve_explicit_shorts,
     resolve_parameter_name,
     to_cli_option_name,
     walk_leaves,
@@ -371,13 +372,16 @@ class ArgumentCollection(list[Argument]):
 
         # Auto-generate a short alias (e.g. ``-e`` for ``--env``), appended as a standalone
         # flag. Gated to root-namespace input-binding parameters so that promoted containers
-        # and dotted nested fields don't silently claim letters. Phase 1 here still reserves
-        # explicit shorts from *every* argument (including nested fields, whose explicit shorts
-        # are global) and records eligibility; the actual short is generated in phase 2 (see
-        # ``_from_callable``) once every explicit short is known, so an earlier parameter's
-        # auto short can't shadow a later parameter's explicit one.
-        if pending_short_aliases is not None and reserve_short_alias(argument, immediate_parameter, used_short_aliases):
-            pending_short_aliases.append(argument)
+        # and dotted nested fields don't silently claim letters. Phase 1 reserves explicit
+        # shorts from *every* argument (including nested fields, whose explicit shorts are
+        # global) and collects eligible arguments; the actual short is generated in phase 2
+        # (see ``_from_callable``) once every explicit short is known, so an earlier
+        # parameter's auto short can't shadow a later parameter's explicit one.
+        if used_short_aliases is not None:
+            reserve_explicit_shorts(argument, used_short_aliases)
+            if is_short_alias_eligible(argument, immediate_parameter):
+                assert pending_short_aliases is not None
+                pending_short_aliases.append(argument)
 
         if positional_index is not None:
             if not argument._accepts_keywords or argument._enum_flag_type:

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -470,19 +470,18 @@ class ArgumentCollection(list[Argument]):
 
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
-        params = signature_parameters(func).values()
         used_short_aliases: set[str] = set(reserved or ())
-        has_star = any(p.kind is p.KEYWORD_ONLY for p in params)
-        for field_info in params:
+        for field_info in signature_parameters(func).values():
             if parse_docstring:
                 subkey_docstring_lookup = {
                     k[1:]: v for k, v in docstring_lookup.items() if k[0] == field_info.name and len(k) > 1
                 }
             else:
                 subkey_docstring_lookup = None
-            short_alias = field_info.kind is field_info.KEYWORD_ONLY or (
-                field_info.kind is field_info.POSITIONAL_OR_KEYWORD and not has_star and not field_info.required
-            )
+            # Any parameter that exposes a ``--long`` keyword form is short-eligible; the
+            # short flag is just a shorthand for that long flag. Purely-positional kinds
+            # (positional-only, ``*args``, ``**kwargs``) have no long form, so no short.
+            short_alias = field_info.kind in (field_info.POSITIONAL_OR_KEYWORD, field_info.KEYWORD_ONLY)
             field_parameters: list[Parameter | None] = [
                 Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
                 None if short_alias else Parameter(short_alias=False),

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -440,6 +440,7 @@ class ArgumentCollection(list[Argument]):
         group_parameters: Group | None = None,
         parse_docstring: bool = True,
         _resolve_groups: bool = True,
+        reserved: Iterable[str] | None = None,
     ):
         out = cls()
 
@@ -463,7 +464,7 @@ class ArgumentCollection(list[Argument]):
 
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
-        used_short_aliases: set[str] = set()
+        used_short_aliases: set[str] = set(reserved or ())
         for field_info in signature_parameters(func).values():
             if parse_docstring:
                 subkey_docstring_lookup = {

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -371,11 +371,12 @@ class ArgumentCollection(list[Argument]):
         argument = Argument(field_info=field_info, parameter=cparam, keys=keys, hint=hint)
 
         # Auto-generate a short alias (e.g. ``-e`` for ``--env``), appended as a standalone
-        # flag. Gated to root-namespace (or explicitly opted-in) input-binding parameters so
-        # that promoted containers and dotted nested fields don't silently claim letters.
-        # Phase 1 here reserves explicit shorts and records eligibility; the actual short is
-        # generated in phase 2 (see ``_from_callable``) once every explicit short is known,
-        # so an earlier parameter's auto short can't shadow a later parameter's explicit one.
+        # flag. Gated to root-namespace input-binding parameters so that promoted containers
+        # and dotted nested fields don't silently claim letters. Phase 1 here still reserves
+        # explicit shorts from *every* argument (including nested fields, whose explicit shorts
+        # are global) and records eligibility; the actual short is generated in phase 2 (see
+        # ``_from_callable``) once every explicit short is known, so an earlier parameter's
+        # auto short can't shadow a later parameter's explicit one.
         if pending_short_aliases is not None and reserve_short_alias(argument, immediate_parameter, used_short_aliases):
             pending_short_aliases.append((argument, field_info))
 

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -26,8 +26,8 @@ from .utils import (
     KIND_PARENT_CHILD_REASSIGNMENT,
     PARAMETER_SUBKEY_BLOCKER,
     extract_docstring_help,
-    maybe_apply_auto_alias,
     resolve_parameter_name,
+    resolve_short_alias,
     to_cli_option_name,
     walk_leaves,
 )
@@ -320,7 +320,7 @@ class ArgumentCollection(list[Argument]):
                 PARAMETER_SUBKEY_BLOCKER,
                 immediate_parameter,
             )
-            cparam = maybe_apply_auto_alias(cparam, field_info, immediate_parameter, used_short_aliases)
+            cparam = resolve_short_alias(cparam, field_info, immediate_parameter, used_short_aliases)
             cparam = Parameter.combine(
                 cparam,
                 Parameter(
@@ -336,7 +336,7 @@ class ArgumentCollection(list[Argument]):
                 upstream_parameter,
                 immediate_parameter,
             )
-            cparam = maybe_apply_auto_alias(cparam, field_info, immediate_parameter, used_short_aliases)
+            cparam = resolve_short_alias(cparam, field_info, immediate_parameter, used_short_aliases)
             assert isinstance(cparam.alias, tuple)
             if cparam.name:
                 if field_info.is_keyword:

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -26,8 +26,9 @@ from .utils import (
     KIND_PARENT_CHILD_REASSIGNMENT,
     PARAMETER_SUBKEY_BLOCKER,
     extract_docstring_help,
+    generate_short_alias,
+    reserve_short_alias,
     resolve_parameter_name,
-    resolve_short_alias,
     to_cli_option_name,
     walk_leaves,
 )
@@ -242,6 +243,7 @@ class ArgumentCollection(list[Argument]):
         docstring_lookup: dict[tuple[str, ...], Parameter] | None = None,
         positional_index: int | None = None,
         used_short_aliases: set[str] | None = None,
+        pending_short_aliases: list[tuple["Argument", Any]] | None = None,
         _resolve_groups: bool = True,
     ):
         from cyclopts.parameter import get_parameters
@@ -370,10 +372,13 @@ class ArgumentCollection(list[Argument]):
         # Auto-generate a short alias (e.g. ``-e`` for ``--env``), appended as a standalone
         # flag. Gated to top-level (or explicitly opted-in) input-binding parameters so that
         # promoted containers and nested fields don't silently claim or namespace letters.
-        shorts = resolve_short_alias(argument, field_info, immediate_parameter, used_short_aliases, top_level=not keys)
-        if shorts:
-            assert isinstance(argument.parameter.name, tuple)
-            argument.parameter = Parameter.combine(argument.parameter, Parameter(name=argument.parameter.name + shorts))
+        # Phase 1 here reserves explicit shorts and records eligibility; the actual short is
+        # generated in phase 2 (see ``_from_callable``) once every explicit short is known,
+        # so an earlier parameter's auto short can't shadow a later parameter's explicit one.
+        if pending_short_aliases is not None and reserve_short_alias(
+            argument, immediate_parameter, used_short_aliases, top_level=not keys
+        ):
+            pending_short_aliases.append((argument, field_info))
 
         if positional_index is not None:
             if not argument._accepts_keywords or argument._enum_flag_type:
@@ -423,6 +428,7 @@ class ArgumentCollection(list[Argument]):
                     docstring_lookup=subkey_docstring_lookup,
                     positional_index=positional_index,
                     used_short_aliases=used_short_aliases,
+                    pending_short_aliases=pending_short_aliases,
                     _resolve_groups=_resolve_groups,
                 )
                 if subkey_argument_collection:
@@ -471,6 +477,7 @@ class ArgumentCollection(list[Argument]):
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
         used_short_aliases: set[str] = set(reserved or ())
+        pending_short_aliases: list[tuple[Argument, Any]] = []
         for field_info in signature_parameters(func).values():
             if parse_docstring:
                 subkey_docstring_lookup = {
@@ -496,6 +503,7 @@ class ArgumentCollection(list[Argument]):
                 group_parameters=group_parameters,
                 positional_index=positional_index,
                 used_short_aliases=used_short_aliases,
+                pending_short_aliases=pending_short_aliases,
                 parse_docstring=parse_docstring,
                 docstring_lookup=subkey_docstring_lookup,
                 _resolve_groups=_resolve_groups,
@@ -505,6 +513,17 @@ class ArgumentCollection(list[Argument]):
                 if positional_index is not None:
                     positional_index += 1
             out.extend(iparam_argument_collection)
+
+        # Phase 2: now that every explicit short flag has been reserved, generate auto
+        # shorts in tree order (first-wins). Deferring to here ensures an explicit alias
+        # on a later parameter is never shadowed by an earlier parameter's auto short.
+        for argument, field_info in pending_short_aliases:
+            shorts = generate_short_alias(argument, field_info, used_short_aliases)
+            if shorts:
+                assert isinstance(argument.parameter.name, tuple)
+                argument.parameter = Parameter.combine(
+                    argument.parameter, Parameter(name=argument.parameter.name + shorts)
+                )
 
         return out
 

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -320,7 +320,6 @@ class ArgumentCollection(list[Argument]):
                 PARAMETER_SUBKEY_BLOCKER,
                 immediate_parameter,
             )
-            cparam = resolve_short_alias(cparam, field_info, immediate_parameter, used_short_aliases)
             cparam = Parameter.combine(
                 cparam,
                 Parameter(
@@ -336,7 +335,6 @@ class ArgumentCollection(list[Argument]):
                 upstream_parameter,
                 immediate_parameter,
             )
-            cparam = resolve_short_alias(cparam, field_info, immediate_parameter, used_short_aliases)
             assert isinstance(cparam.alias, tuple)
             if cparam.name:
                 if field_info.is_keyword:
@@ -368,6 +366,14 @@ class ArgumentCollection(list[Argument]):
             positional_index = None
 
         argument = Argument(field_info=field_info, parameter=cparam, keys=keys, hint=hint)
+
+        # Auto-generate a short alias (e.g. ``-e`` for ``--env``), appended as a standalone
+        # flag. Gated to top-level (or explicitly opted-in) input-binding parameters so that
+        # promoted containers and nested fields don't silently claim or namespace letters.
+        shorts = resolve_short_alias(argument, field_info, immediate_parameter, used_short_aliases, top_level=not keys)
+        if shorts:
+            assert isinstance(argument.parameter.name, tuple)
+            argument.parameter = Parameter.combine(argument.parameter, Parameter(name=argument.parameter.name + shorts))
 
         if positional_index is not None:
             if not argument._accepts_keywords or argument._enum_flag_type:

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -464,19 +464,28 @@ class ArgumentCollection(list[Argument]):
 
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
+        params = signature_parameters(func).values()
         used_short_aliases: set[str] = set(reserved or ())
-        for field_info in signature_parameters(func).values():
+        has_star = any(p.kind is p.KEYWORD_ONLY for p in params)
+        for field_info in params:
             if parse_docstring:
                 subkey_docstring_lookup = {
                     k[1:]: v for k, v in docstring_lookup.items() if k[0] == field_info.name and len(k) > 1
                 }
             else:
                 subkey_docstring_lookup = None
+            auto_alias = field_info.kind is field_info.KEYWORD_ONLY or (
+                field_info.kind is field_info.POSITIONAL_OR_KEYWORD and not has_star and not field_info.required
+            )
+            field_parameters: list[Parameter | None] = [
+                Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
+                None if auto_alias else Parameter(auto_alias=False),
+            ]
             iparam_argument_collection = cls._from_type(
                 field_info,
                 (),
                 *default_parameters,
-                Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
+                *field_parameters,
                 group_lookup=group_lookup,
                 group_arguments=group_arguments,
                 group_parameters=group_parameters,

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -26,6 +26,7 @@ from .utils import (
     KIND_PARENT_CHILD_REASSIGNMENT,
     PARAMETER_SUBKEY_BLOCKER,
     extract_docstring_help,
+    maybe_apply_auto_alias,
     resolve_parameter_name,
     to_cli_option_name,
     walk_leaves,
@@ -240,6 +241,7 @@ class ArgumentCollection(list[Argument]):
         parse_docstring: bool = True,
         docstring_lookup: dict[tuple[str, ...], Parameter] | None = None,
         positional_index: int | None = None,
+        used_short_aliases: set[str] | None = None,
         _resolve_groups: bool = True,
     ):
         from cyclopts.parameter import get_parameters
@@ -318,6 +320,7 @@ class ArgumentCollection(list[Argument]):
                 PARAMETER_SUBKEY_BLOCKER,
                 immediate_parameter,
             )
+            cparam = maybe_apply_auto_alias(cparam, field_info, immediate_parameter, used_short_aliases)
             cparam = Parameter.combine(
                 cparam,
                 Parameter(
@@ -333,6 +336,7 @@ class ArgumentCollection(list[Argument]):
                 upstream_parameter,
                 immediate_parameter,
             )
+            cparam = maybe_apply_auto_alias(cparam, field_info, immediate_parameter, used_short_aliases)
             assert isinstance(cparam.alias, tuple)
             if cparam.name:
                 if field_info.is_keyword:
@@ -412,6 +416,7 @@ class ArgumentCollection(list[Argument]):
                     parse_docstring=parse_docstring,
                     docstring_lookup=subkey_docstring_lookup,
                     positional_index=positional_index,
+                    used_short_aliases=used_short_aliases,
                     _resolve_groups=_resolve_groups,
                 )
                 if subkey_argument_collection:
@@ -458,6 +463,7 @@ class ArgumentCollection(list[Argument]):
 
         docstring_lookup = extract_docstring_help(func) if parse_docstring else {}
         positional_index = 0
+        used_short_aliases: set[str] = set()
         for field_info in signature_parameters(func).values():
             if parse_docstring:
                 subkey_docstring_lookup = {
@@ -474,6 +480,7 @@ class ArgumentCollection(list[Argument]):
                 group_arguments=group_arguments,
                 group_parameters=group_parameters,
                 positional_index=positional_index,
+                used_short_aliases=used_short_aliases,
                 parse_docstring=parse_docstring,
                 docstring_lookup=subkey_docstring_lookup,
                 _resolve_groups=_resolve_groups,

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -171,44 +171,48 @@ def _is_root_namespace(names: str | Iterable[str] | None) -> bool:
     return any(n.startswith("--") and "." not in n for n in (names or ()))
 
 
-def reserve_short_alias(
-    argument: "Argument",
-    immediate_parameter: Parameter,
-    used_short_aliases: set[str] | None,
-) -> bool:
-    """Phase 1: reserve explicitly-provided short flags and report auto-short eligibility.
+def reserve_explicit_shorts(argument: "Argument", used_short_aliases: set[str]) -> None:
+    """Phase 1a: reserve every explicitly-provided short flag into ``used_short_aliases``.
 
-    Runs while the argument tree is being built. Every short flag the user explicitly
-    supplied via ``name`` or ``alias`` is reserved into ``used_short_aliases`` here, so
-    that auto-generation (phase 2, deferred until the whole tree is known) avoids them
-    regardless of parameter ordering.
-
-    Returns :obj:`True` if this argument is eligible for an auto-generated short flag.
-    Auto shorts apply to **input-binding** parameters only (scalars, dicts, enum flags) —
-    never to promoted containers whose fields become child options. They apply only to
-    **root-namespace** parameters (an undotted long flag). A field that stays namespaced
-    (e.g. ``--user.name``) never gets one — ``short_alias`` on such a field is inert;
-    flatten it to the root namespace via ``name="*"`` to expose it for a short.
+    Runs for *every* argument as the tree is built (independent of eligibility), so that
+    auto-generation (phase 2, deferred until the whole tree is known) avoids user-supplied
+    shorts regardless of parameter ordering. At this point no auto short has been appended
+    yet, so any single-letter flag present is necessarily user-provided.
     """
-    if used_short_aliases is None:
-        return False
-
     cparam = argument.parameter
-
-    # Reserve every explicit short flag (from name or alias) so auto-generated shorts
-    # avoid them. At this point no auto short has been appended yet, so any single-letter
-    # flag present is necessarily user-provided.
     for flag in (*(cparam.name or ()), *(cparam.alias or ())):
         if is_short_flag(flag):
             used_short_aliases.add(flag)
 
+
+def is_short_alias_eligible(argument: "Argument", immediate_parameter: Parameter) -> bool:
+    """Phase 1b: pure predicate for whether this argument should receive an auto-generated short flag.
+
+    Auto shorts apply to opted-in (``short_alias``), **input-binding** parameters only
+    (scalars, dicts, enum flags) — never to promoted containers whose fields become child
+    options. They apply only to **root-namespace** parameters (an undotted long flag). A
+    field that stays namespaced (e.g. ``--user.name``) never gets one — ``short_alias`` on
+    such a field is inert; flatten it to the root namespace via ``name="*"`` to expose it.
+    """
+    cparam = argument.parameter
+
+    if not cparam.short_alias:
+        return False
+
     # An explicitly-provided alias or name suppresses auto-generation: the user has taken
     # manual control of this parameter's flags, so Cyclopts only uses what they supplied.
-    # (``name="*"`` flattening sets ``name`` on a container, which is excluded below anyway;
-    # its promoted children carry no explicit ``name`` and remain eligible.)
-    explicit_alias = "alias" in immediate_parameter._provided_args
-    explicit_name = "name" in immediate_parameter._provided_args
-    if explicit_alias or cparam.alias or explicit_name:
+    # The checks deliberately differ:
+    #   - ``name`` uses ``immediate_parameter._provided_args`` (the user's own annotation),
+    #     because Cyclopts always re-injects a resolved ``name`` into ``cparam`` — so
+    #     ``"name" in cparam._provided_args`` is always True and useless here.
+    #   - ``alias`` uses ``cparam.alias`` *truthiness* rather than ``_provided_args``:
+    #     internal subkey combining (``PARAMETER_SUBKEY_BLOCKER``) injects ``alias=None``,
+    #     which pollutes ``cparam._provided_args`` with a spurious ``"alias"``. Truthiness
+    #     ignores that ``None`` while still catching a real alias from a global
+    #     ``App(default_parameter=Parameter(alias=...))``.
+    # (``name="*"`` flattening sets ``name`` on a container, excluded below anyway; its
+    # promoted children carry no explicit ``name`` and remain eligible.)
+    if "name" in immediate_parameter._provided_args or "alias" in immediate_parameter._provided_args or cparam.alias:
         return False
 
     # Root-namespace only. A field that stays namespaced (e.g. ``--user.name``) never gets

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -209,6 +209,11 @@ def resolve_short_alias(
     if not short:
         return None
     shorts = (short,) if isinstance(short, str) else tuple(short)
+    # Drop any short already claimed by an earlier parameter (first-wins), so a
+    # callable that ignores ``used_short_aliases`` can't create duplicate flags.
+    shorts = tuple(s for s in shorts if s not in used_short_aliases)
+    if not shorts:
+        return None
     used_short_aliases.update(shorts)
     return shorts
 

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -153,7 +153,7 @@ def enum_flag_from_dict(
     return convert_enum_flag(enum_type, (k for k, v in data.items() if v), name_transform)
 
 
-def _is_short_flag(flag: str) -> bool:
+def is_short_flag(flag: str) -> bool:
     """Return :obj:`True` for a single-letter flag like ``-e`` (not ``--env`` or ``-`` alone)."""
     return len(flag) == 2 and flag[0] == "-" and flag[1] != "-"
 
@@ -199,7 +199,7 @@ def reserve_short_alias(
     # avoid them. At this point no auto short has been appended yet, so any single-letter
     # flag present is necessarily user-provided.
     for flag in (*(cparam.name or ()), *(cparam.alias or ())):
-        if _is_short_flag(flag):
+        if is_short_flag(flag):
             used_short_aliases.add(flag)
 
     # An explicitly-provided alias or name suppresses auto-generation: the user has taken

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -153,43 +153,75 @@ def enum_flag_from_dict(
     return convert_enum_flag(enum_type, (k for k, v in data.items() if v), name_transform)
 
 
-def resolve_short_alias(
+def _is_short_flag(flag: str) -> bool:
+    """Return :obj:`True` for a single-letter flag like ``-e`` (not ``--env`` or ``-`` alone)."""
+    return len(flag) == 2 and flag[0] == "-" and flag[1] != "-"
+
+
+def reserve_short_alias(
     argument: "Argument",
-    field_info: FieldInfo,
     immediate_parameter: Parameter,
     used_short_aliases: set[str] | None,
     *,
     top_level: bool,
-) -> tuple[str, ...] | None:
-    """Reserve explicit short aliases and, when eligible, generate an auto short flag.
+) -> bool:
+    """Phase 1: reserve explicitly-provided short flags and report auto-short eligibility.
 
-    Auto-generated short flags apply to **input-binding** parameters only (scalars,
-    dicts, enum flags) — never to promoted containers whose fields become child
-    options. By default they only apply to **top-level** command parameters; a nested
-    field opts in explicitly via ``Annotated[..., Parameter(short_alias=...)]``.
+    Runs while the argument tree is being built. Every short flag the user explicitly
+    supplied via ``name`` or ``alias`` is reserved into ``used_short_aliases`` here, so
+    that auto-generation (phase 2, deferred until the whole tree is known) avoids them
+    regardless of parameter ordering.
 
-    Returns the generated short name(s) to append to the argument's name as standalone
-    flags (so they surface globally, e.g. ``-e``, never dotted like ``-u.name``), or
-    :obj:`None`. Always mutates ``used_short_aliases`` to reserve claimed letters.
+    Returns :obj:`True` if this argument is eligible for an auto-generated short flag.
+    Auto shorts apply to **input-binding** parameters only (scalars, dicts, enum flags) —
+    never to promoted containers whose fields become child options. By default they only
+    apply to **top-level** command parameters; a nested field opts in explicitly via
+    ``Annotated[..., Parameter(short_alias=...)]``.
     """
+    if used_short_aliases is None:
+        return False
+
     cparam = argument.parameter
 
-    # An explicitly-provided alias suppresses auto-generation; reserve its letters so
-    # other parameters' auto-generated shorts avoid them.
+    # Reserve every explicit short flag (from name or alias) so auto-generated shorts
+    # avoid them. At this point no auto short has been appended yet, so any single-letter
+    # flag present is necessarily user-provided.
+    for flag in (*(cparam.name or ()), *(cparam.alias or ())):
+        if _is_short_flag(flag):
+            used_short_aliases.add(flag)
+
+    # An explicitly-provided alias suppresses auto-generation.
     explicit_alias = "alias" in immediate_parameter._provided_args
-    if cparam.alias and used_short_aliases is not None:
-        used_short_aliases.update(cparam.alias)
-    if explicit_alias or cparam.alias or used_short_aliases is None:
-        return None
+    if explicit_alias or cparam.alias:
+        return False
 
     # Top-level by default; nested fields require an explicit opt-in.
     explicit_opt_in = "short_alias" in immediate_parameter._provided_args
     if not (top_level or explicit_opt_in):
-        return None
+        return False
 
     # Only parameters that bind CLI input directly get a short; containers do not.
     if argument._accepts_keywords and not argument._enum_flag_type:
-        return None
+        return False
+
+    return True
+
+
+def generate_short_alias(
+    argument: "Argument",
+    field_info: FieldInfo,
+    used_short_aliases: set[str],
+) -> tuple[str, ...] | None:
+    """Phase 2: generate the auto short flag(s) for an argument deemed eligible by phase 1.
+
+    Deferred until every parameter's explicit short has been reserved, so an earlier
+    parameter's auto short can never shadow a later parameter's explicit ``alias``.
+
+    Returns the generated short name(s) to append to the argument's name as standalone
+    flags (so they surface globally, e.g. ``-e``, never dotted like ``-u.name``), or
+    :obj:`None`. Mutates ``used_short_aliases`` to reserve claimed letters.
+    """
+    cparam = argument.parameter
 
     short = None
     short_alias = cparam.short_alias

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -153,6 +153,36 @@ def enum_flag_from_dict(
     return convert_enum_flag(enum_type, (k for k, v in data.items() if v), name_transform)
 
 
+def maybe_apply_auto_alias(
+    cparam: Parameter,
+    field_info: FieldInfo,
+    immediate_parameter: Parameter,
+    used_short_aliases: set[str] | None,
+) -> Parameter:
+    """Add a one-letter CLI alias when enabled by upstream ``Parameter.auto_alias``."""
+    if not cparam.auto_alias:
+        return cparam
+    if "alias" in immediate_parameter._provided_args:
+        return cparam
+    if cparam.alias:
+        return cparam
+    if used_short_aliases is None:
+        return cparam
+    if field_info.kind is not field_info.KEYWORD_ONLY:
+        return cparam
+
+    name = field_info.names[0]
+    if not name:
+        return cparam
+
+    short = f"-{name[0].lower()}"
+    if short in used_short_aliases:
+        return cparam
+
+    used_short_aliases.add(short)
+    return Parameter.combine(cparam, Parameter(alias=short))
+
+
 def extract_docstring_help(f: Callable) -> dict[tuple[str, ...], Parameter]:
     from docstring_parser import parse_from_object
 

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -202,9 +202,13 @@ def reserve_short_alias(
         if _is_short_flag(flag):
             used_short_aliases.add(flag)
 
-    # An explicitly-provided alias suppresses auto-generation.
+    # An explicitly-provided alias or name suppresses auto-generation: the user has taken
+    # manual control of this parameter's flags, so Cyclopts only uses what they supplied.
+    # (``name="*"`` flattening sets ``name`` on a container, which is excluded below anyway;
+    # its promoted children carry no explicit ``name`` and remain eligible.)
     explicit_alias = "alias" in immediate_parameter._provided_args
-    if explicit_alias or cparam.alias:
+    explicit_name = "name" in immediate_parameter._provided_args
+    if explicit_alias or cparam.alias or explicit_name:
         return False
 
     # Root-namespace only. A field that stays namespaced (e.g. ``--user.name``) never gets

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -154,40 +154,63 @@ def enum_flag_from_dict(
 
 
 def resolve_short_alias(
-    cparam: Parameter,
+    argument: "Argument",
     field_info: FieldInfo,
     immediate_parameter: Parameter,
     used_short_aliases: set[str] | None,
-) -> Parameter:
-    if "alias" in immediate_parameter._provided_args:
-        if used_short_aliases is not None and immediate_parameter.alias:
-            used_short_aliases.update(immediate_parameter.alias)
-        return cparam
-    if cparam.alias:
-        if used_short_aliases is not None:
-            used_short_aliases.update(cparam.alias)
-        return cparam
-    if used_short_aliases is None:
-        return cparam
+    *,
+    top_level: bool,
+) -> tuple[str, ...] | None:
+    """Reserve explicit short aliases and, when eligible, generate an auto short flag.
+
+    Auto-generated short flags apply to **input-binding** parameters only (scalars,
+    dicts, enum flags) — never to promoted containers whose fields become child
+    options. By default they only apply to **top-level** command parameters; a nested
+    field opts in explicitly via ``Annotated[..., Parameter(auto_alias=...)]``.
+
+    Returns the generated short name(s) to append to the argument's name as standalone
+    flags (so they surface globally, e.g. ``-e``, never dotted like ``-u.name``), or
+    :obj:`None`. Always mutates ``used_short_aliases`` to reserve claimed letters.
+    """
+    cparam = argument.parameter
+
+    # An explicitly-provided alias suppresses auto-generation; reserve its letters so
+    # other parameters' auto-generated shorts avoid them.
+    explicit_alias = "alias" in immediate_parameter._provided_args
+    if cparam.alias and used_short_aliases is not None:
+        used_short_aliases.update(cparam.alias)
+    if explicit_alias or cparam.alias or used_short_aliases is None:
+        return None
+
+    # Top-level by default; nested fields require an explicit opt-in.
+    explicit_opt_in = "auto_alias" in immediate_parameter._provided_args
+    if not (top_level or explicit_opt_in):
+        return None
+
+    # Only parameters that bind CLI input directly get a short; containers do not.
+    if argument._accepts_keywords and not argument._enum_flag_type:
+        return None
 
     short = None
     auto_alias = cparam.auto_alias
     if callable(auto_alias):
         short = auto_alias(field_info, used_short_aliases)
     elif auto_alias and field_info.kind not in (POSITIONAL_ONLY, VAR_POSITIONAL):
-        name = field_info.names[0]
-        if name:
-            letter = name[0].lower()
+        # Derive the letter from the transformed CLI name (not the raw python identifier)
+        # so it stays consistent with the long flag (``--my-flag`` -> ``-m``, ``_foo`` -> ``-f``).
+        transformed = cparam.name_transform(field_info.names[0])
+        if transformed:
+            letter = transformed[0].lower()
             for candidate in (f"-{letter}", f"-{letter.upper()}"):
                 if candidate not in used_short_aliases:
                     short = candidate
                     break
 
     if not short:
-        return cparam
+        return None
     shorts = (short,) if isinstance(short, str) else tuple(short)
     used_short_aliases.update(shorts)
-    return Parameter.combine(cparam, Parameter(alias=shorts if len(shorts) != 1 else shorts[0]))
+    return shorts
 
 
 def extract_docstring_help(f: Callable) -> dict[tuple[str, ...], Parameter]:

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -166,7 +166,7 @@ def resolve_short_alias(
     Auto-generated short flags apply to **input-binding** parameters only (scalars,
     dicts, enum flags) — never to promoted containers whose fields become child
     options. By default they only apply to **top-level** command parameters; a nested
-    field opts in explicitly via ``Annotated[..., Parameter(auto_alias=...)]``.
+    field opts in explicitly via ``Annotated[..., Parameter(short_alias=...)]``.
 
     Returns the generated short name(s) to append to the argument's name as standalone
     flags (so they surface globally, e.g. ``-e``, never dotted like ``-u.name``), or
@@ -183,7 +183,7 @@ def resolve_short_alias(
         return None
 
     # Top-level by default; nested fields require an explicit opt-in.
-    explicit_opt_in = "auto_alias" in immediate_parameter._provided_args
+    explicit_opt_in = "short_alias" in immediate_parameter._provided_args
     if not (top_level or explicit_opt_in):
         return None
 
@@ -192,10 +192,10 @@ def resolve_short_alias(
         return None
 
     short = None
-    auto_alias = cparam.auto_alias
-    if callable(auto_alias):
-        short = auto_alias(field_info, used_short_aliases)
-    elif auto_alias and field_info.kind not in (POSITIONAL_ONLY, VAR_POSITIONAL):
+    short_alias = cparam.short_alias
+    if callable(short_alias):
+        short = short_alias(field_info, used_short_aliases)
+    elif short_alias and field_info.kind not in (POSITIONAL_ONLY, VAR_POSITIONAL):
         # Derive the letter from the transformed CLI name (not the raw python identifier)
         # so it stays consistent with the long flag (``--my-flag`` -> ``-m``, ``_foo`` -> ``-f``).
         transformed = cparam.name_transform(field_info.names[0])

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -160,11 +160,15 @@ def maybe_apply_auto_alias(
     used_short_aliases: set[str] | None,
 ) -> Parameter:
     """Add a one-letter CLI alias when enabled by upstream ``Parameter.auto_alias``."""
+    if "alias" in immediate_parameter._provided_args:
+        if used_short_aliases is not None and immediate_parameter.alias:
+            used_short_aliases.update(immediate_parameter.alias)
+        return cparam
     if not cparam.auto_alias:
         return cparam
-    if "alias" in immediate_parameter._provided_args:
-        return cparam
     if cparam.alias:
+        if used_short_aliases is not None:
+            used_short_aliases.update(cparam.alias)
         return cparam
     if used_short_aliases is None:
         return cparam
@@ -175,12 +179,13 @@ def maybe_apply_auto_alias(
     if not name:
         return cparam
 
-    short = f"-{name[0].lower()}"
-    if short in used_short_aliases:
-        return cparam
+    letter = name[0].lower()
+    for short in (f"-{letter}", f"-{letter.upper()}"):
+        if short not in used_short_aliases:
+            used_short_aliases.add(short)
+            return Parameter.combine(cparam, Parameter(alias=short))
 
-    used_short_aliases.add(short)
-    return Parameter.combine(cparam, Parameter(alias=short))
+    return cparam
 
 
 def extract_docstring_help(f: Callable) -> dict[tuple[str, ...], Parameter]:

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -172,7 +172,7 @@ def maybe_apply_auto_alias(
         return cparam
     if used_short_aliases is None:
         return cparam
-    if field_info.kind is not field_info.KEYWORD_ONLY:
+    if field_info.kind in (field_info.POSITIONAL_ONLY, field_info.VAR_POSITIONAL):
         return cparam
 
     name = field_info.names[0]

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -153,18 +153,15 @@ def enum_flag_from_dict(
     return convert_enum_flag(enum_type, (k for k, v in data.items() if v), name_transform)
 
 
-def maybe_apply_auto_alias(
+def resolve_short_alias(
     cparam: Parameter,
     field_info: FieldInfo,
     immediate_parameter: Parameter,
     used_short_aliases: set[str] | None,
 ) -> Parameter:
-    """Add a one-letter CLI alias when enabled by upstream ``Parameter.auto_alias``."""
     if "alias" in immediate_parameter._provided_args:
         if used_short_aliases is not None and immediate_parameter.alias:
             used_short_aliases.update(immediate_parameter.alias)
-        return cparam
-    if not cparam.auto_alias:
         return cparam
     if cparam.alias:
         if used_short_aliases is not None:
@@ -172,20 +169,25 @@ def maybe_apply_auto_alias(
         return cparam
     if used_short_aliases is None:
         return cparam
-    if field_info.kind in (field_info.POSITIONAL_ONLY, field_info.VAR_POSITIONAL):
+
+    short = None
+    auto_alias = cparam.auto_alias
+    if callable(auto_alias):
+        short = auto_alias(field_info, used_short_aliases)
+    elif auto_alias and field_info.kind not in (POSITIONAL_ONLY, VAR_POSITIONAL):
+        name = field_info.names[0]
+        if name:
+            letter = name[0].lower()
+            for candidate in (f"-{letter}", f"-{letter.upper()}"):
+                if candidate not in used_short_aliases:
+                    short = candidate
+                    break
+
+    if not short:
         return cparam
-
-    name = field_info.names[0]
-    if not name:
-        return cparam
-
-    letter = name[0].lower()
-    for short in (f"-{letter}", f"-{letter.upper()}"):
-        if short not in used_short_aliases:
-            used_short_aliases.add(short)
-            return Parameter.combine(cparam, Parameter(alias=short))
-
-    return cparam
+    shorts = (short,) if isinstance(short, str) else tuple(short)
+    used_short_aliases.update(shorts)
+    return Parameter.combine(cparam, Parameter(alias=shorts if len(shorts) != 1 else shorts[0]))
 
 
 def extract_docstring_help(f: Callable) -> dict[tuple[str, ...], Parameter]:

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -241,6 +241,11 @@ def generate_short_alias(
         # collision-tracking set and corrupt assignment for later parameters.
         short = short_alias(field_info, frozenset(used_short_aliases))
     elif short_alias and field_info.kind not in (POSITIONAL_ONLY, VAR_POSITIONAL):
+        # A boolean that already defaults to True would only get a no-op positive short
+        # (the meaningful off-switch ``--no-flag`` is long-only), so skip auto-generation
+        # and leave the letter free for a parameter that can actually use it.
+        if argument.hint is bool and field_info.default is True:
+            return None
         # Derive the letter from the transformed CLI name (not the raw python identifier)
         # so it stays consistent with the long flag (``--my-flag`` -> ``-m``, ``_foo`` -> ``-f``).
         transformed = cparam.name_transform(field_info.names[0])

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -267,7 +267,23 @@ def generate_short_alias(
 
     if not short:
         return None
-    shorts = (short,) if isinstance(short, str) else tuple(short)
+    if isinstance(short, str):
+        shorts = (short,)
+    else:
+        try:
+            shorts = tuple(short)
+        except TypeError:
+            raise TypeError(
+                f"Parameter.short_alias callable must return a str, an iterable of str, or None; got {short!r}."
+            ) from None
+    # The callable is custom logic, but it still must produce single-letter short flags
+    # (e.g. ``-e``) — anything else would be silently appended as a long flag or, worse, a
+    # positional name. Fail loudly instead, mirroring the field-level str rejection.
+    for s in shorts:
+        if not isinstance(s, str) or not is_short_flag(s):
+            raise ValueError(
+                f"Parameter.short_alias callable must return single-letter short flags like '-e'; got {s!r}."
+            )
     # Drop any short already claimed by an earlier parameter (first-wins), so a
     # callable that ignores ``used_short_aliases`` can't create duplicate flags.
     shorts = tuple(s for s in shorts if s not in used_short_aliases)

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -1,7 +1,7 @@
 """Shared helper functions and constants for the argument package."""
 
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import suppress
 from enum import Enum, Flag
 from functools import partial
@@ -158,12 +158,23 @@ def _is_short_flag(flag: str) -> bool:
     return len(flag) == 2 and flag[0] == "-" and flag[1] != "-"
 
 
+def _is_root_namespace(names: str | Iterable[str] | None) -> bool:
+    """Return :obj:`True` if the parameter surfaces at the root CLI namespace.
+
+    A root-namespace parameter has an **undotted** long flag (e.g. ``--env``). This
+    covers genuine top-level command parameters as well as fields promoted to the root
+    via ``Parameter(name="*")`` or PEP 692 unpacking (``--name``), while excluding dotted
+    nested fields such as ``--user.name``.
+    """
+    if isinstance(names, str):  # Defensive: resolved names are always a tuple at this point.
+        names = (names,)
+    return any(n.startswith("--") and "." not in n for n in (names or ()))
+
+
 def reserve_short_alias(
     argument: "Argument",
     immediate_parameter: Parameter,
     used_short_aliases: set[str] | None,
-    *,
-    top_level: bool,
 ) -> bool:
     """Phase 1: reserve explicitly-provided short flags and report auto-short eligibility.
 
@@ -175,8 +186,8 @@ def reserve_short_alias(
     Returns :obj:`True` if this argument is eligible for an auto-generated short flag.
     Auto shorts apply to **input-binding** parameters only (scalars, dicts, enum flags) —
     never to promoted containers whose fields become child options. By default they only
-    apply to **top-level** command parameters; a nested field opts in explicitly via
-    ``Annotated[..., Parameter(short_alias=...)]``.
+    apply to **root-namespace** parameters (an undotted long flag); a dotted nested field
+    opts in explicitly via ``Annotated[..., Parameter(short_alias=...)]``.
     """
     if used_short_aliases is None:
         return False
@@ -195,9 +206,9 @@ def reserve_short_alias(
     if explicit_alias or cparam.alias:
         return False
 
-    # Top-level by default; nested fields require an explicit opt-in.
+    # Root-namespace by default; dotted nested fields require an explicit opt-in.
     explicit_opt_in = "short_alias" in immediate_parameter._provided_args
-    if not (top_level or explicit_opt_in):
+    if not (_is_root_namespace(cparam.name) or explicit_opt_in):
         return False
 
     # Only parameters that bind CLI input directly get a short; containers do not.

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -225,7 +225,6 @@ def reserve_short_alias(
 
 def generate_short_alias(
     argument: "Argument",
-    field_info: FieldInfo,
     used_short_aliases: set[str],
 ) -> tuple[str, ...] | None:
     """Phase 2: generate the auto short flag(s) for an argument deemed eligible by phase 1.
@@ -238,6 +237,7 @@ def generate_short_alias(
     :obj:`None`. Mutates ``used_short_aliases`` to reserve claimed letters.
     """
     cparam = argument.parameter
+    field_info = argument.field_info
 
     short = None
     short_alias = cparam.short_alias

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -185,9 +185,10 @@ def reserve_short_alias(
 
     Returns :obj:`True` if this argument is eligible for an auto-generated short flag.
     Auto shorts apply to **input-binding** parameters only (scalars, dicts, enum flags) —
-    never to promoted containers whose fields become child options. By default they only
-    apply to **root-namespace** parameters (an undotted long flag); a dotted nested field
-    opts in explicitly via ``Annotated[..., Parameter(short_alias=...)]``.
+    never to promoted containers whose fields become child options. They apply only to
+    **root-namespace** parameters (an undotted long flag). A field that stays namespaced
+    (e.g. ``--user.name``) never gets one — ``short_alias`` on such a field is inert;
+    flatten it to the root namespace via ``name="*"`` to expose it for a short.
     """
     if used_short_aliases is None:
         return False
@@ -206,9 +207,9 @@ def reserve_short_alias(
     if explicit_alias or cparam.alias:
         return False
 
-    # Root-namespace by default; dotted nested fields require an explicit opt-in.
-    explicit_opt_in = "short_alias" in immediate_parameter._provided_args
-    if not (_is_root_namespace(cparam.name) or explicit_opt_in):
+    # Root-namespace only. A field that stays namespaced (e.g. ``--user.name``) never gets
+    # a short, even with ``short_alias=True`` set directly on it; flatten it via ``name="*"``.
+    if not _is_root_namespace(cparam.name):
         return False
 
     # Only parameters that bind CLI input directly get a short; containers do not.

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -194,7 +194,9 @@ def resolve_short_alias(
     short = None
     short_alias = cparam.short_alias
     if callable(short_alias):
-        short = short_alias(field_info, used_short_aliases)
+        # Hand the callable a read-only snapshot so it cannot mutate the internal
+        # collision-tracking set and corrupt assignment for later parameters.
+        short = short_alias(field_info, frozenset(used_short_aliases))
     elif short_alias and field_info.kind not in (POSITIONAL_ONLY, VAR_POSITIONAL):
         # Derive the letter from the transformed CLI name (not the raw python identifier)
         # so it stays consistent with the long flag (``--my-flag`` -> ``-m``, ``_foo`` -> ``-f``).

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -28,7 +28,7 @@ from attrs import Factory, define, field
 from cyclopts.annotations import resolve_annotated
 from cyclopts.app_stack import AppStack
 from cyclopts.argument import ArgumentCollection
-from cyclopts.argument.utils import _is_short_flag
+from cyclopts.argument.utils import is_short_flag
 from cyclopts.bind import create_bound_arguments, is_option_like, normalize_tokens
 from cyclopts.command_spec import CommandSpec
 from cyclopts.config._env import Env
@@ -1554,7 +1554,7 @@ class App:
             group_arguments=self._group_arguments,  # pyright: ignore
             group_parameters=self._group_parameters,  # pyright: ignore
             parse_docstring=parse_docstring,
-            reserved=(f for f in (*self.help_flags, *self.version_flags) if _is_short_flag(f)),
+            reserved=(f for f in (*self.help_flags, *self.version_flags) if is_short_flag(f)),
         )
 
     def parse_known_args(

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1562,7 +1562,9 @@ class App:
             group_arguments=self._group_arguments,  # pyright: ignore
             group_parameters=self._group_parameters,  # pyright: ignore
             parse_docstring=parse_docstring,
-            reserved=(f for f in (*self.help_flags, *self.version_flags) if len(f) == 2 and f[0] == "-" and f[1] != "-"),
+            reserved=(
+                f for f in (*self.help_flags, *self.version_flags) if len(f) == 2 and f[0] == "-" and f[1] != "-"
+            ),
         )
 
     def parse_known_args(

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -346,7 +346,13 @@ class App:
     default_parameter: Parameter | None = field(default=None, kw_only=True)
 
     short_alias: bool | None = field(default=None, kw_only=True)
-    """Generate one-letter CLI aliases from keyword-only parameter names."""
+    """Generate one-letter CLI aliases (e.g. ``-e`` for ``--env``) for parameters with a long flag.
+
+    Applies to every parameter that exposes a ``--long`` form (positional-or-keyword and
+    keyword-only); purely-positional parameters get no short flag. Equivalent to setting
+    :attr:`Parameter.short_alias <cyclopts.Parameter.short_alias>` on the app's
+    :attr:`default_parameter`.
+    """
 
     # This can ONLY ever be None or Tuple[Callable, ...]
     _config: (

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -345,7 +345,7 @@ class App:
     default_command: Callable[..., Any] | None = field(default=None, converter=_validate_default_command, kw_only=True)
     default_parameter: Parameter | None = field(default=None, kw_only=True)
 
-    auto_alias: bool | None = field(default=None, kw_only=True)
+    short_alias: bool | None = field(default=None, kw_only=True)
     """Generate one-letter CLI aliases from keyword-only parameter names."""
 
     # This can ONLY ever be None or Tuple[Callable, ...]
@@ -510,10 +510,10 @@ class App:
         self.help_flags = self._help_flags
         self.version_flags = self._version_flags
 
-        if self.auto_alias is not None:
+        if self.short_alias is not None:
             self.default_parameter = Parameter.combine(
                 self.default_parameter,
-                Parameter(auto_alias=self.auto_alias),
+                Parameter(short_alias=self.short_alias),
             )
 
         # Capture the module name from the instantiating frame.

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1562,6 +1562,7 @@ class App:
             group_arguments=self._group_arguments,  # pyright: ignore
             group_parameters=self._group_parameters,  # pyright: ignore
             parse_docstring=parse_docstring,
+            reserved=(f for f in (*self.help_flags, *self.version_flags) if len(f) == 2 and f[0] == "-" and f[1] != "-"),
         )
 
     def parse_known_args(

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -345,6 +345,9 @@ class App:
     default_command: Callable[..., Any] | None = field(default=None, converter=_validate_default_command, kw_only=True)
     default_parameter: Parameter | None = field(default=None, kw_only=True)
 
+    auto_alias: bool | None = field(default=None, kw_only=True)
+    """Generate one-letter CLI aliases from keyword-only parameter names."""
+
     # This can ONLY ever be None or Tuple[Callable, ...]
     _config: (
         None
@@ -506,6 +509,12 @@ class App:
         # Trigger the setters
         self.help_flags = self._help_flags
         self.version_flags = self._version_flags
+
+        if self.auto_alias is not None:
+            self.default_parameter = Parameter.combine(
+                self.default_parameter,
+                Parameter(auto_alias=self.auto_alias),
+            )
 
         # Capture the module name from the instantiating frame.
         # This is cheap (just dict lookup) compared to inspect.getmodule().

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -346,15 +346,6 @@ class App:
     default_command: Callable[..., Any] | None = field(default=None, converter=_validate_default_command, kw_only=True)
     default_parameter: Parameter | None = field(default=None, kw_only=True)
 
-    short_alias: bool | None = field(default=None, kw_only=True)
-    """Generate one-letter CLI aliases (e.g. ``-e`` for ``--env``) for parameters with a long flag.
-
-    Applies to every parameter that exposes a ``--long`` form (positional-or-keyword and
-    keyword-only); purely-positional parameters get no short flag. Equivalent to setting
-    :attr:`Parameter.short_alias <cyclopts.Parameter.short_alias>` on the app's
-    :attr:`default_parameter`.
-    """
-
     # This can ONLY ever be None or Tuple[Callable, ...]
     _config: (
         None
@@ -516,12 +507,6 @@ class App:
         # Trigger the setters
         self.help_flags = self._help_flags
         self.version_flags = self._version_flags
-
-        if self.short_alias is not None:
-            self.default_parameter = Parameter.combine(
-                self.default_parameter,
-                Parameter(short_alias=self.short_alias),
-            )
 
         # Capture the module name from the instantiating frame.
         # This is cheap (just dict lookup) compared to inspect.getmodule().

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -28,6 +28,7 @@ from attrs import Factory, define, field
 from cyclopts.annotations import resolve_annotated
 from cyclopts.app_stack import AppStack
 from cyclopts.argument import ArgumentCollection
+from cyclopts.argument.utils import _is_short_flag
 from cyclopts.bind import create_bound_arguments, is_option_like, normalize_tokens
 from cyclopts.command_spec import CommandSpec
 from cyclopts.config._env import Env
@@ -1568,9 +1569,7 @@ class App:
             group_arguments=self._group_arguments,  # pyright: ignore
             group_parameters=self._group_parameters,  # pyright: ignore
             parse_docstring=parse_docstring,
-            reserved=(
-                f for f in (*self.help_flags, *self.version_flags) if len(f) == 2 and f[0] == "-" and f[1] != "-"
-            ),
+            reserved=(f for f in (*self.help_flags, *self.version_flags) if _is_short_flag(f)),
         )
 
     def parse_known_args(

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -14,6 +14,7 @@ from typing import (
 from attrs import define, evolve, field
 
 from cyclopts.annotations import resolve_annotated
+from cyclopts.argument.utils import is_short_flag
 from cyclopts.core import _get_root_module_name, _iter_resolution_argument_collections
 from cyclopts.field_info import get_field_infos
 from cyclopts.group import Group
@@ -183,10 +184,6 @@ class HelpPanel:
             self.entries = [x.value for x in sorted_sort_helper]
         else:
             raise NotImplementedError
-
-
-def _is_short(s):
-    return not s.startswith("--") and s.startswith("-")
 
 
 def _categorize_keyword_arguments(argument_collection: "ArgumentCollection") -> tuple[list, list]:
@@ -417,7 +414,7 @@ def _expand_structured_dict_for_help(
     value_type = argument._default
 
     negatives = set(argument.negatives)
-    outer_long_names = tuple(o for o in argument.names if o not in negatives and not _is_short(o))
+    outer_long_names = tuple(o for o in argument.names if o not in negatives and not is_short_flag(o))
 
     is_unresolvable = isinstance(value_type, (str, ForwardRef))
     is_cycle = id(value_type) in seen
@@ -479,10 +476,10 @@ def _make_help_entry(argument: "Argument", format: str) -> HelpEntry:
             options = [arg_name, *options]
 
     negatives = set(argument.negatives)
-    positive_names = [o for o in options if o not in negatives and not _is_short(o)]
-    positive_shorts = [o for o in options if o not in negatives and _is_short(o)]
-    negative_names = [o for o in options if o in negatives and not _is_short(o)]
-    negative_shorts = [o for o in options if o in negatives and _is_short(o)]
+    positive_names = [o for o in options if o not in negatives and not is_short_flag(o)]
+    positive_shorts = [o for o in options if o not in negatives and is_short_flag(o)]
+    negative_names = [o for o in options if o in negatives and not is_short_flag(o)]
+    negative_shorts = [o for o in options if o in negatives and is_short_flag(o)]
 
     help_description = InlineText.from_format(argument.parameter.help, format=format)
 
@@ -598,7 +595,7 @@ def format_command_entries(apps_with_names: Iterable, format: str) -> list[HelpE
         # Commands don't have negative variants, so all names are "positive"
         short_names, long_names = [], []
         for name in names:
-            short_names.append(name) if _is_short(name) else long_names.append(name)
+            short_names.append(name) if is_short_flag(name) else long_names.append(name)
 
         sort_key = resolve_callables(app.sort_key, app)
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -95,6 +95,12 @@ def _default_if_none_false(value: bool | None) -> bool:
 def _short_alias_converter(
     value: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] | None,
 ) -> bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None]:
+    if isinstance(value, str):
+        raise TypeError(
+            "Parameter.short_alias does not accept a string. Pass a bool to auto-generate a "
+            'short flag, or a callable for custom logic. To set an explicit flag like "-z", use '
+            "Parameter.alias or Parameter.name instead."
+        )
     return False if value is None else value
 
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -32,7 +32,7 @@ from cyclopts.annotations import (
     resolve_annotated,
     resolve_optional,
 )
-from cyclopts.field_info import get_field_infos, signature_parameters
+from cyclopts.field_info import FieldInfo, get_field_infos, signature_parameters
 from cyclopts.group import Group
 from cyclopts.utils import (
     default_name_transform,
@@ -90,6 +90,12 @@ def _default_if_none_true(value: bool | None) -> bool:
 
 def _default_if_none_false(value: bool | None) -> bool:
     return value if value is not None else False
+
+
+def _auto_alias_converter(
+    value: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] | None,
+) -> bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None]:
+    return False if value is None else value
 
 
 def _negative_converter(default: tuple[str, ...]):
@@ -336,9 +342,9 @@ class Parameter:
         kw_only=True,
     )
 
-    auto_alias: bool = field(
+    auto_alias: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] = field(
         default=None,
-        converter=_default_if_none_false,
+        converter=_auto_alias_converter,
         kw_only=True,
     )
 
@@ -377,7 +383,7 @@ class Parameter:
             # Sort union members by priority: non-None types first, then None/NoneType
             # This ensures that if bool | None both produce the same custom negative,
             # we only include it once from the higher-priority type (bool).
-            sorted_args = sorted(union_args, key=lambda x: (is_nonetype(x) or x is None))
+            sorted_args = sorted(union_args, key=lambda x: is_nonetype(x) or x is None)
             out: list[str] = []
             for x in sorted_args:
                 for neg in self.get_negatives(x):

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -336,6 +336,12 @@ class Parameter:
         kw_only=True,
     )
 
+    auto_alias: bool = field(
+        default=None,
+        converter=_default_if_none_false,
+        kw_only=True,
+    )
+
     allow_repeating: bool | None = field(
         default=None,
         kw_only=True,

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -92,7 +92,7 @@ def _default_if_none_false(value: bool | None) -> bool:
     return value if value is not None else False
 
 
-def _auto_alias_converter(
+def _short_alias_converter(
     value: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] | None,
 ) -> bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None]:
     return False if value is None else value
@@ -342,9 +342,9 @@ class Parameter:
         kw_only=True,
     )
 
-    auto_alias: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] = field(
+    short_alias: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] = field(
         default=None,
-        converter=_auto_alias_converter,
+        converter=_short_alias_converter,
         kw_only=True,
     )
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -96,13 +96,18 @@ def _default_if_none_false(value: bool | None) -> bool:
 def _short_alias_converter(
     value: bool | Callable[[FieldInfo, frozenset[str]], str | Iterable[str] | None] | None,
 ) -> bool | Callable[[FieldInfo, frozenset[str]], str | Iterable[str] | None]:
+    return False if value is None else value
+
+
+def _short_alias_validator(instance, attribute, value):
+    # A str is also an Iterable[str], so an explicit "-z" would silently expand into
+    # individual letters. Reject it so the developer reaches for alias/name instead.
     if isinstance(value, str):
         raise TypeError(
             "Parameter.short_alias does not accept a string. Pass a bool to auto-generate a "
             'short flag, or a callable for custom logic. To set an explicit flag like "-z", use '
             "Parameter.alias or Parameter.name instead."
         )
-    return False if value is None else value
 
 
 def _negative_converter(default: tuple[str, ...]):
@@ -352,6 +357,7 @@ class Parameter:
     short_alias: bool | Callable[[FieldInfo, frozenset[str]], str | Iterable[str] | None] = field(
         default=None,
         converter=_short_alias_converter,
+        validator=_short_alias_validator,
         kw_only=True,
     )
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -93,8 +93,8 @@ def _default_if_none_false(value: bool | None) -> bool:
 
 
 def _short_alias_converter(
-    value: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] | None,
-) -> bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None]:
+    value: bool | Callable[[FieldInfo, frozenset[str]], str | Iterable[str] | None] | None,
+) -> bool | Callable[[FieldInfo, frozenset[str]], str | Iterable[str] | None]:
     if isinstance(value, str):
         raise TypeError(
             "Parameter.short_alias does not accept a string. Pass a bool to auto-generate a "
@@ -348,7 +348,7 @@ class Parameter:
         kw_only=True,
     )
 
-    short_alias: bool | Callable[[FieldInfo, set[str]], str | Iterable[str] | None] = field(
+    short_alias: bool | Callable[[FieldInfo, frozenset[str]], str | Iterable[str] | None] = field(
         default=None,
         converter=_short_alias_converter,
         kw_only=True,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -975,6 +975,7 @@ API
       A container parameter (e.g. a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
       A child field may opt in via ``Annotated[..., Parameter(short_alias=True)]``; its short flag surfaces as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
       :obj:`~enum.Flag` parameters are the exception: because they consume tokens directly (e.g. ``--perm read write``), the flag itself does receive a short, even though it also exposes per-member options.
+      A boolean parameter that defaults to :obj:`True` also gets no short, since the positive short would be a no-op and the off-switch ``--no-flag`` is long-only; the letter is left free for another parameter.
 
       For full control, supply a callable ``(field_info, used_short_aliases) -> Union[str, Iterable[str], None]`` that returns the short name(s) to use (or :obj:`None` to skip).
       Consult ``used_short_aliases`` to pick a free letter; any returned name already claimed by an earlier parameter is dropped (first-wins).

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -977,6 +977,7 @@ API
       :obj:`~enum.Flag` parameters are the exception: because they consume tokens directly (e.g. ``--perm read write``), the flag itself does receive a short, even though it also exposes per-member options.
 
       For full control, supply a callable ``(field_info, used_short_aliases) -> Union[str, Iterable[str], None]`` that returns the short name(s) to use (or :obj:`None` to skip).
+      Consult ``used_short_aliases`` to pick a free letter; any returned name already claimed by an earlier parameter is dropped (first-wins).
 
       .. code-block:: python
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -974,6 +974,7 @@ API
       Only **top-level** parameters that bind input directly receive a short flag.
       A container parameter (e.g. a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
       A child field may opt in via ``Annotated[..., Parameter(short_alias=True)]``; its short flag surfaces as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
+      :obj:`~enum.Flag` parameters are the exception: because they consume tokens directly (e.g. ``--perm read write``), the flag itself does receive a short, even though it also exposes per-member options.
 
       For full control, supply a callable ``(field_info, used_short_aliases) -> Union[str, Iterable[str], None]`` that returns the short name(s) to use (or :obj:`None` to skip).
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -545,6 +545,16 @@ API
       If :obj:`None` (default value), uses :func:`~.default_name_transform`.
       Subapps inherit from the first non-:obj:`None` parent :attr:`name_transform`.
 
+   .. attribute:: short_alias
+      :type: Optional[bool]
+      :value: None
+
+      When ``True``, enables automatic single-letter short flags for all eligible parameters in the app
+      (equivalent to setting ``short_alias=True`` on :attr:`default_parameter`).
+      Can also be set per-command via ``@app.command(short_alias=True)``.
+      See :attr:`.Parameter.short_alias` for the full behavior, including collision handling and the
+      top-level-only / nested opt-in rules.
+
    .. attribute:: config
       :type: Union[None, Callable, Iterable[Callable]]
       :value: None
@@ -947,6 +957,35 @@ API
          @app.default
          def main(foo: Annotated[int, Parameter(alias="-f")]):
              pass
+
+   .. attribute:: short_alias
+      :type: Union[bool, Callable[[FieldInfo, set[str]], Union[str, Iterable[str], None]]]
+      :value: None
+
+      When ``True``, automatically generates a single-letter short flag (e.g. ``--verbose`` also gets ``-v``).
+      The short flag is **appended** as an additional name; it does not override the long name.
+      This pairs with :attr:`.alias`: use ``alias`` to specify a name yourself, or ``short_alias`` to have Cyclopts derive one.
+
+      The letter is the first character of the parameter's CLI name (after :attr:`.name_transform`), lowercased.
+      If that letter is already claimed, the uppercase variant is tried; if both are taken, no short flag is generated.
+      Reserved short flags (``-h``, and ``-v`` when a short version flag is configured) are never claimed.
+      Explicitly setting :attr:`.alias` or :attr:`.name` on a parameter suppresses auto-generation for it and reserves those letters.
+
+      Only **top-level** parameters that bind input directly receive a short flag.
+      A container parameter (e.g. a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
+      A child field may opt in via ``Annotated[..., Parameter(short_alias=True)]``; its short flag surfaces as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
+
+      For full control, supply a callable ``(field_info, used_short_aliases) -> Union[str, Iterable[str], None]`` that returns the short name(s) to use (or :obj:`None` to skip).
+
+      .. code-block:: python
+
+         @app.command(short_alias=True)
+         def deploy(env: str = "staging", replicas: int = 10):
+             pass
+
+      .. code-block:: console
+
+         $ my-script deploy -e prod -r 5
 
    .. attribute:: converter
       :type: Optional[Callable]

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -545,16 +545,6 @@ API
       If :obj:`None` (default value), uses :func:`~.default_name_transform`.
       Subapps inherit from the first non-:obj:`None` parent :attr:`name_transform`.
 
-   .. attribute:: short_alias
-      :type: Optional[bool]
-      :value: None
-
-      When ``True``, enables automatic single-letter short flags for all eligible parameters in the app
-      (equivalent to setting ``short_alias=True`` on :attr:`default_parameter`).
-      Can also be set per-command via ``@app.command(short_alias=True)``.
-      See :attr:`.Parameter.short_alias` for the full behavior, including collision handling and the
-      root-namespace-only rule.
-
    .. attribute:: config
       :type: Union[None, Callable, Iterable[Callable]]
       :value: None
@@ -982,7 +972,9 @@ API
 
       .. code-block:: python
 
-         @app.command(short_alias=True)
+         app = App(default_parameter=Parameter(short_alias=True))
+
+         @app.command
          def deploy(env: str = "staging", replicas: int = 10):
              pass
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -959,7 +959,7 @@ API
              pass
 
    .. attribute:: short_alias
-      :type: Union[bool, Callable[[FieldInfo, set[str]], Union[str, Iterable[str], None]]]
+      :type: Union[bool, Callable[[FieldInfo, frozenset[str]], Union[str, Iterable[str], None]]]
       :value: None
 
       When ``True``, automatically generates a single-letter short flag (e.g. ``--verbose`` also gets ``-v``).

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -553,7 +553,7 @@ API
       (equivalent to setting ``short_alias=True`` on :attr:`default_parameter`).
       Can also be set per-command via ``@app.command(short_alias=True)``.
       See :attr:`.Parameter.short_alias` for the full behavior, including collision handling and the
-      top-level-only / nested opt-in rules.
+      root-namespace-only rule.
 
    .. attribute:: config
       :type: Union[None, Callable, Iterable[Callable]]
@@ -971,9 +971,9 @@ API
       Reserved short flags (``-h``, and ``-v`` when a short version flag is configured) are never claimed.
       Explicitly setting :attr:`.alias` or :attr:`.name` on a parameter suppresses auto-generation for it and reserves those letters.
 
-      Only **top-level** parameters that bind input directly receive a short flag.
-      A container parameter (e.g. a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
-      A child field may opt in via ``Annotated[..., Parameter(short_alias=True)]``; its short flag surfaces as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
+      Only **root-namespace** parameters that bind input directly receive a short flag.
+      A container parameter (e.g. a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields; ``short_alias`` is inert on a field that stays namespaced.
+      To give a nested field a short flag, flatten it to the root namespace with ``Parameter(name="*")``.
       :obj:`~enum.Flag` parameters are the exception: because they consume tokens directly (e.g. ``--perm read write``), the flag itself does receive a short, even though it also exposes per-member options.
       A boolean parameter that defaults to :obj:`True` also gets no short, since the positive short would be a no-op and the off-switch ``--no-flag`` is long-only; the letter is left free for another parameter.
 

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -200,7 +200,6 @@ Enable it per-parameter with :attr:`Parameter.short_alias <cyclopts.Parameter.sh
 
 The letter is the first character of the parameter's CLI name (after :attr:`~cyclopts.Parameter.name_transform`), lowercased.
 If that letter is already claimed, the uppercase variant is used; if both are taken, the parameter gets no short flag.
-The help flag ``-h`` (and ``-v`` when a short version flag is configured) is always reserved.
 
 .. code-block:: python
 
@@ -218,23 +217,15 @@ The help flag ``-h`` (and ``-v`` when a short version flag is configured) is alw
    $ my-script deploy -e prod
    Deploying to prod in us-east-1
 
-The short flag is additional; the long ``--env`` still works.
-
-Explicitly setting :attr:`~cyclopts.Parameter.alias` (or :attr:`~cyclopts.Parameter.name`) on a parameter opts it out of auto-generation: Cyclopts uses only the short flag you provided and does **not** also derive one.
+Explicitly setting :attr:`~cyclopts.Parameter.alias` (or :attr:`~cyclopts.Parameter.name`) on a parameter **opts it out** of auto-generation: Cyclopts will only use the short flag you provided.
 For example, ``env: Annotated[str, Parameter(alias="-E")]`` exposes ``-E`` but not ``-e``, even when ``short_alias=True`` is enabled app-wide.
 
 Short flags only apply to parameters that bind input directly **and** surface at the root CLI namespace (i.e. an undotted long flag like ``--env``).
 A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its dotted child fields.
 ``short_alias`` is inert on a field that stays namespaced: setting it on a nested leaf has no effect.
 
-To give a nested field a short flag, flatten it to the root namespace with ``Parameter(name="*")``.
-Flattened fields are treated like top-level parameters (they surface as undotted ``--name`` flags), so they receive short flags automatically.
-
-:obj:`~enum.Flag` parameters are the one exception to the "containers don't get a short flag" rule: since they consume tokens directly (e.g. ``--perm read write``), the flag itself receives a short flag in addition to its per-member options.
-
-A boolean parameter that already defaults to :obj:`True` gets no short flag.
+A boolean parameter that already defaults to :obj:`True` gets no automatic short flag.
 Its short would map to the positive long form (e.g. ``-f`` → ``--flag``), which is a no-op since the value is already :obj:`True`; the meaningful off-switch ``--no-flag`` is long-only.
-The letter is left free for another parameter to use.
 
 ----
 Help

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -231,6 +231,10 @@ Fields flattened to the root namespace via ``Parameter(name="*")`` are treated l
 
 :obj:`~enum.Flag` parameters are the one exception to the "containers don't get a short flag" rule: since they consume tokens directly (e.g. ``--perm read write``), the flag itself receives a short flag in addition to its per-member options.
 
+A boolean parameter that already defaults to :obj:`True` gets no short flag.
+Its short would map to the positive long form (e.g. ``-f`` → ``--flag``), which is a no-op since the value is already :obj:`True`; the meaningful off-switch ``--no-flag`` is long-only.
+The letter is left free for another parameter to use.
+
 ----
 Help
 ----

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -220,6 +220,9 @@ The help flag ``-h`` (and ``-v`` when a short version flag is configured) is alw
 
 The short flag is additional; the long ``--env`` still works.
 
+Explicitly setting :attr:`~cyclopts.Parameter.alias` (or :attr:`~cyclopts.Parameter.name`) on a parameter opts it out of auto-generation: Cyclopts uses only the short flag you provided and does **not** also derive one.
+For example, ``env: Annotated[str, Parameter(alias="-E")]`` exposes ``-E`` but not ``-e``, even when ``short_alias=True`` is enabled app-wide.
+
 Short flags only apply to parameters that bind input directly **and** surface at the root CLI namespace (i.e. an undotted long flag like ``--env``).
 A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its dotted child fields by default.
 To opt a nested field in, annotate it with ``Annotated[..., Parameter(short_alias=True)]``; its short flag appears as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -224,6 +224,8 @@ Short flags only apply to **top-level** parameters that bind input directly.
 A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
 To opt a nested field in, annotate it with ``Annotated[..., Parameter(short_alias=True)]``; its short flag appears as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
 
+:obj:`~enum.Flag` parameters are the one exception to the "containers don't get a short flag" rule: since they consume tokens directly (e.g. ``--perm read write``), the flag itself receives a short flag in addition to its per-member options.
+
 ----
 Help
 ----

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -224,10 +224,11 @@ Explicitly setting :attr:`~cyclopts.Parameter.alias` (or :attr:`~cyclopts.Parame
 For example, ``env: Annotated[str, Parameter(alias="-E")]`` exposes ``-E`` but not ``-e``, even when ``short_alias=True`` is enabled app-wide.
 
 Short flags only apply to parameters that bind input directly **and** surface at the root CLI namespace (i.e. an undotted long flag like ``--env``).
-A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its dotted child fields by default.
-To opt a nested field in, annotate it with ``Annotated[..., Parameter(short_alias=True)]``; its short flag appears as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
+A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its dotted child fields.
+``short_alias`` is inert on a field that stays namespaced: setting it on a nested leaf has no effect.
 
-Fields flattened to the root namespace via ``Parameter(name="*")`` are treated like top-level parameters, so they receive short flags automatically.
+To give a nested field a short flag, flatten it to the root namespace with ``Parameter(name="*")``.
+Flattened fields are treated like top-level parameters (they surface as undotted ``--name`` flags), so they receive short flags automatically.
 
 :obj:`~enum.Flag` parameters are the one exception to the "containers don't get a short flag" rule: since they consume tokens directly (e.g. ``--perm read write``), the flag itself receives a short flag in addition to its per-member options.
 

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -196,16 +196,16 @@ To change the :attr:`~cyclopts.Parameter.name_transform` across your entire app,
 Short Flags
 ^^^^^^^^^^^
 Cyclopts can automatically generate single-letter short flags from your parameter names, so you don't have to specify an alias for every option.
-Enable it per-parameter with :attr:`Parameter.short_alias <cyclopts.Parameter.short_alias>`, or across the whole app with :attr:`App.short_alias <cyclopts.App.short_alias>`.
+Enable it per-parameter with :attr:`Parameter.short_alias <cyclopts.Parameter.short_alias>`, or across the whole app by setting it on the app's :attr:`~cyclopts.App.default_parameter`.
 
 The letter is the first character of the parameter's CLI name (after :attr:`~cyclopts.Parameter.name_transform`), lowercased.
 If that letter is already claimed, the uppercase variant is used; if both are taken, the parameter gets no short flag.
 
 .. code-block:: python
 
-   from cyclopts import App
+   from cyclopts import App, Parameter
 
-   app = App(short_alias=True)
+   app = App(default_parameter=Parameter(short_alias=True))
 
    @app.command
    def deploy(env: str, region: str = "us-east-1"):

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -190,6 +190,40 @@ To change the :attr:`~cyclopts.Parameter.name_transform` across your entire app,
        default_parameter=Parameter(name_transform=my_custom_name_transform),
    )
 
+.. _Parameters - Short Flags:
+
+^^^^^^^^^^^
+Short Flags
+^^^^^^^^^^^
+Cyclopts can automatically generate single-letter short flags from your parameter names, so you don't have to specify an alias for every option.
+Enable it per-parameter with :attr:`Parameter.short_alias <cyclopts.Parameter.short_alias>`, or across the whole app with :attr:`App.short_alias <cyclopts.App.short_alias>`.
+
+The letter is the first character of the parameter's CLI name (after :attr:`~cyclopts.Parameter.name_transform`), lowercased.
+If that letter is already claimed, the uppercase variant is used; if both are taken, the parameter gets no short flag.
+The help flag ``-h`` (and ``-v`` when a short version flag is configured) is always reserved.
+
+.. code-block:: python
+
+   from cyclopts import App
+
+   app = App(short_alias=True)
+
+   @app.command
+   def deploy(env: str, region: str = "us-east-1"):
+       """Deploy to an environment."""
+       print(f"Deploying to {env} in {region}")
+
+.. code-block:: console
+
+   $ my-script deploy -e prod
+   Deploying to prod in us-east-1
+
+The short flag is additional; the long ``--env`` still works.
+
+Short flags only apply to **top-level** parameters that bind input directly.
+A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
+To opt a nested field in, annotate it with ``Annotated[..., Parameter(short_alias=True)]``; its short flag appears as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
+
 ----
 Help
 ----

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -220,9 +220,11 @@ The help flag ``-h`` (and ``-v`` when a short version flag is configured) is alw
 
 The short flag is additional; the long ``--env`` still works.
 
-Short flags only apply to **top-level** parameters that bind input directly.
-A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its promoted child fields by default.
+Short flags only apply to parameters that bind input directly **and** surface at the root CLI namespace (i.e. an undotted long flag like ``--env``).
+A container parameter (such as a dataclass whose fields become ``--user.name`` options) gets no short flag, and neither do its dotted child fields by default.
 To opt a nested field in, annotate it with ``Annotated[..., Parameter(short_alias=True)]``; its short flag appears as a standalone global flag (e.g. ``-n``), never dotted like ``-u.name``.
+
+Fields flattened to the root namespace via ``Parameter(name="*")`` are treated like top-level parameters, so they receive short flags automatically.
 
 :obj:`~enum.Flag` parameters are the one exception to the "containers don't get a short flag" rule: since they consume tokens directly (e.g. ``--perm read write``), the flag itself receives a short flag in addition to its per-member options.
 

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -32,7 +32,8 @@ def test_auto_alias_opt_out(app, assert_parse_args):
 
     assert_parse_args(aliased, "aliased -e prod", env="prod")
     assert_parse_args(plain, "plain --env prod", env="prod")
-    assert "-e" not in app["plain"].assemble_argument_collection()["--env"].parameter.name
+    collection = app["plain"].assemble_argument_collection()
+    assert collection[0].parameter.name == ("--env",)
 
 
 def test_auto_alias_explicit_alias(app, assert_parse_args):
@@ -59,14 +60,14 @@ def test_auto_alias_assignment():
         pass
 
     collection = ArgumentCollection._from_callable(keyword, Parameter(auto_alias=True))
-    assert "-e" in collection["--env"].parameter.name
-    assert "-E" in collection["--endpoint"].parameter.name
-    assert "-e" not in collection["--extra"].parameter.name
-    assert "-r" in collection["--replicas"].parameter.name
+    assert collection[0].parameter.name == ("--env", "-e")
+    assert collection[1].parameter.name == ("--endpoint", "-E")
+    assert collection[2].parameter.name == ("--extra",)
+    assert collection[3].parameter.name == ("--replicas", "-r")
 
     positional_collection = ArgumentCollection._from_callable(positional, Parameter(auto_alias=True))
-    assert "-e" not in positional_collection["ENV"].parameter.name
-    assert "-r" in positional_collection["--replicas"].parameter.name
+    assert positional_collection[0].parameter.name == ("ENV",)
+    assert positional_collection[1].parameter.name == ("--replicas", "-r")
 
 
 def test_auto_alias_on_app_default():
@@ -85,8 +86,8 @@ def test_auto_alias_combines_with_default_parameter(app):
         pass
 
     collection = app["deploy"].assemble_argument_collection()
-    assert "-f" in collection["--flag"].parameter.name
-    assert not collection["--flag"].negatives
+    assert collection[1].parameter.name == ("--flag", "-f")
+    assert not collection[1].negatives
 
 
 def test_auto_alias_skips_help_flag(app, assert_parse_args):
@@ -95,8 +96,7 @@ def test_auto_alias_skips_help_flag(app, assert_parse_args):
         pass
 
     collection = app["connect"].assemble_argument_collection()
-    assert "-h" not in collection["--host"].parameter.name
-    assert "-H" in collection["--host"].parameter.name
+    assert collection[0].parameter.name == ("--host", "-H")
     assert_parse_args(connect, "connect -H localhost -p 9000", host="localhost", port=9000)
 
 
@@ -106,7 +106,7 @@ def test_auto_alias_uses_help_flag_when_unreserved(app):
         pass
 
     collection = app["connect"].assemble_argument_collection()
-    assert "-h" in collection["--host"].parameter.name
+    assert collection[0].parameter.name == ("--host", "-h")
 
 
 def test_auto_alias_skips_version_flag(app):
@@ -115,7 +115,7 @@ def test_auto_alias_skips_version_flag(app):
         pass
 
     collection = app["main"].assemble_argument_collection()
-    assert "-v" not in collection["--verbose"].parameter.name
+    assert collection[0].parameter.name == ("--verbose", "-V")
 
 
 def test_auto_alias_help(app, console):

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -1,0 +1,131 @@
+from typing import Annotated
+
+from cyclopts import App, Parameter
+from cyclopts.argument import ArgumentCollection
+
+
+def _arg_named(collection, name: str):
+    return next(arg for arg in collection if arg.field_info.name == name)
+
+
+def test_auto_alias_on_command():
+    app = App(result_action="return_value")
+
+    @app.command(auto_alias=True)
+    def deploy(*, env: str, replicas: int = 10):
+        return env, replicas
+
+    assert app("deploy -e prod -r 5") == ("prod", 5)
+    assert app("deploy --env staging --replicas 3") == ("staging", 3)
+
+
+def test_auto_alias_not_on_other_commands():
+    app = App(result_action="return_value")
+
+    @app.command(auto_alias=True)
+    def aliased(*, env: str):
+        return env
+
+    @app.command
+    def plain(*, env: str):
+        return env
+
+    assert app("aliased -e prod") == "prod"
+
+    aliased_collection = app["aliased"].assemble_argument_collection()
+    plain_collection = app["plain"].assemble_argument_collection()
+    assert "-e" in _arg_named(aliased_collection, "env").parameter.name
+    assert "-e" not in _arg_named(plain_collection, "env").parameter.name
+
+
+def test_auto_alias_explicit_alias_overrides():
+    app = App(result_action="return_value")
+
+    @app.command(default_parameter=Parameter(auto_alias=True))
+    def deploy(
+        *,
+        env: Annotated[str, Parameter(alias="-E")],
+        replicas: int = 10,
+    ):
+        return env, replicas
+
+    assert app("deploy -E prod -r 5") == ("prod", 5)
+
+
+def test_auto_alias_skips_collision():
+    app = App(result_action="return_value")
+
+    @app.command(default_parameter=Parameter(auto_alias=True))
+    def deploy(*, env: str, endpoint: str):
+        return env, endpoint
+
+    collection = app["deploy"].assemble_argument_collection()
+    env_arg = _arg_named(collection, "env")
+    endpoint_arg = _arg_named(collection, "endpoint")
+
+    assert "-e" in env_arg.parameter.name
+    assert "-e" not in endpoint_arg.parameter.name
+
+
+def test_auto_alias_skips_positional():
+    app = App(result_action="return_value")
+
+    @app.command(default_parameter=Parameter(auto_alias=True))
+    def deploy(env, /, *, replicas: int = 10):
+        return env, replicas
+
+    collection = app["deploy"].assemble_argument_collection()
+    env_arg = _arg_named(collection, "env")
+    replicas_arg = _arg_named(collection, "replicas")
+
+    assert "-e" not in env_arg.parameter.name
+    assert "-r" in replicas_arg.parameter.name
+
+
+def test_auto_alias_from_argument_collection():
+    def deploy(*, env: str, replicas: int = 10):
+        pass
+
+    collection = ArgumentCollection._from_callable(deploy, Parameter(auto_alias=True))
+    assert "-e" in _arg_named(collection, "env").parameter.name
+    assert "-r" in _arg_named(collection, "replicas").parameter.name
+
+
+def test_auto_alias_on_app_default():
+    app = App(result_action="return_value", auto_alias=True)
+
+    @app.default
+    def main(*, env: str):
+        return env
+
+    assert app("-e prod") == "prod"
+
+
+def test_auto_alias_command_kwarg_combines_with_default_parameter():
+    app = App(result_action="return_value")
+
+    @app.command(auto_alias=True, default_parameter=Parameter(negative=""))
+    def deploy(*, env: str, flag: bool = False):
+        return env, flag
+
+    collection = app["deploy"].assemble_argument_collection()
+    env_arg = _arg_named(collection, "env")
+    flag_arg = _arg_named(collection, "flag")
+
+    assert "-e" in env_arg.parameter.name
+    assert "-f" in flag_arg.parameter.name
+    assert not flag_arg.negatives
+
+
+def test_auto_alias_help(app, console):
+
+    @app.command(auto_alias=True)
+    def deploy(*, env: str, replicas: int = 10):
+        """Deploy."""
+
+    with console.capture() as capture:
+        app("deploy --help", console=console)
+
+    output = capture.get()
+    assert "--env -e" in output
+    assert "--replicas -r" in output

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -52,19 +52,36 @@ def test_auto_alias_explicit_alias_overrides():
     assert app("deploy -E prod -r 5") == ("prod", 5)
 
 
-def test_auto_alias_skips_collision():
+def test_auto_alias_same_letter_lowercase_then_uppercase():
     app = App(result_action="return_value")
 
     @app.command(default_parameter=Parameter(auto_alias=True))
     def deploy(*, env: str, endpoint: str):
         return env, endpoint
 
-    collection = app["deploy"].assemble_argument_collection()
-    env_arg = _arg_named(collection, "env")
-    endpoint_arg = _arg_named(collection, "endpoint")
+    assert app("deploy -e dev -E api") == ("dev", "api")
 
-    assert "-e" in env_arg.parameter.name
-    assert "-e" not in endpoint_arg.parameter.name
+    collection = app["deploy"].assemble_argument_collection()
+
+    assert "-e" in _arg_named(collection, "env").parameter.name
+    assert "-E" in _arg_named(collection, "endpoint").parameter.name
+
+
+def test_auto_alias_same_letter_third_gets_none():
+    app = App(result_action="return_value")
+
+    @app.command(default_parameter=Parameter(auto_alias=True))
+    def deploy(*, env: str, endpoint: str, extra: str):
+        return env, endpoint, extra
+
+    collection = app["deploy"].assemble_argument_collection()
+
+    assert "-e" in _arg_named(collection, "env").parameter.name
+    assert "-E" in _arg_named(collection, "endpoint").parameter.name
+
+    extra_arg = _arg_named(collection, "extra")
+    assert "-e" not in extra_arg.parameter.name
+    assert "-E" not in extra_arg.parameter.name
 
 
 def test_auto_alias_skips_positional():
@@ -75,11 +92,9 @@ def test_auto_alias_skips_positional():
         return env, replicas
 
     collection = app["deploy"].assemble_argument_collection()
-    env_arg = _arg_named(collection, "env")
-    replicas_arg = _arg_named(collection, "replicas")
 
-    assert "-e" not in env_arg.parameter.name
-    assert "-r" in replicas_arg.parameter.name
+    assert "-e" not in _arg_named(collection, "env").parameter.name
+    assert "-r" in _arg_named(collection, "replicas").parameter.name
 
 
 def test_auto_alias_from_argument_collection():
@@ -109,10 +124,10 @@ def test_auto_alias_command_kwarg_combines_with_default_parameter():
         return env, flag
 
     collection = app["deploy"].assemble_argument_collection()
-    env_arg = _arg_named(collection, "env")
-    flag_arg = _arg_named(collection, "flag")
 
-    assert "-e" in env_arg.parameter.name
+    assert "-e" in _arg_named(collection, "env").parameter.name
+
+    flag_arg = _arg_named(collection, "flag")
     assert "-f" in flag_arg.parameter.name
     assert not flag_arg.negatives
 

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -1,113 +1,76 @@
 from typing import Annotated
 
+import pytest
+
 from cyclopts import App, Parameter
 from cyclopts.argument import ArgumentCollection
 
 
-def _arg_named(collection, name: str):
-    return next(arg for arg in collection if arg.field_info.name == name)
-
-
-def test_auto_alias_on_command():
-    app = App(result_action="return_value")
-
+@pytest.mark.parametrize(
+    "cmd, kwargs",
+    [
+        ("deploy -e prod -r 5", {"env": "prod", "replicas": 5}),
+        ("deploy --env staging --replicas 3", {"env": "staging", "replicas": 3}),
+    ],
+)
+def test_auto_alias_parses(app, assert_parse_args, cmd, kwargs):
     @app.command(auto_alias=True)
-    def deploy(*, env: str, replicas: int = 10):
-        return env, replicas
-
-    assert app("deploy -e prod -r 5") == ("prod", 5)
-    assert app("deploy --env staging --replicas 3") == ("staging", 3)
-
-
-def test_auto_alias_not_on_other_commands():
-    app = App(result_action="return_value")
-
-    @app.command(auto_alias=True)
-    def aliased(*, env: str):
-        return env
-
-    @app.command
-    def plain(*, env: str):
-        return env
-
-    assert app("aliased -e prod") == "prod"
-
-    aliased_collection = app["aliased"].assemble_argument_collection()
-    plain_collection = app["plain"].assemble_argument_collection()
-    assert "-e" in _arg_named(aliased_collection, "env").parameter.name
-    assert "-e" not in _arg_named(plain_collection, "env").parameter.name
-
-
-def test_auto_alias_explicit_alias_overrides():
-    app = App(result_action="return_value")
-
-    @app.command(default_parameter=Parameter(auto_alias=True))
-    def deploy(
-        *,
-        env: Annotated[str, Parameter(alias="-E")],
-        replicas: int = 10,
-    ):
-        return env, replicas
-
-    assert app("deploy -E prod -r 5") == ("prod", 5)
-
-
-def test_auto_alias_same_letter_lowercase_then_uppercase():
-    app = App(result_action="return_value")
-
-    @app.command(default_parameter=Parameter(auto_alias=True))
-    def deploy(*, env: str, endpoint: str):
-        return env, endpoint
-
-    assert app("deploy -e dev -E api") == ("dev", "api")
-
-    collection = app["deploy"].assemble_argument_collection()
-
-    assert "-e" in _arg_named(collection, "env").parameter.name
-    assert "-E" in _arg_named(collection, "endpoint").parameter.name
-
-
-def test_auto_alias_same_letter_third_gets_none():
-    app = App(result_action="return_value")
-
-    @app.command(default_parameter=Parameter(auto_alias=True))
-    def deploy(*, env: str, endpoint: str, extra: str):
-        return env, endpoint, extra
-
-    collection = app["deploy"].assemble_argument_collection()
-
-    assert "-e" in _arg_named(collection, "env").parameter.name
-    assert "-E" in _arg_named(collection, "endpoint").parameter.name
-
-    extra_arg = _arg_named(collection, "extra")
-    assert "-e" not in extra_arg.parameter.name
-    assert "-E" not in extra_arg.parameter.name
-
-
-def test_auto_alias_skips_positional():
-    app = App(result_action="return_value")
-
-    @app.command(default_parameter=Parameter(auto_alias=True))
-    def deploy(env, /, *, replicas: int = 10):
-        return env, replicas
-
-    collection = app["deploy"].assemble_argument_collection()
-
-    assert "-e" not in _arg_named(collection, "env").parameter.name
-    assert "-r" in _arg_named(collection, "replicas").parameter.name
-
-
-def test_auto_alias_from_argument_collection():
     def deploy(*, env: str, replicas: int = 10):
         pass
 
-    collection = ArgumentCollection._from_callable(deploy, Parameter(auto_alias=True))
-    assert "-e" in _arg_named(collection, "env").parameter.name
-    assert "-r" in _arg_named(collection, "replicas").parameter.name
+    assert_parse_args(deploy, cmd, **kwargs)
+
+
+def test_auto_alias_opt_out(app, assert_parse_args):
+    @app.command(auto_alias=True)
+    def aliased(*, env: str):
+        pass
+
+    @app.command
+    def plain(*, env: str):
+        pass
+
+    assert_parse_args(aliased, "aliased -e prod", env="prod")
+    assert_parse_args(plain, "plain --env prod", env="prod")
+    assert "-e" not in app["plain"].assemble_argument_collection()["--env"].parameter.name
+
+
+def test_auto_alias_explicit_alias(app, assert_parse_args):
+    @app.command(auto_alias=True)
+    def deploy(*, env: Annotated[str, Parameter(alias="-E")], replicas: int = 10):
+        pass
+
+    assert_parse_args(deploy, "deploy -E prod -r 5", env="prod", replicas=5)
+
+
+def test_auto_alias_same_letter(app, assert_parse_args):
+    @app.command(auto_alias=True)
+    def deploy(*, env: str, endpoint: str):
+        pass
+
+    assert_parse_args(deploy, "deploy -e dev -E api", env="dev", endpoint="api")
+
+
+def test_auto_alias_assignment():
+    def keyword(*, env: str, endpoint: str, extra: str, replicas: int = 10):
+        pass
+
+    def positional(env, /, *, replicas: int = 10):
+        pass
+
+    collection = ArgumentCollection._from_callable(keyword, Parameter(auto_alias=True))
+    assert "-e" in collection["--env"].parameter.name
+    assert "-E" in collection["--endpoint"].parameter.name
+    assert "-e" not in collection["--extra"].parameter.name
+    assert "-r" in collection["--replicas"].parameter.name
+
+    positional_collection = ArgumentCollection._from_callable(positional, Parameter(auto_alias=True))
+    assert "-e" not in positional_collection["ENV"].parameter.name
+    assert "-r" in positional_collection["--replicas"].parameter.name
 
 
 def test_auto_alias_on_app_default():
-    app = App(result_action="return_value", auto_alias=True)
+    app = App(auto_alias=True, result_action="return_value")
 
     @app.default
     def main(*, env: str):
@@ -116,24 +79,17 @@ def test_auto_alias_on_app_default():
     assert app("-e prod") == "prod"
 
 
-def test_auto_alias_command_kwarg_combines_with_default_parameter():
-    app = App(result_action="return_value")
-
+def test_auto_alias_combines_with_default_parameter(app):
     @app.command(auto_alias=True, default_parameter=Parameter(negative=""))
     def deploy(*, env: str, flag: bool = False):
-        return env, flag
+        pass
 
     collection = app["deploy"].assemble_argument_collection()
-
-    assert "-e" in _arg_named(collection, "env").parameter.name
-
-    flag_arg = _arg_named(collection, "flag")
-    assert "-f" in flag_arg.parameter.name
-    assert not flag_arg.negatives
+    assert "-f" in collection["--flag"].parameter.name
+    assert not collection["--flag"].negatives
 
 
 def test_auto_alias_help(app, console):
-
     @app.command(auto_alias=True)
     def deploy(*, env: str, replicas: int = 10):
         """Deploy."""

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -52,6 +52,18 @@ def test_auto_alias_same_letter(app, assert_parse_args):
     assert_parse_args(deploy, "deploy -e dev -E api", env="dev", endpoint="api")
 
 
+def test_auto_alias_callable():
+    def fn(host: str = "localhost", port: int = 8080):
+        pass
+
+    collection = ArgumentCollection._from_callable(
+        fn,
+        Parameter(auto_alias=lambda field_info, _: f"-{field_info.names[0][0].upper()}"),
+    )
+    assert collection[0].parameter.name == ("--host", "-H")
+    assert collection[1].parameter.name == ("--port", "-P")
+
+
 def test_auto_alias_assignment():
     def keyword(env: str = "a", endpoint: str = "b", extra: str = "c", replicas: int = 10):
         pass

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -15,7 +15,7 @@ from cyclopts.argument import ArgumentCollection
 )
 def test_auto_alias_parses(app, assert_parse_args, cmd, kwargs):
     @app.command(auto_alias=True)
-    def deploy(*, env: str, replicas: int = 10):
+    def deploy(env: str = "staging", replicas: int = 10):
         pass
 
     assert_parse_args(deploy, cmd, **kwargs)
@@ -23,11 +23,11 @@ def test_auto_alias_parses(app, assert_parse_args, cmd, kwargs):
 
 def test_auto_alias_opt_out(app, assert_parse_args):
     @app.command(auto_alias=True)
-    def aliased(*, env: str):
+    def aliased(env: str = "prod"):
         pass
 
     @app.command
-    def plain(*, env: str):
+    def plain(env: str = "prod"):
         pass
 
     assert_parse_args(aliased, "aliased -e prod", env="prod")
@@ -37,7 +37,7 @@ def test_auto_alias_opt_out(app, assert_parse_args):
 
 def test_auto_alias_explicit_alias(app, assert_parse_args):
     @app.command(auto_alias=True)
-    def deploy(*, env: Annotated[str, Parameter(alias="-E")], replicas: int = 10):
+    def deploy(env: Annotated[str, Parameter(alias="-E")] = "prod", replicas: int = 10):
         pass
 
     assert_parse_args(deploy, "deploy -E prod -r 5", env="prod", replicas=5)
@@ -45,14 +45,14 @@ def test_auto_alias_explicit_alias(app, assert_parse_args):
 
 def test_auto_alias_same_letter(app, assert_parse_args):
     @app.command(auto_alias=True)
-    def deploy(*, env: str, endpoint: str):
+    def deploy(env: str = "dev", endpoint: str = "api"):
         pass
 
     assert_parse_args(deploy, "deploy -e dev -E api", env="dev", endpoint="api")
 
 
 def test_auto_alias_assignment():
-    def keyword(*, env: str, endpoint: str, extra: str, replicas: int = 10):
+    def keyword(env: str = "a", endpoint: str = "b", extra: str = "c", replicas: int = 10):
         pass
 
     def positional(env, /, *, replicas: int = 10):
@@ -73,7 +73,7 @@ def test_auto_alias_on_app_default():
     app = App(auto_alias=True, result_action="return_value")
 
     @app.default
-    def main(*, env: str):
+    def main(env: str = "prod"):
         return env
 
     assert app("-e prod") == "prod"
@@ -81,7 +81,7 @@ def test_auto_alias_on_app_default():
 
 def test_auto_alias_combines_with_default_parameter(app):
     @app.command(auto_alias=True, default_parameter=Parameter(negative=""))
-    def deploy(*, env: str, flag: bool = False):
+    def deploy(env: str = "prod", flag: bool = False):
         pass
 
     collection = app["deploy"].assemble_argument_collection()
@@ -91,18 +91,18 @@ def test_auto_alias_combines_with_default_parameter(app):
 
 def test_auto_alias_skips_help_flag(app, assert_parse_args):
     @app.command(auto_alias=True)
-    def connect(*, host: str, port: int):
+    def connect(host: str = "localhost", port: int = 8080):
         pass
 
     collection = app["connect"].assemble_argument_collection()
     assert "-h" not in collection["--host"].parameter.name
     assert "-H" in collection["--host"].parameter.name
-    assert_parse_args(connect, "connect -H localhost -p 8080", host="localhost", port=8080)
+    assert_parse_args(connect, "connect -H localhost -p 9000", host="localhost", port=9000)
 
 
 def test_auto_alias_uses_help_flag_when_unreserved(app):
     @app.command(auto_alias=True, help_flags=["--help"])
-    def connect(*, host: str):
+    def connect(host: str = "localhost"):
         pass
 
     collection = app["connect"].assemble_argument_collection()
@@ -111,7 +111,7 @@ def test_auto_alias_uses_help_flag_when_unreserved(app):
 
 def test_auto_alias_skips_version_flag(app):
     @app.command(auto_alias=True, version_flags=["-v", "--version"])
-    def main(*, verbose: bool = False):
+    def main(verbose: bool = False):
         pass
 
     collection = app["main"].assemble_argument_collection()
@@ -120,7 +120,7 @@ def test_auto_alias_skips_version_flag(app):
 
 def test_auto_alias_help(app, console):
     @app.command(auto_alias=True)
-    def deploy(*, env: str, replicas: int = 10):
+    def deploy(env: str = "staging", replicas: int = 10):
         """Deploy."""
 
     with console.capture() as capture:

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -89,6 +89,35 @@ def test_auto_alias_combines_with_default_parameter(app):
     assert not collection["--flag"].negatives
 
 
+def test_auto_alias_skips_help_flag(app, assert_parse_args):
+    @app.command(auto_alias=True)
+    def connect(*, host: str, port: int):
+        pass
+
+    collection = app["connect"].assemble_argument_collection()
+    assert "-h" not in collection["--host"].parameter.name
+    assert "-H" in collection["--host"].parameter.name
+    assert_parse_args(connect, "connect -H localhost -p 8080", host="localhost", port=8080)
+
+
+def test_auto_alias_uses_help_flag_when_unreserved(app):
+    @app.command(auto_alias=True, help_flags=["--help"])
+    def connect(*, host: str):
+        pass
+
+    collection = app["connect"].assemble_argument_collection()
+    assert "-h" in collection["--host"].parameter.name
+
+
+def test_auto_alias_skips_version_flag(app):
+    @app.command(auto_alias=True, version_flags=["-v", "--version"])
+    def main(*, verbose: bool = False):
+        pass
+
+    collection = app["main"].assemble_argument_collection()
+    assert "-v" not in collection["--verbose"].parameter.name
+
+
 def test_auto_alias_help(app, console):
     @app.command(auto_alias=True)
     def deploy(*, env: str, replicas: int = 10):

--- a/tests/test_auto_alias.py
+++ b/tests/test_auto_alias.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from typing import Annotated
 
 import pytest
@@ -128,6 +129,77 @@ def test_auto_alias_skips_version_flag(app):
 
     collection = app["main"].assemble_argument_collection()
     assert collection[0].parameter.name == ("--verbose", "-V")
+
+
+def test_auto_alias_nested_dataclass_top_level_only(app, assert_parse_args):
+    """Containers and their promoted fields get no auto short by default; only top-level scalars do."""
+
+    @dataclass
+    class Color:
+        red: int = 0
+        green: int = 0
+
+    @dataclass
+    class User:
+        name: str = ""
+        color: Color = field(default_factory=Color)
+
+    @app.command(auto_alias=True)
+    def foo(*, user: User | None = None, upload: bool = False):
+        pass
+
+    collection = app["foo"].assemble_argument_collection()
+    names = {c.parameter.name[0]: c.parameter.name for c in collection}
+    # The container and every promoted field get no short (no ``-u``, no ``-u.name``, no ``-n``).
+    assert names["--user"] == ("--user",)
+    assert names["--user.name"] == ("--user.name",)
+    assert names["--user.color.red"] == ("--user.color.red",)
+    # Only the top-level scalar gets a short.
+    assert names["--upload"] == ("--upload", "-u")
+    assert_parse_args(foo, "foo -u", upload=True)
+
+
+def test_auto_alias_nested_field_explicit_opt_in(app, assert_parse_args):
+    """A nested leaf field opts in explicitly and surfaces a standalone (not dotted) short."""
+
+    @dataclass
+    class User:
+        name: Annotated[str, Parameter(auto_alias=True)] = ""
+        color: str = ""
+
+    @app.command(auto_alias=True)
+    def foo(*, user: User):
+        pass
+
+    collection = app["foo"].assemble_argument_collection()
+    names = {c.parameter.name[0]: c.parameter.name for c in collection}
+    assert names["--user.name"] == ("--user.name", "-n")
+    assert names["--user.color"] == ("--user.color",)
+    assert_parse_args(foo, "foo -n Bob", user=User(name="Bob"))
+
+
+def test_auto_alias_letter_from_transformed_name(app):
+    """The short letter follows the transformed long flag, not the raw python identifier."""
+
+    @app.command(auto_alias=True)
+    def foo(*, _private: str = "", verbose: bool = False):
+        pass
+
+    collection = app["foo"].assemble_argument_collection()
+    names = {c.parameter.name[0]: c.parameter.name for c in collection}
+    assert names["--private"] == ("--private", "-p")  # not "-_"
+    assert names["--verbose"] == ("--verbose", "-v")
+
+
+def test_auto_alias_letter_respects_custom_name_transform(app):
+    """A custom name_transform drives both the long name and the short letter."""
+
+    @app.command(auto_alias=True, default_parameter=Parameter(name_transform=lambda s: "x" + s))
+    def foo(*, my_flag: bool = False):
+        pass
+
+    collection = app["foo"].assemble_argument_collection()
+    assert collection[0].parameter.name == ("--xmy_flag", "-x")
 
 
 def test_auto_alias_help(app, console):

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -157,8 +157,12 @@ def test_short_alias_nested_dataclass_top_level_only(app, assert_parse_args):
     assert_parse_args(foo, "foo -u", upload=True)
 
 
-def test_short_alias_nested_field_explicit_opt_in(app, assert_parse_args):
-    """A nested leaf field opts in explicitly and surfaces a standalone (not dotted) short."""
+def test_short_alias_nested_field_opt_in_is_inert(app):
+    """``short_alias`` is inert on a field that stays namespaced; only root-namespace gets a short.
+
+    A nested leaf keeps its dotted ``--user.name`` flag and no short, even when it sets
+    ``short_alias=True`` directly. Flattening via ``name="*"`` is the way to give it a short.
+    """
 
     @dataclass
     class User:
@@ -171,9 +175,8 @@ def test_short_alias_nested_field_explicit_opt_in(app, assert_parse_args):
 
     collection = app["foo"].assemble_argument_collection()
     names = {c.parameter.name[0]: c.parameter.name for c in collection}
-    assert names["--user.name"] == ("--user.name", "-n")
+    assert names["--user.name"] == ("--user.name",)
     assert names["--user.color"] == ("--user.color",)
-    assert_parse_args(foo, "foo -n Bob", user=User(name="Bob"))
 
 
 def test_short_alias_flattened_fields_get_short(app, assert_parse_args):

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -389,6 +389,25 @@ def test_short_alias_callable_collision_deduped():
     assert collection[1].parameter.name == ("--beta",)
 
 
+@pytest.mark.parametrize(
+    "returned, exc, match",
+    [
+        ("e", ValueError, "single-letter short flags"),  # missing leading dash -> would be positional
+        ("--foo", ValueError, "single-letter short flags"),  # long flag, not a short
+        (["-e", "x"], ValueError, "single-letter short flags"),  # one bad item in the iterable
+        (42, TypeError, "must return a str"),  # not a str or iterable
+    ],
+)
+def test_short_alias_callable_bad_return_rejected(returned, exc, match):
+    """A callable must return single-letter shorts; anything else fails loudly, not silently."""
+
+    def fn(env: str = ""):
+        pass
+
+    with pytest.raises(exc, match=match):
+        ArgumentCollection._from_callable(fn, Parameter(short_alias=lambda fi, used: returned))
+
+
 def test_short_alias_explicit_alias_not_shadowed_by_earlier_auto(app, assert_parse_args):
     """An explicit ``alias`` on a later parameter wins over an earlier parameter's auto short.
 

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -418,6 +418,33 @@ def test_short_alias_explicit_name_short_not_shadowed_by_earlier_auto(app):
     assert collection[1].parameter.name == ("--region", "-r")
 
 
+def test_short_alias_explicit_name_opts_out_and_frees_letter(app):
+    """An explicit ``name`` opts the parameter out of auto-generation entirely.
+
+    ``foo`` already carries an explicit ``-f`` via ``name``, so it must not also get a
+    redundant auto ``-F``. Crucially, because it comes first, the freed ``-F`` must remain
+    available to the later ``force`` parameter rather than being stolen by ``foo``.
+    """
+
+    @app.command(default_parameter=Parameter(short_alias=True))
+    def deploy(foo: Annotated[str, Parameter(name=("--foo", "-f"))] = "a", force: bool = False):
+        pass
+
+    collection = app["deploy"].assemble_argument_collection()
+    assert collection[0].parameter.name == ("--foo", "-f")  # no redundant -F
+    assert collection[1].parameter.name == ("--force", "-F")  # reclaims the freed letter
+
+
+def test_short_alias_explicit_name_rename_opts_out(app):
+    """A pure rename via ``name`` (no short) also opts out of auto-generation."""
+
+    @app.command(default_parameter=Parameter(short_alias=True))
+    def deploy(env: Annotated[str, Parameter(name="--environment")] = "x"):
+        pass
+
+    assert app["deploy"].assemble_argument_collection()[0].parameter.name == ("--environment",)
+
+
 def test_short_alias_propagates_to_subapp_at_runtime():
     """``short_alias=True`` on a root app reaches commands registered on a subapp at parse time."""
     root = App(name="root", default_parameter=Parameter(short_alias=True), result_action="return_value")

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -25,7 +25,7 @@ def test_short_alias_parses(app, assert_parse_args, cmd, kwargs):
     uses its short.
     """
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def deploy(env: str, replicas: int = 10):
         pass
 
@@ -39,7 +39,7 @@ def test_short_alias_explicit_alias(app, assert_parse_args):
     alias signals manual control of the short flag.
     """
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def deploy(env: Annotated[str, Parameter(alias="-E")] = "prod", replicas: int = 10):
         pass
 
@@ -82,7 +82,7 @@ def test_short_alias_assignment():
 
 
 def test_short_alias_on_app_default():
-    app = App(short_alias=True, result_action="return_value")
+    app = App(default_parameter=Parameter(short_alias=True), result_action="return_value")
 
     @app.default
     def main(env: str = "prod"):
@@ -92,7 +92,7 @@ def test_short_alias_on_app_default():
 
 
 def test_short_alias_combines_with_default_parameter(app):
-    @app.command(short_alias=True, default_parameter=Parameter(negative=""))
+    @app.command(default_parameter=Parameter(short_alias=True, negative=""))
     def deploy(env: str = "prod", flag: bool = False):
         pass
 
@@ -102,7 +102,7 @@ def test_short_alias_combines_with_default_parameter(app):
 
 
 def test_short_alias_skips_help_flag(app, assert_parse_args):
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def connect(host: str = "localhost", port: int = 8080):
         pass
 
@@ -112,7 +112,7 @@ def test_short_alias_skips_help_flag(app, assert_parse_args):
 
 
 def test_short_alias_uses_help_flag_when_unreserved(app):
-    @app.command(short_alias=True, help_flags=["--help"])
+    @app.command(default_parameter=Parameter(short_alias=True), help_flags=["--help"])
     def connect(host: str = "localhost"):
         pass
 
@@ -121,7 +121,7 @@ def test_short_alias_uses_help_flag_when_unreserved(app):
 
 
 def test_short_alias_skips_version_flag(app):
-    @app.command(short_alias=True, version_flags=["-v", "--version"])
+    @app.command(default_parameter=Parameter(short_alias=True), version_flags=["-v", "--version"])
     def main(verbose: bool = False):
         pass
 
@@ -142,7 +142,7 @@ def test_short_alias_nested_dataclass_top_level_only(app, assert_parse_args):
         name: str = ""
         color: Color = field(default_factory=Color)
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def foo(*, user: User | None = None, upload: bool = False):
         pass
 
@@ -169,7 +169,7 @@ def test_short_alias_nested_field_opt_in_is_inert(app):
         name: Annotated[str, Parameter(short_alias=True)] = ""
         color: str = ""
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def foo(*, user: User):
         pass
 
@@ -197,7 +197,7 @@ def test_short_alias_flattened_fields_get_short(app, assert_parse_args):
         email: str = ""
         color: Color = field(default_factory=Color)
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def foo(user: Annotated[User | None, Parameter(name="*")] = None):
         pass
 
@@ -213,7 +213,7 @@ def test_short_alias_flattened_fields_get_short(app, assert_parse_args):
 def test_short_alias_letter_from_transformed_name(app):
     """The short letter follows the transformed long flag, not the raw python identifier."""
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def foo(*, _private: str = "", verbose: bool = False):
         pass
 
@@ -226,7 +226,7 @@ def test_short_alias_letter_from_transformed_name(app):
 def test_short_alias_letter_respects_custom_name_transform(app):
     """A custom name_transform drives both the long name and the short letter."""
 
-    @app.command(short_alias=True, default_parameter=Parameter(name_transform=lambda s: "x" + s))
+    @app.command(default_parameter=Parameter(short_alias=True, name_transform=lambda s: "x" + s))
     def foo(*, my_flag: bool = False):
         pass
 
@@ -235,7 +235,7 @@ def test_short_alias_letter_respects_custom_name_transform(app):
 
 
 def test_short_alias_help(app, console):
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def deploy(env: str = "staging", replicas: int = 10):
         """Deploy."""
 
@@ -267,7 +267,7 @@ def test_short_alias_combined_flags(app, assert_parse_args):
 def test_short_alias_no_negative_for_short(app):
     """A boolean's short flag does not get a negated form (negatives are long-only)."""
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def main(*, verbose: bool = False):
         pass
 
@@ -286,7 +286,7 @@ def test_short_alias_skips_bool_defaulting_true(app):
     get shorts.
     """
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def main(*, force: bool = True, file: str = "", verbose: bool = False, req: bool):
         pass
 
@@ -304,7 +304,7 @@ def test_short_alias_enum_flag_gets_short(app):
         read = auto()
         write = auto()
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def main(*, perm: Perm = Perm.read):
         pass
 
@@ -321,7 +321,7 @@ def test_short_alias_accepts_keys_false_gets_short(app):
         x: int = 0
         y: int = 0
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def main(*, pt: Annotated[Point, Parameter(accepts_keys=False)]):
         pass
 
@@ -396,7 +396,7 @@ def test_short_alias_explicit_alias_not_shadowed_by_earlier_auto(app, assert_par
     the explicit request must win and ``reset`` falls back to ``-R``.
     """
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def deploy(reset: bool = False, region: Annotated[str, Parameter(alias="-r")] = "x"):
         pass
 
@@ -409,7 +409,7 @@ def test_short_alias_explicit_alias_not_shadowed_by_earlier_auto(app, assert_par
 def test_short_alias_explicit_name_short_not_shadowed_by_earlier_auto(app):
     """A short embedded in an explicit ``name`` is reserved before auto-generation too."""
 
-    @app.command(short_alias=True)
+    @app.command(default_parameter=Parameter(short_alias=True))
     def deploy(reset: bool = False, region: Annotated[str, Parameter(name=("--region", "-r"))] = "x"):
         pass
 
@@ -420,7 +420,7 @@ def test_short_alias_explicit_name_short_not_shadowed_by_earlier_auto(app):
 
 def test_short_alias_propagates_to_subapp_at_runtime():
     """``short_alias=True`` on a root app reaches commands registered on a subapp at parse time."""
-    root = App(name="root", short_alias=True, result_action="return_value")
+    root = App(name="root", default_parameter=Parameter(short_alias=True), result_action="return_value")
     sub = App(name="sub")
     root.command(sub)
 

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -6,6 +6,7 @@ import pytest
 
 from cyclopts import App, Parameter
 from cyclopts.argument import ArgumentCollection
+from cyclopts.exceptions import UnknownOptionError
 
 
 @pytest.mark.parametrize(
@@ -24,11 +25,22 @@ def test_short_alias_parses(app, assert_parse_args, cmd, kwargs):
 
 
 def test_short_alias_explicit_alias(app, assert_parse_args):
+    """An explicit ``alias`` opts the parameter out of auto-generation entirely.
+
+    ``env`` gets ``-E`` (the explicit alias) but no auto ``-e``; the explicit
+    alias signals manual control of the short flag.
+    """
+
     @app.command(short_alias=True)
     def deploy(env: Annotated[str, Parameter(alias="-E")] = "prod", replicas: int = 10):
         pass
 
+    assert app["deploy"].assemble_argument_collection()[0].parameter.name == ("--env", "-E")
     assert_parse_args(deploy, "deploy -E prod -r 5", env="prod", replicas=5)
+
+    # The auto short is suppressed, so lowercase ``-e`` is not a valid flag.
+    with pytest.raises(UnknownOptionError):
+        app.parse_args("deploy -e prod", print_error=False, exit_on_error=False)
 
 
 def test_short_alias_callable():

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -23,35 +23,12 @@ def test_short_alias_parses(app, assert_parse_args, cmd, kwargs):
     assert_parse_args(deploy, cmd, **kwargs)
 
 
-def test_short_alias_opt_out(app, assert_parse_args):
-    @app.command(short_alias=True)
-    def aliased(env: str = "prod"):
-        pass
-
-    @app.command
-    def plain(env: str = "prod"):
-        pass
-
-    assert_parse_args(aliased, "aliased -e prod", env="prod")
-    assert_parse_args(plain, "plain --env prod", env="prod")
-    collection = app["plain"].assemble_argument_collection()
-    assert collection[0].parameter.name == ("--env",)
-
-
 def test_short_alias_explicit_alias(app, assert_parse_args):
     @app.command(short_alias=True)
     def deploy(env: Annotated[str, Parameter(alias="-E")] = "prod", replicas: int = 10):
         pass
 
     assert_parse_args(deploy, "deploy -E prod -r 5", env="prod", replicas=5)
-
-
-def test_short_alias_same_letter(app, assert_parse_args):
-    @app.command(short_alias=True)
-    def deploy(env: str = "dev", endpoint: str = "api"):
-        pass
-
-    assert_parse_args(deploy, "deploy -e dev -E api", env="dev", endpoint="api")
 
 
 def test_short_alias_callable():

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -364,6 +364,35 @@ def test_short_alias_callable_collision_deduped():
     assert collection[1].parameter.name == ("--beta",)
 
 
+def test_short_alias_explicit_alias_not_shadowed_by_earlier_auto(app, assert_parse_args):
+    """An explicit ``alias`` on a later parameter wins over an earlier parameter's auto short.
+
+    ``reset`` would auto-claim ``-r`` first, but ``region`` explicitly asks for ``-r``;
+    the explicit request must win and ``reset`` falls back to ``-R``.
+    """
+
+    @app.command(short_alias=True)
+    def deploy(reset: bool = False, region: Annotated[str, Parameter(alias="-r")] = "x"):
+        pass
+
+    collection = app["deploy"].assemble_argument_collection()
+    assert collection[0].parameter.name == ("--reset", "-R")
+    assert collection[1].parameter.name == ("--region", "-r")
+    assert_parse_args(deploy, "deploy -r eu", region="eu")
+
+
+def test_short_alias_explicit_name_short_not_shadowed_by_earlier_auto(app):
+    """A short embedded in an explicit ``name`` is reserved before auto-generation too."""
+
+    @app.command(short_alias=True)
+    def deploy(reset: bool = False, region: Annotated[str, Parameter(name=("--region", "-r"))] = "x"):
+        pass
+
+    collection = app["deploy"].assemble_argument_collection()
+    assert collection[0].parameter.name == ("--reset", "-R")
+    assert collection[1].parameter.name == ("--region", "-r")
+
+
 def test_short_alias_propagates_to_subapp_at_runtime():
     """``short_alias=True`` on a root app reaches commands registered on a subapp at parse time."""
     root = App(name="root", short_alias=True, result_action="return_value")

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -14,11 +14,19 @@ from cyclopts.exceptions import UnknownOptionError
     [
         ("deploy -e prod -r 5", {"env": "prod", "replicas": 5}),
         ("deploy --env staging --replicas 3", {"env": "staging", "replicas": 3}),
+        ("deploy prod -r 5", {"env": "prod", "replicas": 5}),
     ],
 )
 def test_short_alias_parses(app, assert_parse_args, cmd, kwargs):
+    """Shorts work alongside the long names and positional binding.
+
+    ``env`` is required (no default), exercising that a required positional-or-keyword
+    param still gets a short; the final case binds ``env`` positionally while ``replicas``
+    uses its short.
+    """
+
     @app.command(short_alias=True)
-    def deploy(env: str = "staging", replicas: int = 10):
+    def deploy(env: str, replicas: int = 10):
         pass
 
     assert_parse_args(deploy, cmd, **kwargs)
@@ -71,31 +79,6 @@ def test_short_alias_assignment():
     positional_collection = ArgumentCollection._from_callable(positional, Parameter(short_alias=True))
     assert positional_collection[0].parameter.name == ("ENV",)
     assert positional_collection[1].parameter.name == ("--replicas", "-r")
-
-
-def test_short_alias_positional_or_keyword_gets_short(app, assert_parse_args):
-    """Every positional-or-keyword param exposes a ``--long`` form, so it also gets a short.
-
-    Applies to required params and to params preceding a ``*`` (keyword-only) marker.
-    """
-
-    @app.command(short_alias=True)
-    def deploy(env: str, region: str = "us-east-1"):
-        pass
-
-    collection = app["deploy"].assemble_argument_collection()
-    assert collection[0].parameter.name == ("--env", "-e")
-    assert collection[1].parameter.name == ("--region", "-r")
-    assert_parse_args(deploy, "deploy -e prod", env="prod")
-    assert_parse_args(deploy, "deploy prod -r eu", env="prod", region="eu")
-
-    @app.command(short_alias=True)
-    def pre_star(src: str, *, verbose: bool = False):
-        pass
-
-    pre_star_collection = app["pre-star"].assemble_argument_collection()
-    assert pre_star_collection[0].parameter.name == ("--src", "-s")
-    assert pre_star_collection[1].parameter.name == ("--verbose", "-v")
 
 
 def test_short_alias_on_app_default():
@@ -290,6 +273,25 @@ def test_short_alias_no_negative_for_short(app):
     assert "--no-verbose" in arg.names
     assert "--no-v" not in arg.names
     assert "-no-v" not in arg.names
+
+
+def test_short_alias_skips_bool_defaulting_true(app):
+    """A bool that defaults to True gets no auto short; the positive short would be a no-op.
+
+    The off-switch (``--no-flag``) is long-only, so the letter is freed for a parameter
+    that can use it. A required bool (no default) and a ``False``-defaulting bool still
+    get shorts.
+    """
+
+    @app.command(short_alias=True)
+    def main(*, force: bool = True, file: str = "", verbose: bool = False, req: bool):
+        pass
+
+    names = {c.parameter.name[0]: c.parameter.name for c in app["main"].assemble_argument_collection()}
+    assert names["--force"] == ("--force",)  # no-op positive short skipped
+    assert names["--file"] == ("--file", "-f")  # reclaims the letter force did not take
+    assert names["--verbose"] == ("--verbose", "-v")
+    assert names["--req"] == ("--req", "-r")  # required bool still gets a short
 
 
 def test_short_alias_enum_flag_gets_short(app):

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Flag, auto
-from typing import Annotated
+from typing import Annotated, Optional, Union
 
 import pytest
 
@@ -295,6 +295,28 @@ def test_short_alias_skips_bool_defaulting_true(app):
     assert names["--file"] == ("--file", "-f")  # reclaims the letter force did not take
     assert names["--verbose"] == ("--verbose", "-v")
     assert names["--req"] == ("--req", "-r")  # required bool still gets a short
+
+
+def test_short_alias_optional_bool_defaulting_true_skipped(app):
+    """``Optional[bool]`` is resolved to ``bool`` upstream, so the default-True skip still applies.
+
+    A ``True``-defaulting optional bool gets no short (no-op positive), while a
+    ``False``-defaulting one still does — matching plain ``bool`` behavior.
+    """
+
+    @app.command(default_parameter=Parameter(short_alias=True))
+    def main(
+        *,
+        verbose: Optional[bool] = True,
+        kappa: Union[bool, None] = True,
+        debug: Optional[bool] = False,
+    ):
+        pass
+
+    names = {c.parameter.name[0]: c.parameter.name for c in app["main"].assemble_argument_collection()}
+    assert names["--verbose"] == ("--verbose",)  # default-True optional bool: no short
+    assert names["--kappa"] == ("--kappa",)  # same for the Union spelling
+    assert names["--debug"] == ("--debug", "-d")  # default-False optional bool still gets one
 
 
 def test_short_alias_enum_flag_gets_short(app):

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -14,16 +14,16 @@ from cyclopts.argument import ArgumentCollection
         ("deploy --env staging --replicas 3", {"env": "staging", "replicas": 3}),
     ],
 )
-def test_auto_alias_parses(app, assert_parse_args, cmd, kwargs):
-    @app.command(auto_alias=True)
+def test_short_alias_parses(app, assert_parse_args, cmd, kwargs):
+    @app.command(short_alias=True)
     def deploy(env: str = "staging", replicas: int = 10):
         pass
 
     assert_parse_args(deploy, cmd, **kwargs)
 
 
-def test_auto_alias_opt_out(app, assert_parse_args):
-    @app.command(auto_alias=True)
+def test_short_alias_opt_out(app, assert_parse_args):
+    @app.command(short_alias=True)
     def aliased(env: str = "prod"):
         pass
 
@@ -37,54 +37,54 @@ def test_auto_alias_opt_out(app, assert_parse_args):
     assert collection[0].parameter.name == ("--env",)
 
 
-def test_auto_alias_explicit_alias(app, assert_parse_args):
-    @app.command(auto_alias=True)
+def test_short_alias_explicit_alias(app, assert_parse_args):
+    @app.command(short_alias=True)
     def deploy(env: Annotated[str, Parameter(alias="-E")] = "prod", replicas: int = 10):
         pass
 
     assert_parse_args(deploy, "deploy -E prod -r 5", env="prod", replicas=5)
 
 
-def test_auto_alias_same_letter(app, assert_parse_args):
-    @app.command(auto_alias=True)
+def test_short_alias_same_letter(app, assert_parse_args):
+    @app.command(short_alias=True)
     def deploy(env: str = "dev", endpoint: str = "api"):
         pass
 
     assert_parse_args(deploy, "deploy -e dev -E api", env="dev", endpoint="api")
 
 
-def test_auto_alias_callable():
+def test_short_alias_callable():
     def fn(host: str = "localhost", port: int = 8080):
         pass
 
     collection = ArgumentCollection._from_callable(
         fn,
-        Parameter(auto_alias=lambda field_info, _: f"-{field_info.names[0][0].upper()}"),
+        Parameter(short_alias=lambda field_info, _: f"-{field_info.names[0][0].upper()}"),
     )
     assert collection[0].parameter.name == ("--host", "-H")
     assert collection[1].parameter.name == ("--port", "-P")
 
 
-def test_auto_alias_assignment():
+def test_short_alias_assignment():
     def keyword(env: str = "a", endpoint: str = "b", extra: str = "c", replicas: int = 10):
         pass
 
     def positional(env, /, *, replicas: int = 10):
         pass
 
-    collection = ArgumentCollection._from_callable(keyword, Parameter(auto_alias=True))
+    collection = ArgumentCollection._from_callable(keyword, Parameter(short_alias=True))
     assert collection[0].parameter.name == ("--env", "-e")
     assert collection[1].parameter.name == ("--endpoint", "-E")
     assert collection[2].parameter.name == ("--extra",)
     assert collection[3].parameter.name == ("--replicas", "-r")
 
-    positional_collection = ArgumentCollection._from_callable(positional, Parameter(auto_alias=True))
+    positional_collection = ArgumentCollection._from_callable(positional, Parameter(short_alias=True))
     assert positional_collection[0].parameter.name == ("ENV",)
     assert positional_collection[1].parameter.name == ("--replicas", "-r")
 
 
-def test_auto_alias_on_app_default():
-    app = App(auto_alias=True, result_action="return_value")
+def test_short_alias_on_app_default():
+    app = App(short_alias=True, result_action="return_value")
 
     @app.default
     def main(env: str = "prod"):
@@ -93,8 +93,8 @@ def test_auto_alias_on_app_default():
     assert app("-e prod") == "prod"
 
 
-def test_auto_alias_combines_with_default_parameter(app):
-    @app.command(auto_alias=True, default_parameter=Parameter(negative=""))
+def test_short_alias_combines_with_default_parameter(app):
+    @app.command(short_alias=True, default_parameter=Parameter(negative=""))
     def deploy(env: str = "prod", flag: bool = False):
         pass
 
@@ -103,8 +103,8 @@ def test_auto_alias_combines_with_default_parameter(app):
     assert not collection[1].negatives
 
 
-def test_auto_alias_skips_help_flag(app, assert_parse_args):
-    @app.command(auto_alias=True)
+def test_short_alias_skips_help_flag(app, assert_parse_args):
+    @app.command(short_alias=True)
     def connect(host: str = "localhost", port: int = 8080):
         pass
 
@@ -113,8 +113,8 @@ def test_auto_alias_skips_help_flag(app, assert_parse_args):
     assert_parse_args(connect, "connect -H localhost -p 9000", host="localhost", port=9000)
 
 
-def test_auto_alias_uses_help_flag_when_unreserved(app):
-    @app.command(auto_alias=True, help_flags=["--help"])
+def test_short_alias_uses_help_flag_when_unreserved(app):
+    @app.command(short_alias=True, help_flags=["--help"])
     def connect(host: str = "localhost"):
         pass
 
@@ -122,8 +122,8 @@ def test_auto_alias_uses_help_flag_when_unreserved(app):
     assert collection[0].parameter.name == ("--host", "-h")
 
 
-def test_auto_alias_skips_version_flag(app):
-    @app.command(auto_alias=True, version_flags=["-v", "--version"])
+def test_short_alias_skips_version_flag(app):
+    @app.command(short_alias=True, version_flags=["-v", "--version"])
     def main(verbose: bool = False):
         pass
 
@@ -131,7 +131,7 @@ def test_auto_alias_skips_version_flag(app):
     assert collection[0].parameter.name == ("--verbose", "-V")
 
 
-def test_auto_alias_nested_dataclass_top_level_only(app, assert_parse_args):
+def test_short_alias_nested_dataclass_top_level_only(app, assert_parse_args):
     """Containers and their promoted fields get no auto short by default; only top-level scalars do."""
 
     @dataclass
@@ -144,7 +144,7 @@ def test_auto_alias_nested_dataclass_top_level_only(app, assert_parse_args):
         name: str = ""
         color: Color = field(default_factory=Color)
 
-    @app.command(auto_alias=True)
+    @app.command(short_alias=True)
     def foo(*, user: User | None = None, upload: bool = False):
         pass
 
@@ -159,15 +159,15 @@ def test_auto_alias_nested_dataclass_top_level_only(app, assert_parse_args):
     assert_parse_args(foo, "foo -u", upload=True)
 
 
-def test_auto_alias_nested_field_explicit_opt_in(app, assert_parse_args):
+def test_short_alias_nested_field_explicit_opt_in(app, assert_parse_args):
     """A nested leaf field opts in explicitly and surfaces a standalone (not dotted) short."""
 
     @dataclass
     class User:
-        name: Annotated[str, Parameter(auto_alias=True)] = ""
+        name: Annotated[str, Parameter(short_alias=True)] = ""
         color: str = ""
 
-    @app.command(auto_alias=True)
+    @app.command(short_alias=True)
     def foo(*, user: User):
         pass
 
@@ -178,10 +178,10 @@ def test_auto_alias_nested_field_explicit_opt_in(app, assert_parse_args):
     assert_parse_args(foo, "foo -n Bob", user=User(name="Bob"))
 
 
-def test_auto_alias_letter_from_transformed_name(app):
+def test_short_alias_letter_from_transformed_name(app):
     """The short letter follows the transformed long flag, not the raw python identifier."""
 
-    @app.command(auto_alias=True)
+    @app.command(short_alias=True)
     def foo(*, _private: str = "", verbose: bool = False):
         pass
 
@@ -191,10 +191,10 @@ def test_auto_alias_letter_from_transformed_name(app):
     assert names["--verbose"] == ("--verbose", "-v")
 
 
-def test_auto_alias_letter_respects_custom_name_transform(app):
+def test_short_alias_letter_respects_custom_name_transform(app):
     """A custom name_transform drives both the long name and the short letter."""
 
-    @app.command(auto_alias=True, default_parameter=Parameter(name_transform=lambda s: "x" + s))
+    @app.command(short_alias=True, default_parameter=Parameter(name_transform=lambda s: "x" + s))
     def foo(*, my_flag: bool = False):
         pass
 
@@ -202,8 +202,8 @@ def test_auto_alias_letter_respects_custom_name_transform(app):
     assert collection[0].parameter.name == ("--xmy_flag", "-x")
 
 
-def test_auto_alias_help(app, console):
-    @app.command(auto_alias=True)
+def test_short_alias_help(app, console):
+    @app.command(short_alias=True)
     def deploy(env: str = "staging", replicas: int = 10):
         """Deploy."""
 

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -204,6 +204,37 @@ def test_short_alias_nested_field_explicit_opt_in(app, assert_parse_args):
     assert_parse_args(foo, "foo -n Bob", user=User(name="Bob"))
 
 
+def test_short_alias_flattened_fields_get_short(app, assert_parse_args):
+    """Fields flattened to the root namespace via ``name="*"`` get shorts like top-level params.
+
+    They surface as undotted ``--name``/``--email`` flags, so they're treated as
+    root-namespace parameters. A non-flattened container nested *underneath* the
+    flattened one (``--color``) and its dotted leaf (``--color.red``) still get no short.
+    """
+
+    @dataclass
+    class Color:
+        red: int = 0
+
+    @dataclass
+    class User:
+        name: str = ""
+        email: str = ""
+        color: Color = field(default_factory=Color)
+
+    @app.command(short_alias=True)
+    def foo(user: Annotated[User | None, Parameter(name="*")] = None):
+        pass
+
+    collection = app["foo"].assemble_argument_collection()
+    names = {c.parameter.name[0]: c.parameter.name for c in collection}
+    assert names["--name"] == ("--name", "-n")
+    assert names["--email"] == ("--email", "-e")
+    assert names["--color"] == ("--color",)
+    assert names["--color.red"] == ("--color.red",)
+    assert_parse_args(foo, "foo -n Bob -e b@x", user=User(name="Bob", email="b@x"))
+
+
 def test_short_alias_letter_from_transformed_name(app):
     """The short letter follows the transformed long flag, not the raw python identifier."""
 

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -84,6 +84,31 @@ def test_short_alias_assignment():
     assert positional_collection[1].parameter.name == ("--replicas", "-r")
 
 
+def test_short_alias_positional_or_keyword_gets_short(app, assert_parse_args):
+    """Every positional-or-keyword param exposes a ``--long`` form, so it also gets a short.
+
+    Applies to required params and to params preceding a ``*`` (keyword-only) marker.
+    """
+
+    @app.command(short_alias=True)
+    def deploy(env: str, region: str = "us-east-1"):
+        pass
+
+    collection = app["deploy"].assemble_argument_collection()
+    assert collection[0].parameter.name == ("--env", "-e")
+    assert collection[1].parameter.name == ("--region", "-r")
+    assert_parse_args(deploy, "deploy -e prod", env="prod")
+    assert_parse_args(deploy, "deploy prod -r eu", env="prod", region="eu")
+
+    @app.command(short_alias=True)
+    def pre_star(src: str, *, verbose: bool = False):
+        pass
+
+    pre_star_collection = app["pre-star"].assemble_argument_collection()
+    assert pre_star_collection[0].parameter.name == ("--src", "-s")
+    assert pre_star_collection[1].parameter.name == ("--verbose", "-v")
+
+
 def test_short_alias_on_app_default():
     app = App(short_alias=True, result_action="return_value")
 

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -307,6 +307,23 @@ def test_short_alias_callable_can_dedupe_via_used():
     assert collection[1].parameter.name == ("--apex", "-A")
 
 
+def test_short_alias_callable_receives_readonly_frozenset():
+    """The callable is handed a frozenset so it cannot mutate cyclopts' collision state."""
+    seen: list = []
+
+    def cb(field_info, used):
+        seen.append(used)
+        with pytest.raises(AttributeError):
+            used.add("-z")  # frozenset has no .add
+        return None
+
+    def fn(host: str = "", port: int = 0):
+        pass
+
+    ArgumentCollection._from_callable(fn, Parameter(short_alias=cb))
+    assert seen and all(isinstance(u, frozenset) for u in seen)
+
+
 def test_short_alias_callable_collision_deduped():
     """A callable-returned short already claimed by an earlier parameter is dropped (first-wins).
 

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -307,11 +307,11 @@ def test_short_alias_callable_can_dedupe_via_used():
     assert collection[1].parameter.name == ("--apex", "-A")
 
 
-def test_short_alias_callable_collision_not_deduped():
-    """KNOWN LIMITATION: a callable that ignores ``used`` produces duplicate shorts.
+def test_short_alias_callable_collision_deduped():
+    """A callable-returned short already claimed by an earlier parameter is dropped (first-wins).
 
-    Unlike the bool form (lowercase -> uppercase -> drop), cyclopts does not dedupe
-    callable-returned shorts. This locks in the documented current behavior.
+    Even a callable that ignores ``used`` cannot create duplicate flags: ``alpha`` claims
+    ``-a`` and ``beta``'s colliding ``-a`` is silently dropped rather than duplicated.
     """
 
     def fn(alpha: str = "", beta: str = ""):
@@ -319,7 +319,7 @@ def test_short_alias_callable_collision_not_deduped():
 
     collection = ArgumentCollection._from_callable(fn, Parameter(short_alias=lambda fi, used: "-a"))
     assert collection[0].parameter.name == ("--alpha", "-a")
-    assert collection[1].parameter.name == ("--beta", "-a")
+    assert collection[1].parameter.name == ("--beta",)
 
 
 def test_short_alias_propagates_to_subapp_at_runtime():

--- a/tests/test_short_alias.py
+++ b/tests/test_short_alias.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Flag, auto
 from typing import Annotated
 
 import pytest
@@ -213,3 +214,134 @@ def test_short_alias_help(app, console):
     output = capture.get()
     assert "--env -e" in output
     assert "--replicas -r" in output
+
+
+def test_short_alias_rejects_string():
+    """A string is a footgun (looks like an explicit flag); reject it with a clear error."""
+    with pytest.raises(TypeError, match="does not accept a string"):
+        Parameter(short_alias="-z")  # pyright: ignore[reportArgumentType]
+
+
+def test_short_alias_combined_flags(app, assert_parse_args):
+    """Two generated boolean shorts can be combined GNU-style (``-vf``)."""
+    app.default_parameter = Parameter(short_alias=True)
+
+    @app.default
+    def main(*, verbose: bool = False, force: bool = False):
+        pass
+
+    assert_parse_args(main, "-vf", verbose=True, force=True)
+
+
+def test_short_alias_no_negative_for_short(app):
+    """A boolean's short flag does not get a negated form (negatives are long-only)."""
+
+    @app.command(short_alias=True)
+    def main(*, verbose: bool = False):
+        pass
+
+    arg = app["main"].assemble_argument_collection()[0]
+    assert arg.parameter.name == ("--verbose", "-v")
+    assert "--no-verbose" in arg.names
+    assert "--no-v" not in arg.names
+    assert "-no-v" not in arg.names
+
+
+def test_short_alias_enum_flag_gets_short(app):
+    """An enum.Flag binds tokens directly, so it receives a short; its members do not."""
+
+    class Perm(Flag):
+        read = auto()
+        write = auto()
+
+    @app.command(short_alias=True)
+    def main(*, perm: Perm = Perm.read):
+        pass
+
+    names = {c.parameter.name[0]: c.parameter.name for c in app["main"].assemble_argument_collection()}
+    assert names["--perm"] == ("--perm", "-p")
+    assert names["--perm.read"] == ("--perm.read",)
+
+
+def test_short_alias_accepts_keys_false_gets_short(app):
+    """A class with accepts_keys=False consumes tokens directly, so it gets a short."""
+
+    @dataclass
+    class Point:
+        x: int = 0
+        y: int = 0
+
+    @app.command(short_alias=True)
+    def main(*, pt: Annotated[Point, Parameter(accepts_keys=False)]):
+        pass
+
+    assert app["main"].assemble_argument_collection()[0].parameter.name == ("--pt", "-p")
+
+
+def test_short_alias_callable_none_skips():
+    """A callable returning None generates no short for that parameter."""
+
+    def fn(host: str = "", port: int = 0):
+        pass
+
+    collection = ArgumentCollection._from_callable(fn, Parameter(short_alias=lambda fi, used: None))
+    assert collection[0].parameter.name == ("--host",)
+    assert collection[1].parameter.name == ("--port",)
+
+
+def test_short_alias_callable_can_dedupe_via_used():
+    """A well-behaved callable consults ``used`` to avoid collisions."""
+
+    def unique(field_info, used):
+        letter = field_info.names[0][0]
+        for candidate in (f"-{letter}", f"-{letter.upper()}"):
+            if candidate not in used:
+                return candidate
+        return None
+
+    def fn(alpha: str = "", apex: str = ""):
+        pass
+
+    collection = ArgumentCollection._from_callable(fn, Parameter(short_alias=unique))
+    assert collection[0].parameter.name == ("--alpha", "-a")
+    assert collection[1].parameter.name == ("--apex", "-A")
+
+
+def test_short_alias_callable_collision_not_deduped():
+    """KNOWN LIMITATION: a callable that ignores ``used`` produces duplicate shorts.
+
+    Unlike the bool form (lowercase -> uppercase -> drop), cyclopts does not dedupe
+    callable-returned shorts. This locks in the documented current behavior.
+    """
+
+    def fn(alpha: str = "", beta: str = ""):
+        pass
+
+    collection = ArgumentCollection._from_callable(fn, Parameter(short_alias=lambda fi, used: "-a"))
+    assert collection[0].parameter.name == ("--alpha", "-a")
+    assert collection[1].parameter.name == ("--beta", "-a")
+
+
+def test_short_alias_propagates_to_subapp_at_runtime():
+    """``short_alias=True`` on a root app reaches commands registered on a subapp at parse time."""
+    root = App(name="root", short_alias=True, result_action="return_value")
+    sub = App(name="sub")
+    root.command(sub)
+
+    @sub.command
+    def deploy(env: str = "x"):
+        return env
+
+    assert root(["sub", "deploy", "-e", "prod"]) == "prod"
+
+
+def test_short_alias_does_not_affect_env_var(app, assert_parse_args, monkeypatch):
+    """Adding a short flag leaves the canonical-name-derived env var lookup intact."""
+    monkeypatch.setenv("MYAPP_ENV", "from_env")
+
+    @app.default
+    def main(env: Annotated[str, Parameter(env_var="MYAPP_ENV", short_alias=True)] = "default"):
+        pass
+
+    assert app.assemble_argument_collection()[0].parameter.name == ("--env", "-e")
+    assert_parse_args(main, "", env="from_env")


### PR DESCRIPTION
An implementation proposal for https://github.com/BrianPugh/cyclopts/issues/830 - not reviewed yet, but just wanted to elicit comments.

This lets you specify auto_alias=True at either App or Command level - Command overrides App. The auto alias is the first letter of the argument name. If more than 1 arg share the same name, the first one should take precedence. Specific aliases take precedence.

From @BrianPugh 's requests:

* [x] Make linter / static tests pass
* [ ] Align on name
* [ ] Extend Parameter.name and Parameter.alias to allow for a callable that derives names
* [ ] Update docs