### PR TITLE
Add `ArgumentCollection.filter_by(missing=...)` for required/conditionally-required fields.

### DIFF
--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -1297,8 +1297,20 @@ class Argument:
         fully-omitted composite) the checker returns every required child. For multi-branch
         ``Union`` composites, requiredness is branch-aware (see
         :meth:`_active_branch_required_keys`).
+
+        Special case: a *required* multi-branch ``Union`` with no supplied fields hasn't
+        committed to a branch, so :meth:`_active_branch_required_keys` owes nothing — which
+        would leave an interactive prompt loop blind to a value it must collect. Default to
+        the first branch's required fields so the loop converges on (and instantiates) it,
+        matching the declaration-order preference of :meth:`_resolve_union_member`. This
+        read-only query path only; conversion still errors on the composite itself.
         """
         supplied_keys = {child.keys[-1] for child in self.children if child.has_tokens}
+        if self._union_branches and self.required and not supplied_keys:
+            first_branch_required = {k for k, v in self._union_branches[0][1].items() if v.required}
+            return [
+                child for child in self.children if not child.has_tokens and child.keys[-1] in first_branch_required
+            ]
         active_required = self._active_branch_required_keys(supplied_keys)
         if active_required is not None:
             return [child for child in self.children if not child.has_tokens and child.keys[-1] in active_required]

--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -22,6 +22,7 @@ from cyclopts.annotations import (
     ITERABLE_TYPES,
     contains_hint,
     get_annotated_discriminator,
+    get_hint_name,
     is_attrs,
     is_dataclass,
     is_enum_flag,
@@ -166,6 +167,15 @@ class Argument:
 
     _enum_flag_type: Any | None = field(default=None, init=False, repr=False)
 
+    _union_branches: "list[tuple[Any, dict[str, FieldInfo]]]" = field(factory=list, init=False, repr=False)
+    """Per-branch ``(member_type, field_infos)`` when :attr:`hint` is a ``Union`` of 2+ keyword-accepting types.
+
+    Empty for non-unions and single-composite optionals (e.g. ``Foo | None``). Drives
+    branch-aware required-field detection so that supplying one ``Union`` member's fields
+    doesn't demand another member's required fields, and selects the member to instantiate.
+    See :meth:`_active_branch_required_keys` and :meth:`_resolve_union_member`.
+    """
+
     def __attrs_post_init__(self):
         from cyclopts.argument._collection import ArgumentCollection
 
@@ -267,6 +277,18 @@ class Argument:
                     self._default = field_info.annotation
                 else:
                     self._update_lookup({field_info.name: field_info})
+
+        if self._accepts_keywords and len(hints) > 1:
+            # Genuine multi-branch ``Union`` of keyword-accepting types (not ``Foo | None``,
+            # whose only composite branch collapses to a single dict). Record each branch's
+            # type and fields so requiredness can be evaluated per-branch at conversion time.
+            branches = [(member, fis) for member in hints if (fis := get_field_infos(member))]
+            if len(branches) > 1:
+                self._union_branches = branches
+                # The generic checker would introspect the ``typing.Union`` alias itself
+                # (yielding phantom fields like ``origin``); branch-aware gating in
+                # :meth:`_convert` supersedes it.
+                self._missing_keys_checker = None
 
     def _update_lookup(self, field_infos: dict[str, FieldInfo]):
         from typing import Literal
@@ -782,11 +804,16 @@ class Argument:
                 if positional_tokens:
                     return safe_converter(self.hint, tuple(positional_tokens))
 
+            supplied_keys = {child.keys[-1] for child in self.children if child.has_tokens}
+            active_required = self._active_branch_required_keys(supplied_keys)
             for child in self.children:
                 assert len(child.keys) == (len(self.keys) + 1)
+                # For multi-branch unions, requiredness is decided per active branch rather
+                # than by the (cross-branch, over-counting) static ``child.required``.
+                child_required = child.keys[-1] in active_required if active_required is not None else child.required
                 if child.has_tokens:
                     data[child.keys[-1]] = child.convert_and_validate(converter=converter)
-                elif child.required:
+                elif child_required:
                     obj = data
                     for k in child.keys:
                         try:
@@ -794,6 +821,13 @@ class Argument:
                         except Exception:
                             raise MissingArgumentError(argument=child) from None
                     child._marked = True
+                elif active_required is not None:
+                    # Inactive-branch leaf of a multi-branch union: the parent owns the whole
+                    # subtree, so mark it (and descendants) handled to stop the collection loop
+                    # from converting it standalone and raising on its static ``required``.
+                    child._marked = True
+                    for descendant in child.children_recursive:
+                        descendant._marked = True
 
             self._run_missing_keys_checker(data)
 
@@ -802,7 +836,20 @@ class Argument:
                 if not out:
                     out = UNSET
             elif data:
-                out = instantiate_from_dict(self.hint, data)
+                target_hint = self.hint
+                if self._union_branches:
+                    # ``instantiate_from_dict`` cannot build a bare ``Union``; pick the branch
+                    # whose fields accept the supplied data.
+                    member = self._resolve_union_member(set(data))
+                    if member is None:
+                        # Supplied fields span multiple branches / match no single one.
+                        raise CoercionError(
+                            msg=f"Cannot determine which {get_hint_name(self.hint)} variant the supplied fields belong to.",
+                            argument=self,
+                            target_type=self.hint,
+                        )
+                    target_hint = member
+                out = instantiate_from_dict(target_hint, data)
             elif self.required:
                 raise MissingArgumentError(argument=self)  # pragma: no cover
             else:
@@ -1189,14 +1236,73 @@ class Argument:
             out.append((keys, matched[0] if matched else None))
         return out
 
+    def _union_candidate_branches(self, supplied_keys: "set[str]") -> "list[tuple[Any, set[str]]]":
+        """Branches that can fully account for ``supplied_keys`` (i.e. ``supplied ⊆ branch``).
+
+        These are the ``Union`` members the user could be completing; a branch that doesn't
+        contain every supplied field can't be the intended one. Yields ``(member, required_keys)``
+        — the only branch information either caller needs. Returns ``[]`` when the supplied
+        fields span multiple branches (over-supplied / ambiguous input) or when this is not a
+        multi-branch ``Union``. In declaration order.
+        """
+        return [
+            (member, {k for k, v in fis.items() if v.required})
+            for member, fis in self._union_branches
+            if supplied_keys <= set(fis)
+        ]
+
+    def _active_branch_required_keys(self, supplied_keys: "set[str]") -> "set[str] | None":
+        """Required child keys still owed by the chosen branch of a multi-branch ``Union``.
+
+        Picks among the candidate branches (see :meth:`_union_candidate_branches`): if any is
+        already fully satisfied, nothing is owed (``set()``); otherwise the candidate closest
+        to completion (fewest missing required fields, ties broken by declaration order) guides
+        which fields are still required. This convergent guidance means the prompt loop fills
+        the same branch that :meth:`_resolve_union_member` later instantiates. Supplying one
+        ``Union`` member's fields never demands a sibling member's
+        required fields. Returns ``None`` when :attr:`hint` is not a multi-branch ``Union``
+        (caller falls back to the static :attr:`Argument.required` per child).
+        """
+        if not self._union_branches:
+            return None
+        if not supplied_keys:
+            # Nothing supplied: the user hasn't committed to a branch, so don't demand any
+            # particular one. Total omission is handled by the composite-level required check.
+            return set()
+        candidates = self._union_candidate_branches(supplied_keys)
+        if not candidates:  # ambiguous/over-supplied: owe nothing, let instantiation error cleanly
+            return set()
+        required_per_candidate = [required for _, required in candidates]
+        if any(required <= supplied_keys for required in required_per_candidate):
+            return set()  # a complete branch exists
+        return min(required_per_candidate, key=lambda required: len(required - supplied_keys))
+
+    def _resolve_union_member(self, data_keys: "set[str]"):
+        """The ``Union`` member to instantiate given the converted ``data_keys``.
+
+        Picks the first candidate branch (``data ⊆ branch``) whose required fields are all
+        present, since :func:`instantiate_from_dict` cannot instantiate a bare ``Union``.
+        Returns ``None`` if no branch is satisfied (caller raises a clean error).
+        """
+        for member, required in self._union_candidate_branches(data_keys):
+            if required <= data_keys:
+                return member
+        return None
+
     def _missing_children(self) -> "list[Argument]":
         """Direct child arguments the checker reports as required-and-absent (non-raising).
 
         Builds the provided-key set from token presence rather than converted values, so it
         can be called before/without conversion. When no child currently has a token (a
-        fully-omitted composite) the checker returns every required child.
+        fully-omitted composite) the checker returns every required child. For multi-branch
+        ``Union`` composites, requiredness is branch-aware (see
+        :meth:`_active_branch_required_keys`).
         """
-        data = {child.keys[-1]: None for child in self.children if child.has_tokens}
+        supplied_keys = {child.keys[-1] for child in self.children if child.has_tokens}
+        active_required = self._active_branch_required_keys(supplied_keys)
+        if active_required is not None:
+            return [child for child in self.children if not child.has_tokens and child.keys[-1] in active_required]
+        data = dict.fromkeys(supplied_keys)
         return [argument for _, argument in self._resolve_missing_keys(data) if argument is not None]
 
     def _run_missing_keys_checker(self, data):

--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -1170,17 +1170,41 @@ class Argument:
                 out[keys[0]] = token.value if token.implicit_value is UNSET else token.implicit_value
         return out
 
+    def _resolve_missing_keys(self, data) -> "list[tuple[tuple[str, ...], Argument | None]]":
+        """Map each required-but-absent key reported by the checker to its child ``Argument``.
+
+        Non-raising core shared by :meth:`_run_missing_keys_checker` (the conversion-time
+        error path) and :meth:`_missing_children` (the read-only query path). The checker
+        only inspects ``set(data)`` — the keys — so the values in ``data`` are irrelevant.
+
+        Returns a list of ``(full_keys, argument)`` pairs in checker order; ``argument`` is
+        ``None`` for a required key that maps to no Cyclopts-accessible child.
+        """
+        if not self._missing_keys_checker:
+            return []
+        out = []
+        for key in self._missing_keys_checker(self, data):
+            keys = self.keys + (key,)
+            matched = self.children.filter_by(keys_prefix=keys)
+            out.append((keys, matched[0] if matched else None))
+        return out
+
+    def _missing_children(self) -> "list[Argument]":
+        """Direct child arguments the checker reports as required-and-absent (non-raising).
+
+        Builds the provided-key set from token presence rather than converted values, so it
+        can be called before/without conversion. When no child currently has a token (a
+        fully-omitted composite) the checker returns every required child.
+        """
+        data = {child.keys[-1]: None for child in self.children if child.has_tokens}
+        return [argument for _, argument in self._resolve_missing_keys(data) if argument is not None]
+
     def _run_missing_keys_checker(self, data):
         if not self._missing_keys_checker or (not self.required and not data):
             return
-        if not (missing_keys := self._missing_keys_checker(self, data)):
-            return
-        missing_key = missing_keys[0]
-        keys = self.keys + (missing_key,)
-        missing_arguments = self.children.filter_by(keys_prefix=keys)
-        if missing_arguments:
-            raise MissingArgumentError(argument=missing_arguments[0])
-        else:
+        for keys, argument in self._resolve_missing_keys(data):
+            if argument is not None:
+                raise MissingArgumentError(argument=argument)
             missing_description = self.field_info.names[0] + "->" + "->".join(keys)
             raise ValueError(
                 f'Required field "{missing_description}" is not accessible by Cyclopts; possibly due to conflicting POSITIONAL/KEYWORD requirements.'

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -549,7 +549,7 @@ class ArgumentCollection(list[Argument]):
         if has_tokens is not None:
             ac = cls(x for x in ac if not (bool(x.tokens) ^ bool(has_tokens)))
         if has_tree_tokens is not None:
-            ac = cls(x for x in ac if not (bool(x.tokens) ^ bool(has_tree_tokens)))
+            ac = cls(x for x in ac if not (bool(x.has_tokens) ^ bool(has_tree_tokens)))
         if keys_prefix is not None:
             ac = cls(x for x in ac if x.keys[: len(keys_prefix)] == keys_prefix)
         if show is not None:

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -522,7 +522,10 @@ class ArgumentCollection(list[Argument]):
         out = cls()
 
         def expand_required(argument: Argument) -> None:
-            # ``argument`` is known to be required and currently has no tokens.
+            # ``argument`` is known to be required and currently has no tokens. Append it
+            # (if it's a parseable leaf) or recurse into each of its required children.
+            # Requiredness is established by the caller/checker, *not* re-derived from the
+            # static ``argument.required`` — conditionally-required leaves have it ``False``.
             if not argument.children:
                 if argument.parse:
                     out.append(argument)
@@ -531,20 +534,18 @@ class ArgumentCollection(list[Argument]):
                 expand_required(child)
 
         def walk(argument: Argument) -> None:
-            if not argument.children:  # leaf
-                if argument.parse and argument.required and not argument.has_tokens:
-                    out.append(argument)
-                return
-            if argument.has_tokens:  # activated composite
-                missing_ids = {id(a) for a in argument._missing_children()}
+            if argument.has_tokens:
+                if not argument.children:  # leaf already satisfied
+                    return
+                missing_ids = {id(a) for a in argument._missing_children()}  # activated composite
                 for child in argument.children:
                     if child.has_tokens:
                         walk(child)  # recurse into (possibly nested) partial fills
                     elif id(child) in missing_ids:
                         expand_required(child)
-            elif argument.required:  # fully-omitted required composite
+            elif argument.required:  # fully-omitted required leaf or composite
                 expand_required(argument)
-            # optional composite with no tokens: contributes nothing
+            # optional, no tokens: contributes nothing
 
         for argument in self._root_arguments:
             walk(argument)
@@ -601,7 +602,7 @@ class ArgumentCollection(list[Argument]):
         if has_tokens is not None:
             ac = cls(x for x in ac if not (bool(x.tokens) ^ bool(has_tokens)))
         if has_tree_tokens is not None:
-            ac = cls(x for x in ac if not (bool(x.has_tokens) ^ bool(has_tree_tokens)))
+            ac = cls(x for x in ac if not (x.has_tokens ^ bool(has_tree_tokens)))
         if keys_prefix is not None:
             ac = cls(x for x in ac if x.keys[: len(keys_prefix)] == keys_prefix)
         if show is not None:

--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -506,6 +506,50 @@ class ArgumentCollection(list[Argument]):
     def _max_index(self) -> int | None:
         return max((x.index for x in self if x.index is not None), default=None)
 
+    def _missing(self) -> "ArgumentCollection":
+        """Leaf arguments still needing a value, given what's been parsed.
+
+        Tree-aware counterpart to the static :attr:`Argument.required`. Includes
+        conditionally-required fields of composites that have been *partially* supplied
+        (e.g. ``--end`` when only ``--start`` was given) by delegating to each composite's
+        own missing-keys checker — so it is correct for dataclasses, pydantic, attrs and
+        TypedDicts alike. A *required* composite that received no tokens contributes all of
+        its required leaves; an *optional* one contributes nothing.
+
+        Returns leaf arguments in declaration order. Read-only: nothing is converted.
+        """
+        cls = type(self)
+        out = cls()
+
+        def expand_required(argument: Argument) -> None:
+            # ``argument`` is known to be required and currently has no tokens.
+            if not argument.children:
+                if argument.parse:
+                    out.append(argument)
+                return
+            for child in argument._missing_children():  # empty data -> every required child
+                expand_required(child)
+
+        def walk(argument: Argument) -> None:
+            if not argument.children:  # leaf
+                if argument.parse and argument.required and not argument.has_tokens:
+                    out.append(argument)
+                return
+            if argument.has_tokens:  # activated composite
+                missing_ids = {id(a) for a in argument._missing_children()}
+                for child in argument.children:
+                    if child.has_tokens:
+                        walk(child)  # recurse into (possibly nested) partial fills
+                    elif id(child) in missing_ids:
+                        expand_required(child)
+            elif argument.required:  # fully-omitted required composite
+                expand_required(argument)
+            # optional composite with no tokens: contributes nothing
+
+        for argument in self._root_arguments:
+            walk(argument)
+        return out
+
     def filter_by(
         self,
         *,
@@ -514,6 +558,7 @@ class ArgumentCollection(list[Argument]):
         has_tree_tokens: bool | None = None,
         keys_prefix: tuple[str, ...] | None = None,
         kind: inspect._ParameterKind | None = None,
+        missing: bool | None = None,
         parse: bool | None = None,
         show: bool | None = None,
         value_set: bool | None = None,
@@ -532,6 +577,10 @@ class ArgumentCollection(list[Argument]):
             :class:`Argument` and/or it's children have parsed tokens.
         kind: inspect._ParameterKind | None
             The :attr:`~inspect.Parameter.kind` of the argument.
+        missing: bool | None
+            The leaf :class:`Argument` still needs a value given what's been parsed,
+            accounting for conditionally-required fields of partially-supplied composites.
+            See :meth:`_missing`. ``False`` selects the complement.
         parse: bool | None
             If the argument is intended to be parsed or not.
         show: bool | None
@@ -542,6 +591,9 @@ class ArgumentCollection(list[Argument]):
         ac = self.copy()
         cls = type(self)
 
+        if missing is not None:
+            missing_ids = {id(x) for x in self._missing()}
+            ac = cls(x for x in ac if not ((id(x) in missing_ids) ^ bool(missing)))
         if group is not None:
             ac = cls(x for x in ac if group in x.parameter.group)  # pyright: ignore
         if kind is not None:

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -683,8 +683,31 @@ def test_filter_by_missing_multi_branch_union_active_branch():
     assert _names(collection.filter_by(missing=True)) == ["--time-period.end"]
 
 
-def test_filter_by_missing_multi_branch_union_untouched():
-    """A fully-omitted Union composite can't pick a branch, so it reports nothing."""
+def test_filter_by_missing_multi_branch_union_untouched_required():
+    """A fully-omitted *required* Union defaults to the first branch so a prompt loop can fill it.
+
+    Only the first branch's *required* fields are reported; its optional field (``step``) is not.
+    """
+
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+        step: int = 1
+
+    @dataclass
+    class Live:
+        live: bool
+
+    def cli(*, time_period: Union[TimeRange, Live]):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    assert _names(collection.filter_by(missing=True)) == ["--time-period.start", "--time-period.end"]
+
+
+def test_filter_by_missing_multi_branch_union_untouched_optional():
+    """A fully-omitted *optional* Union uses its default, so it reports nothing."""
 
     @dataclass
     class TimeRange:
@@ -695,7 +718,7 @@ def test_filter_by_missing_multi_branch_union_untouched():
     class Live:
         live: bool
 
-    def cli(*, time_period: Union[TimeRange, Live]):
+    def cli(*, time_period: Optional[Union[TimeRange, Live]] = None):
         pass
 
     collection = ArgumentCollection._from_callable(cli)

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -1,4 +1,6 @@
+import inspect
 from collections import namedtuple
+from dataclasses import dataclass
 from typing import Annotated, Dict, Optional, TypedDict, Union  # noqa: UP035
 
 import pytest
@@ -441,6 +443,217 @@ def test_argument_collection_filter_by_has_tree_tokens():
 
     # ``has_tokens`` (immediate) must NOT match the root.
     assert root not in collection.filter_by(has_tokens=True)
+
+
+def _names(collection):
+    return [argument.name for argument in collection]
+
+
+def test_filter_by_missing_simple_leaf():
+    def foo(a: int, b: int = 5):
+        pass
+
+    collection = ArgumentCollection._from_callable(foo)
+    # Nothing supplied: required ``a`` is missing, defaulted ``b`` is not.
+    assert _names(collection.filter_by(missing=True)) == ["--a"]
+
+    collection["--a"].append(Token(value="1", source="test"))
+    assert _names(collection.filter_by(missing=True)) == []
+
+
+def test_filter_by_missing_partial_composite():
+    """The headline case: a partially-supplied optional composite reports its absent field."""
+
+    @Parameter(name="*")
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    def cli(data_source: str, /, *, time_range: Optional[TimeRange] = None):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--start"].append(Token(keyword="--start", value="1", source="test"))
+
+    assert _names(collection.filter_by(missing=True)) == ["DATA_SOURCE", "--end"]
+
+
+def test_filter_by_missing_optional_composite_untouched():
+    @Parameter(name="*")
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    def cli(data_source: str, /, *, time_range: Optional[TimeRange] = None):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    # Untouched optional composite contributes nothing.
+    assert _names(collection.filter_by(missing=True)) == ["DATA_SOURCE"]
+
+
+def test_filter_by_missing_required_composite_omitted():
+    @Parameter(name="*")
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    def cli(*, time_range: TimeRange):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    # Fully-omitted *required* composite surfaces all of its required leaves.
+    assert _names(collection.filter_by(missing=True)) == ["--start", "--end"]
+
+
+def test_filter_by_missing_defaulted_subfield_excluded():
+    @Parameter(name="*")
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int = 5
+
+    def cli(*, time_range: Optional[TimeRange] = None):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--start"].append(Token(keyword="--start", value="1", source="test"))
+    # ``end`` has a default, so it is not missing.
+    assert _names(collection.filter_by(missing=True)) == []
+
+
+def test_filter_by_missing_nested_composite():
+    @dataclass
+    class Inner:
+        a: int
+        b: int
+
+    @dataclass
+    class Outer:
+        inner: Inner
+        name: str
+
+    def cli(o: Outer):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--o.inner.a"].append(Token(value="1", source="test"))
+    # Recurses into the activated inner composite to find ``b``.
+    assert _names(collection.filter_by(missing=True)) == ["--o.inner.b", "--o.name"]
+
+
+def test_filter_by_missing_typeddict():
+    class Inner(TypedDict):
+        x: int
+        y: int
+
+    def cli(d: Inner):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--d.x"].append(Token(value="1", source="test"))
+    assert _names(collection.filter_by(missing=True)) == ["--d.y"]
+
+
+def test_filter_by_missing_pydantic():
+    import pydantic
+
+    @Parameter(name="*")
+    class TimeRange(pydantic.BaseModel):
+        start: int
+        end: int
+
+    def cli(*, time_range: Optional[TimeRange] = None):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--start"].append(Token(keyword="--start", value="1", source="test"))
+    assert _names(collection.filter_by(missing=True)) == ["--end"]
+
+
+def test_filter_by_missing_attrs():
+    import attrs
+
+    @Parameter(name="*")
+    @attrs.define
+    class TimeRange:
+        start: int
+        end: int
+
+    def cli(*, time_range: Optional[TimeRange] = None):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--start"].append(Token(keyword="--start", value="1", source="test"))
+    assert _names(collection.filter_by(missing=True)) == ["--end"]
+
+
+def test_filter_by_missing_false_is_complement():
+    def foo(a: int, b: int = 5):
+        pass
+
+    collection = ArgumentCollection._from_callable(foo)
+    missing = collection.filter_by(missing=True)
+    not_missing = collection.filter_by(missing=False)
+    assert _names(missing) == ["--a"]
+    assert _names(not_missing) == ["--b"]
+
+
+def test_filter_by_missing_composes_with_other_filters():
+    @Parameter(name="*")
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    def cli(data_source: str, /, *, time_range: Optional[TimeRange] = None):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--start"].append(Token(keyword="--start", value="1", source="test"))
+    # ``missing`` intersects with the other (AND) filters.
+    result = collection.filter_by(missing=True, kind=inspect.Parameter.KEYWORD_ONLY)
+    assert _names(result) == ["--end"]
+
+
+def test_filter_by_missing_end_to_end_prompt():
+    """The ``while`` recipe from the docs, driven by an activated-on-CLI composite.
+
+    ``--start`` on the CLI activates the optional composite, so ``--end`` becomes a
+    conditionally-required missing field that the static ``Argument.required`` can't see.
+    """
+    from cyclopts import App
+
+    @Parameter(name="*")
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    answers = iter(["my_source", "2"])
+
+    def prompt_for_missing(app, commands, arguments):
+        prompted = []
+        while missing := arguments.filter_by(missing=True):
+            argument = missing[0]
+            prompted.append(argument.name)
+            argument.tokens.append(Token(keyword=argument.name, value=next(answers), source="interactive"))
+        assert prompted == ["DATA_SOURCE", "--end"]
+
+    app = App(name="cli", config=prompt_for_missing, result_action="return_value")
+
+    captured = {}
+
+    @app.command
+    def run(data_source: str, /, *, time_range: Optional[TimeRange] = None):
+        captured["data_source"] = data_source
+        captured["time_range"] = time_range
+
+    app(["run", "--start", "1"], exit_on_error=False)
+    assert captured == {"data_source": "my_source", "time_range": TimeRange(start=1, end=2)}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -656,6 +656,52 @@ def test_filter_by_missing_end_to_end_prompt():
     assert captured == {"data_source": "my_source", "time_range": TimeRange(start=1, end=2)}
 
 
+def test_filter_by_missing_multi_branch_union_active_branch():
+    """Supplying one Union member's field must not mark a sibling member's fields missing."""
+
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    @dataclass
+    class Live:
+        live: bool
+
+    def cli(*, time_period: Union[TimeRange, Live]):
+        pass
+
+    # Activate the ``Live`` branch -> nothing missing (it's fully supplied).
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--time-period.live"].append(Token(value="true", source="test"))
+    assert _names(collection.filter_by(missing=True)) == []
+
+    # Activate the ``TimeRange`` branch with only ``start`` -> only ``end`` is missing,
+    # *not* the ``Live`` branch's ``live``.
+    collection = ArgumentCollection._from_callable(cli)
+    collection["--time-period.start"].append(Token(value="1", source="test"))
+    assert _names(collection.filter_by(missing=True)) == ["--time-period.end"]
+
+
+def test_filter_by_missing_multi_branch_union_untouched():
+    """A fully-omitted Union composite can't pick a branch, so it reports nothing."""
+
+    @dataclass
+    class TimeRange:
+        start: int
+        end: int
+
+    @dataclass
+    class Live:
+        live: bool
+
+    def cli(*, time_period: Union[TimeRange, Live]):
+        pass
+
+    collection = ArgumentCollection._from_callable(cli)
+    assert _names(collection.filter_by(missing=True)) == []
+
+
 @pytest.mark.parametrize(
     "args, expected",
     [

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -412,6 +412,37 @@ def test_argument_collection_var_keyword_match():
     assert argument.field_info.name == "b"
 
 
+def test_argument_collection_filter_by_has_tree_tokens():
+    """``has_tree_tokens`` must be tree-aware, unlike ``has_tokens``.
+
+    A composite whose only tokens live on a child must be matched by
+    ``has_tree_tokens=True`` even though it has no immediate tokens of its own.
+    """
+
+    class Inner(TypedDict):
+        fizz: float
+        buzz: int
+
+    def foo(a: Inner):
+        pass
+
+    collection = ArgumentCollection._from_callable(foo)
+
+    leaf = collection["--a.fizz"]
+    leaf.append(Token(value="1.5", source="test"))
+
+    root = collection["--a"]
+    assert not root.tokens  # no immediate tokens
+    assert root.has_tokens  # but tree-aware: a child has a token
+
+    has_tree_tokens = collection.filter_by(has_tree_tokens=True)
+    assert root in has_tree_tokens
+    assert leaf in has_tree_tokens
+
+    # ``has_tokens`` (immediate) must NOT match the root.
+    assert root not in collection.filter_by(has_tokens=True)
+
+
 @pytest.mark.parametrize(
     "args, expected",
     [

--- a/tests/test_bind_union.py
+++ b/tests/test_bind_union.py
@@ -1,11 +1,12 @@
+from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
-from typing import Annotated
+from typing import Annotated, Union
 
 import pytest
 
 from cyclopts import Parameter
-from cyclopts.exceptions import CoercionError
+from cyclopts.exceptions import CoercionError, MissingArgumentError
 
 
 @pytest.mark.parametrize(
@@ -93,3 +94,111 @@ def test_union_of_list_types_optional(app, cmd_str, expected, assert_parse_args)
         pass
 
     assert_parse_args(foo, cmd_str, expected)
+
+
+@dataclass
+class _TimeRange:
+    start: int
+    end: int
+
+
+@dataclass
+class _Live:
+    live: Annotated[bool, Parameter(negative=())]
+
+
+def test_union_of_dataclasses_branch_selection(app, assert_parse_args):
+    """A ``Union`` of keyword-accepting types instantiates the branch matching supplied fields.
+
+    Each branch's requiredness is evaluated independently, so supplying one member's fields
+    does not demand a sibling member's required fields (issue #839 follow-up / PR #840).
+    """
+
+    @app.command
+    def cli(*, time_period: Union[_TimeRange, _Live]):
+        pass
+
+    # ``_Live`` branch: ``start``/``end`` from ``_TimeRange`` are not demanded.
+    assert_parse_args(cli, "cli --time-period.live", time_period=_Live(live=True))
+    # ``_TimeRange`` branch: ``live`` from ``_Live`` is not demanded.
+    assert_parse_args(
+        cli,
+        "cli --time-period.start 1 --time-period.end 2",
+        time_period=_TimeRange(start=1, end=2),
+    )
+
+
+def test_union_of_dataclasses_missing_active_branch_field(app):
+    """A partially-supplied branch still reports its own missing required field."""
+
+    @app.command
+    def cli(*, time_period: Union[_TimeRange, _Live]):
+        pass
+
+    with pytest.raises(MissingArgumentError) as e:
+        app.parse_args("cli --time-period.start 1", print_error=False, exit_on_error=False)
+    assert e.value.argument is not None
+    assert e.value.argument.name == "--time-period.end"
+
+
+@dataclass
+class _Cat:
+    kind: str
+    meow: int
+
+
+@dataclass
+class _Dog:
+    kind: str
+    bark: int
+
+
+def test_union_of_dataclasses_overlapping_fields(app, assert_parse_args):
+    """Branches sharing a field name resolve by which branch fully accounts for the input."""
+
+    @app.command
+    def cli(*, pet: Union[_Cat, _Dog]):
+        pass
+
+    assert_parse_args(cli, "cli --pet.kind x --pet.bark 2", pet=_Dog(kind="x", bark=2))
+    assert_parse_args(cli, "cli --pet.kind x --pet.meow 5", pet=_Cat(kind="x", meow=5))
+
+
+@dataclass
+class _Small:
+    a: int
+
+
+@dataclass
+class _Big:
+    a: int
+    b: int
+
+
+@pytest.mark.parametrize("hint", [Union[_Small, _Big], Union[_Big, _Small]])
+def test_union_of_dataclasses_subset_branch_reachable(app, assert_parse_args, hint):
+    """A branch whose fields are a subset of another's is still selectable (order-independent)."""
+
+    @app.command
+    def cli(*, x: hint):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    # Only the subset branch's field -> the subset branch.
+    assert_parse_args(cli, "cli --x.a 1", x=_Small(a=1))
+    # Both fields -> the superset branch.
+    assert_parse_args(cli, "cli --x.a 1 --x.b 2", x=_Big(a=1, b=2))
+
+
+def test_union_of_dataclasses_ambiguous_fields_error(app):
+    """Supplying fields spanning multiple branches yields a clean CoercionError, not a TypeError."""
+
+    @app.command
+    def cli(*, time_period: Union[_TimeRange, _Live]):
+        pass
+
+    with pytest.raises(CoercionError):
+        app.parse_args(
+            "cli --time-period.start 1 --time-period.end 2 --time-period.live 3",
+            print_error=False,
+            exit_on_error=False,
+        )


### PR DESCRIPTION
Simplifies #839 demo to:

```python
import questionary
from dataclasses import dataclass
from datetime import datetime
from cyclopts import App, Parameter, Token
from cyclopts.argument import ArgumentCollection

def prompt_for_missing(app: App, commands: tuple[str, ...], arguments: ArgumentCollection):
    while missing := arguments.filter_by(missing=True):  # re-evaluates after each answer
        argument = missing[0]
        answer = questionary.text(f"{argument.name} ({argument.hint}):").ask()
        if answer is None:  # user hit Ctrl-C
            raise SystemExit(1)
        argument.tokens.append(Token(keyword=argument.name, value=answer, source="interactive"))

@Parameter(name="*")
@dataclass
class TimeRange:
    start: datetime
    end: datetime

app = App(config=prompt_for_missing)

@app.command
def cli(data_source: str, /, *, time_range: TimeRange | None = None):
    print(f"data_source={data_source!r} time_range={time_range!r}")

app()
```