### PR TITLE
Fix dropped `Parameter` metadata in nested Annotated/Optional/NewType types

### DIFF
--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -30,6 +30,7 @@ from cyclopts.annotations import (
     is_union,
     resolve,
     resolve_annotated,
+    resolve_new_type,
     resolve_optional,
 )
 from cyclopts.field_info import get_field_infos, signature_parameters
@@ -584,21 +585,25 @@ def get_parameters(hint: T, skip_converter_params: bool = False) -> tuple[T, lis
         List of parameters discovered, ordered by priority (lowest to highest):
         converter-decoration < type-decoration < annotation.
     """
-    hint = resolve_optional(hint)
-
     # Extract parameters from Annotated metadata.
-    # Loop to handle nested Annotated/Optional combinations, e.g.
-    # ``Annotated[cyclopts.types.ResolvedPath | None, Parameter()]`` where the inner
-    # ``ResolvedPath`` is itself an ``Annotated`` carrying a converter. After resolving
-    # the Optional, the hint can become Annotated again, so we keep unwrapping.
+    # Loop to handle nested Annotated/Optional/NewType combinations, e.g.
+    # ``Annotated[cyclopts.types.ResolvedPath | None, Parameter()]`` or a ``NewType``
+    # wrapping ``ResolvedPath`` -- the inner wrapper is itself an ``Annotated`` carrying a
+    # converter/validator that must not be lost. After unwrapping one layer the hint can
+    # become Annotated again, so we keep unwrapping until it stabilizes.
     annotated_params = []
-    while is_annotated(hint):
-        inner = get_args(hint)
-        hint = inner[0]
-        # Prepend so that more deeply nested annotations have lower priority than outer ones.
-        annotated_params[:0] = [x for x in inner[1:] if isinstance(x, Parameter)]
-        # Resolve Optional again after unwrapping Annotated, since hint could be Type | None
+    while True:
+        hint_prev = hint
+        hint = cast(T, resolve_new_type(hint))
         hint = resolve_optional(hint)
+        if is_annotated(hint):
+            inner = get_args(hint)
+            hint = inner[0]
+            # Prepend so that more deeply nested annotations have lower priority than outer ones.
+            annotated_params[:0] = [x for x in inner[1:] if isinstance(x, Parameter)]
+            continue
+        if hint == hint_prev:
+            break
 
     # Extract parameters from type's __cyclopts__ attribute (after unwrapping Annotated)
     type_cyclopts_config_params = []

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -586,12 +586,17 @@ def get_parameters(hint: T, skip_converter_params: bool = False) -> tuple[T, lis
     """
     hint = resolve_optional(hint)
 
-    # Extract parameters from Annotated metadata
+    # Extract parameters from Annotated metadata.
+    # Loop to handle nested Annotated/Optional combinations, e.g.
+    # ``Annotated[cyclopts.types.ResolvedPath | None, Parameter()]`` where the inner
+    # ``ResolvedPath`` is itself an ``Annotated`` carrying a converter. After resolving
+    # the Optional, the hint can become Annotated again, so we keep unwrapping.
     annotated_params = []
-    if is_annotated(hint):
+    while is_annotated(hint):
         inner = get_args(hint)
         hint = inner[0]
-        annotated_params.extend(x for x in inner[1:] if isinstance(x, Parameter))
+        # Prepend so that more deeply nested annotations have lower priority than outer ones.
+        annotated_params[:0] = [x for x in inner[1:] if isinstance(x, Parameter)]
         # Resolve Optional again after unwrapping Annotated, since hint could be Type | None
         hint = resolve_optional(hint)
 

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -580,7 +580,7 @@ def get_parameters(hint: T, skip_converter_params: bool = False) -> tuple[T, lis
     Returns
     -------
     hint
-        Annotation hint with :obj:`Annotated` and :obj:`Optional` resolved.
+        Annotation hint with :obj:`Annotated`, :obj:`Optional`, and :obj:`NewType` resolved.
     list[Parameter]
         List of parameters discovered, ordered by priority (lowest to highest):
         converter-decoration < type-decoration < annotation.

--- a/tests/py312/test_type_alias_parameter.py
+++ b/tests/py312/test_type_alias_parameter.py
@@ -3,11 +3,13 @@
 Regression tests for https://github.com/BrianPugh/cyclopts/issues/669
 """
 
+from pathlib import Path
 from typing import Annotated, Optional
 
 import pytest
 
 from cyclopts import Parameter
+from cyclopts import types as ct
 from cyclopts.annotations import resolve, resolve_annotated, resolve_optional
 
 # Define type aliases using Python 3.12 'type' statement
@@ -16,6 +18,9 @@ type OptionalIntWithAlias = Optional[Annotated[int, Parameter(alias="-f")]]
 type BoolAlias = bool
 type AnnotatedIntWithMetadata = Annotated[int, "metadata"]
 type OptionalInt = Optional[int]
+# A 'type' alias over a cyclopts.types converter type (which is itself Annotated).
+# https://github.com/BrianPugh/cyclopts/issues/836
+type ResolvedPathAlias = ct.ResolvedPath
 
 
 @pytest.mark.parametrize(
@@ -112,3 +117,23 @@ def test_type_alias_in_help(capsys):
     help_text = captured.out
     assert "--foo" in help_text
     assert "-f" in help_text
+
+
+def test_type_alias_over_cyclopts_type_bare(app, assert_parse_args):
+    """A 'type' alias over a cyclopts.types converter type keeps the converter."""
+
+    @app.default
+    def main(foo: ResolvedPathAlias):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_type_alias_over_cyclopts_type_optional(app, assert_parse_args):
+    """A 'type' alias over a cyclopts.types converter type, made optional, keeps the converter."""
+
+    @app.default
+    def main(foo: Annotated[Optional[ResolvedPathAlias], Parameter()]):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())

--- a/tests/types/test_types_nested_annotations.py
+++ b/tests/types/test_types_nested_annotations.py
@@ -1,0 +1,183 @@
+"""Tests that ``cyclopts.types`` converters/validators survive being wrapped in
+additional ``Annotated`` / ``Optional`` / ``NewType`` layers.
+
+Regression tests for https://github.com/BrianPugh/cyclopts/issues/836
+
+The ``cyclopts.types.*`` aliases are themselves ``Annotated[..., Parameter(...)]``.
+Wrapping them again (e.g. ``Annotated[ResolvedPath | None, Parameter()]``) used to
+drop the inner ``Parameter`` -- and with it the converter/validator.
+"""
+
+from pathlib import Path
+from typing import Annotated, NewType, Optional, Union
+
+import pytest
+
+from cyclopts import Parameter
+from cyclopts import types as ct
+from cyclopts.exceptions import ValidationError
+
+
+def test_types_resolved_optional_no_outer_param(app, assert_parse_args):
+    """Converter type inside ``Optional`` with no extra outer ``Parameter``."""
+
+    @app.default
+    def main(foo: ct.ResolvedPath | None):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_resolved_optional_with_outer_param(app, assert_parse_args):
+    """https://github.com/BrianPugh/cyclopts/issues/836 (the original report)."""
+
+    @app.default
+    def main(foo: Annotated[ct.ResolvedPath | None, Parameter()]):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_resolved_optional_typing_optional_spelling(app, assert_parse_args):
+    """``Optional[...]`` spelling behaves the same as ``... | None``."""
+
+    @app.default
+    def main(foo: Annotated[Optional[ct.ResolvedPath], Parameter()]):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_resolved_optional_union_spelling(app, assert_parse_args):
+    """``Union[..., None]`` spelling behaves the same as ``... | None``."""
+
+    @app.default
+    def main(foo: Annotated[Union[ct.ResolvedPath, None], Parameter()]):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_resolved_file_optional_converter_applies(app, assert_parse_args):
+    """``ResolvedFile`` triple-nests (Annotated[Annotated[Annotated[...]]]); converter still fires."""
+
+    @app.default
+    def main(foo: Annotated[ct.ResolvedFile | None, Parameter()]):
+        pass
+
+    assert_parse_args(main, "foo.bin", Path("foo.bin").resolve())
+
+
+def test_types_resolved_file_optional_validator_still_fires(app, tmp_path):
+    """The inner validator (file-only) must not be lost when wrapped/optional."""
+
+    @app.default
+    def main(foo: Annotated[ct.ResolvedFile | None, Parameter()]):
+        pass
+
+    with pytest.raises(ValidationError):
+        app([str(tmp_path)], exit_on_error=False)  # a directory should be rejected
+
+
+def test_types_existing_file_optional_validator_fires(app):
+    """Validator-based type inside ``Annotated[... | None, Parameter()]``."""
+
+    @app.default
+    def main(foo: Annotated[ct.ExistingFile | None, Parameter()]):
+        pass
+
+    with pytest.raises(ValidationError):
+        app(["this-file-does-not-exist"], exit_on_error=False)
+
+
+def test_types_positive_int_optional_validator_fires(app):
+    @app.default
+    def main(foo: Annotated[ct.PositiveInt | None, Parameter()]):
+        pass
+
+    with pytest.raises(ValidationError):
+        app(["-5"], exit_on_error=False)
+
+
+def test_types_positive_int_optional_ok(app, assert_parse_args):
+    @app.default
+    def main(foo: Annotated[ct.PositiveInt | None, Parameter()]):
+        pass
+
+    assert_parse_args(main, "5", 5)
+
+
+def test_types_hexuint_optional_converter_applies(app, assert_parse_args):
+    @app.default
+    def main(foo: Annotated[ct.HexUInt | None, Parameter()]):
+        pass
+
+    assert_parse_args(main, "0xff", 255)
+
+
+def test_types_list_of_optional_resolved(app, assert_parse_args):
+    """Converter applies element-wise through a list of the optional-annotated type."""
+
+    @app.default
+    def main(foo: list[Annotated[ct.ResolvedPath | None, Parameter()]]):
+        pass
+
+    assert_parse_args(main, ["a", "b"], [Path("a").resolve(), Path("b").resolve()])
+
+
+def test_types_double_optional_annotated(app, assert_parse_args):
+    """Doubly-wrapped Optional/Annotated nesting."""
+
+    @app.default
+    def main(foo: Annotated[Annotated[ct.ResolvedPath | None, Parameter()] | None, Parameter()]):
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_outer_converter_overrides_inner(app, assert_parse_args):
+    """An outer ``Parameter(converter=...)`` keeps higher priority than the inner one."""
+
+    @app.default
+    def main(foo: Annotated[ct.ResolvedPath | None, Parameter(converter=lambda type_, tokens: "OVERRIDDEN")]):
+        pass
+
+    assert_parse_args(main, "bar", "OVERRIDDEN")
+
+
+def test_types_newtype_resolved_bare(app, assert_parse_args):
+    """A ``NewType`` over a converter type keeps the converter.
+
+    ``NewType`` over an ``Annotated`` alias is valid at runtime but flagged statically,
+    hence the ``pyright: ignore`` comments.
+    """
+    MyPath = NewType("MyPath", ct.ResolvedPath)  # pyright: ignore[reportGeneralTypeIssues]
+
+    @app.default
+    def main(foo: MyPath):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_newtype_resolved_optional(app, assert_parse_args):
+    """A ``NewType`` over a converter type, made optional, keeps the converter."""
+    MyPath = NewType("MyPath", ct.ResolvedPath)  # pyright: ignore[reportGeneralTypeIssues]
+
+    @app.default
+    def main(foo: Annotated[Optional[MyPath], Parameter()]):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())
+
+
+def test_types_nested_newtype_resolved_optional(app, assert_parse_args):
+    """A ``NewType`` over a ``NewType`` over a converter type, made optional."""
+    MyPath = NewType("MyPath", ct.ResolvedPath)  # pyright: ignore[reportGeneralTypeIssues]
+    DeepPath = NewType("DeepPath", MyPath)  # pyright: ignore[reportGeneralTypeIssues]
+
+    @app.default
+    def main(foo: Annotated[Optional[DeepPath], Parameter()]):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    assert_parse_args(main, "bar", Path("bar").resolve())

--- a/tests/types/test_types_path.py
+++ b/tests/types/test_types_path.py
@@ -171,6 +171,24 @@ def test_types_resolved_file_validation_error(convert, tmp_path):
         convert(ct.ResolvedFile, tmp_path)
 
 
+def test_types_resolved_path_optional_annotated_app(app, assert_parse_args):
+    """A ``cyclopts.types`` annotation wrapped in ``Annotated[... | None, Parameter()]``
+    should still apply its converter.
+
+    https://github.com/BrianPugh/cyclopts/issues/836
+    """
+    from typing import Annotated
+
+    from cyclopts import Parameter
+
+    @app.default
+    def main(foo: Annotated[ct.ResolvedPath | None, Parameter()]):
+        pass
+
+    expected = Path("bar").resolve()
+    assert_parse_args(main, "bar", expected)
+
+
 def test_types_path_resolve_converter(convert, tmp_path):
     """Tests that ``_path_resolve_converter`` handles things like tuples correctly."""
     dir1 = tmp_path / "foo"


### PR DESCRIPTION
Fixes issue #836