### PR TITLE
Add `cyclopts tree` command and `App.command_tree()`

### DIFF
--- a/cyclopts/cli/__init__.py
+++ b/cyclopts/cli/__init__.py
@@ -11,11 +11,9 @@ app.register_install_completion_command(
 )
 
 
-# Explicitly import command modules
-from cyclopts.cli import (
-    _complete,  # noqa: F401
-    docs,  # noqa: F401
-    run,  # noqa: F401
-)
+from cyclopts.cli import _complete as _complete
+from cyclopts.cli import docs as docs
+from cyclopts.cli import run as run
+from cyclopts.cli import tree as tree
 
 __all__ = ["app"]

--- a/cyclopts/cli/tree.py
+++ b/cyclopts/cli/tree.py
@@ -1,0 +1,34 @@
+"""Display a tree of a Cyclopts application's commands."""
+
+from typing import Annotated
+
+from rich.console import Console
+
+from cyclopts.cli import app
+from cyclopts.loader import load_app_from_script
+from cyclopts.parameter import Parameter
+
+
+@app.command
+def tree(
+    script: str,
+    /,
+    *,
+    description: Annotated[bool, Parameter(alias="-d")] = True,
+    max_depth: Annotated[int | None, Parameter(alias="-m")] = None,
+):
+    """Display a tree of a Cyclopts application's commands.
+
+    Parameters
+    ----------
+    script : str
+        Python script path, optionally with ``':app_object'`` notation to specify
+        the App object. If not specified, will search for App objects in the
+        script's global namespace.
+    description : bool
+        Show each command's short description next to its name.
+    max_depth : Optional[int]
+        Maximum subcommand depth to display. ``None`` (default) shows all.
+    """
+    app_obj, _ = load_app_from_script(script)
+    Console().print(app_obj.command_tree(description=description, max_depth=max_depth))

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2443,7 +2443,9 @@ class App:
         def build(node, subapp: "App", depth: int) -> None:
             if max_depth is not None and depth > max_depth:
                 return
-            for name, child in iterate_commands(subapp, include_hidden=include_hidden):
+            # resolve_lazy=True so the tree shows the complete hierarchy; lazy
+            # commands left unresolved would be silently omitted entirely.
+            for name, child in iterate_commands(subapp, include_hidden=include_hidden, resolve_lazy=True):
                 branch = node.add(node_label(name, child))
                 build(branch, child, depth + 1)
 

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -69,6 +69,7 @@ with suppress(ImportError):
 
 if TYPE_CHECKING:
     from rich.console import Console
+    from rich.tree import Tree
 
     from cyclopts.docs.types import DocFormat
     from cyclopts.help import HelpPanel
@@ -2381,6 +2382,74 @@ class App:
             )
 
         return doc
+
+    def command_tree(
+        self,
+        *,
+        description: bool = True,
+        include_hidden: bool = False,
+        max_depth: int | None = None,
+    ) -> "Tree":
+        """Build a :class:`rich.tree.Tree` of this application's command hierarchy.
+
+        The returned tree is a Rich renderable; print it with
+        ``console.print(app.command_tree())`` or embed it within other Rich
+        output. Hidden commands and built-in help/version flags are excluded by
+        default.
+
+        Parameters
+        ----------
+        description : bool
+            Show each command's short description (from its docstring) next to
+            its name. Default is True.
+        include_hidden : bool
+            Include hidden commands (``show=False``). Default is False.
+        max_depth : int | None
+            Maximum subcommand depth to display. ``None`` (default) shows all
+            levels; ``1`` shows only top-level commands.
+
+        Returns
+        -------
+        rich.tree.Tree
+            A renderable tree of the command hierarchy.
+
+        Examples
+        --------
+        >>> from rich.console import Console
+        >>> app = App(name="myapp")
+        >>> Console().print(app.command_tree())  # doctest: +SKIP
+        """
+        from rich.text import Text
+        from rich.tree import Tree
+
+        from cyclopts.docs.base import iterate_commands
+        from cyclopts.help.help import docstring_parse
+
+        def short_description(subapp: "App") -> str:
+            try:
+                return docstring_parse(subapp.help, "restructuredtext").short_description or ""
+            except Exception:
+                return ""
+
+        def node_label(name: str, subapp: "App") -> Text:
+            label = Text(name)
+            if description:
+                short = short_description(subapp)
+                if short:
+                    label.append("  ")
+                    label.append(short, style="dim")
+            return label
+
+        def build(node, subapp: "App", depth: int) -> None:
+            if max_depth is not None and depth > max_depth:
+                return
+            for name, child in iterate_commands(subapp, include_hidden=include_hidden):
+                branch = node.add(node_label(name, child))
+                build(branch, child, depth + 1)
+
+        tree = Tree(node_label(self.name[0], self))
+        build(tree, self, 1)
+        return tree
 
     def generate_completion(
         self,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,7 +5,7 @@ API
 ===
 
 .. autoclass:: cyclopts.App
-   :members: default, command, version_print, help_print, interactive_shell, parse_commands, parse_known_args, parse_args, run_async, assemble_argument_collection, update, generate_docs, generate_completion, install_completion, register_install_completion_command
+   :members: default, command, version_print, help_print, interactive_shell, parse_commands, parse_known_args, parse_args, run_async, assemble_argument_collection, update, generate_docs, command_tree, generate_completion, install_completion, register_install_completion_command
    :special-members: __call__, __getitem__, __iter__
 
    Cyclopts Application.

--- a/tests/cli/test_tree.py
+++ b/tests/cli/test_tree.py
@@ -1,0 +1,147 @@
+"""Tests for the 'cyclopts tree' command."""
+
+from textwrap import dedent
+
+import pytest
+
+from cyclopts.cli import app as cyclopts_cli
+
+NESTED_SCRIPT = dedent(
+    """\
+    from cyclopts import App
+
+    app = App(name="my-app")
+
+    render = App(name="render")
+    app.command(render)
+
+    @render.command
+    def map():
+        '''Render maps.'''
+
+    @render.command
+    def transect():
+        '''Render transects.'''
+
+    @app.command
+    def archive():
+        '''Archive tools.'''
+
+    @app.command(show=False)
+    def secret():
+        '''Hidden command.'''
+    """
+)
+
+
+def test_tree_nested(tmp_path, capsys):
+    """Tree shows nested commands with connectors."""
+    script = tmp_path / "nested.py"
+    script.write_text(NESTED_SCRIPT)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cyclopts_cli(["tree", str(script)])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "my-app" in out
+    assert "render" in out
+    assert "map" in out
+    assert "transect" in out
+    assert "archive" in out
+    # Tree connectors are rendered.
+    assert "├" in out or "└" in out
+
+
+def test_tree_descriptions_shown_by_default(tmp_path, capsys):
+    """Short descriptions appear next to command names by default."""
+    script = tmp_path / "desc.py"
+    script.write_text(NESTED_SCRIPT)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cyclopts_cli(["tree", str(script)])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "Render maps." in out
+    assert "Archive tools." in out
+
+
+def test_tree_no_description(tmp_path, capsys):
+    """--no-description suppresses the description text."""
+    script = tmp_path / "nodesc.py"
+    script.write_text(NESTED_SCRIPT)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cyclopts_cli(["tree", str(script), "--no-description"])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "map" in out
+    assert "Render maps." not in out
+    assert "Archive tools." not in out
+
+
+@pytest.mark.parametrize("flag", ["--max-depth", "-m"])
+def test_tree_max_depth(tmp_path, capsys, flag):
+    """--max-depth/-m limits the displayed depth."""
+    script = tmp_path / "depth.py"
+    script.write_text(NESTED_SCRIPT)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cyclopts_cli(["tree", str(script), flag, "1"])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "render" in out
+    assert "archive" in out
+    # Nested commands beyond depth 1 are not shown.
+    assert "map" not in out
+    assert "transect" not in out
+
+
+def test_tree_excludes_hidden_and_builtin(tmp_path, capsys):
+    """Hidden commands and built-in help/version flags are excluded."""
+    script = tmp_path / "hidden.py"
+    script.write_text(NESTED_SCRIPT)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cyclopts_cli(["tree", str(script)])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "secret" not in out
+    assert "--help" not in out
+    assert "--version" not in out
+
+
+def test_tree_app_notation(tmp_path, capsys):
+    """':app' notation selects a specific app object."""
+    script = tmp_path / "multi.py"
+    script.write_text(
+        dedent(
+            """\
+            from cyclopts import App
+
+            app1 = App(name="app1")
+            app2 = App(name="app2")
+
+            @app1.command
+            def foo():
+                pass
+
+            @app2.command
+            def bar():
+                pass
+            """
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cyclopts_cli(["tree", f"{script}:app2"])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "app2" in out
+    assert "bar" in out
+    assert "foo" not in out

--- a/tests/test_command_tree.py
+++ b/tests/test_command_tree.py
@@ -1,0 +1,83 @@
+"""Tests for App.command_tree() method."""
+
+from rich.console import Console
+from rich.tree import Tree
+
+from cyclopts import App
+
+
+def _render(tree: Tree) -> str:
+    console = Console(width=200)
+    with console.capture() as capture:
+        console.print(tree)
+    return capture.get()
+
+
+def _build_app() -> App:
+    app = App(name="my-app")
+
+    render = App(name="render")
+    app.command(render)
+
+    @render.command
+    def map():
+        """Render maps."""
+
+    @render.command
+    def video():
+        """Render video."""
+
+    @app.command
+    def archive():
+        """Archive tools."""
+
+    @app.command(show=False)
+    def secret():
+        """Hidden command."""
+
+    return app
+
+
+def test_command_tree_returns_tree():
+    """command_tree returns a rich Tree renderable rooted at the app name."""
+    app = _build_app()
+    tree = app.command_tree()
+    assert isinstance(tree, Tree)
+    out = _render(tree)
+    assert "my-app" in out
+    assert "render" in out
+    assert "map" in out
+    assert "video" in out
+    assert "archive" in out
+
+
+def test_command_tree_descriptions_by_default():
+    out = _render(_build_app().command_tree())
+    assert "Render maps." in out
+    assert "Archive tools." in out
+
+
+def test_command_tree_no_description():
+    out = _render(_build_app().command_tree(description=False))
+    assert "map" in out
+    assert "Render maps." not in out
+
+
+def test_command_tree_max_depth():
+    out = _render(_build_app().command_tree(max_depth=1))
+    assert "render" in out
+    assert "archive" in out
+    assert "map" not in out
+    assert "video" not in out
+
+
+def test_command_tree_excludes_hidden_and_builtin():
+    out = _render(_build_app().command_tree())
+    assert "secret" not in out
+    assert "--help" not in out
+    assert "--version" not in out
+
+
+def test_command_tree_include_hidden():
+    out = _render(_build_app().command_tree(include_hidden=True))
+    assert "secret" in out


### PR DESCRIPTION
Add a public `App.command_tree()` method. The new `cyclopts tree` CLI command is a thin wrapper that loads an app from a script and prints the tree.

- `--description/-d` (default on) shows each command's short description
- `--max-depth/-m` limits displayed depth

Resolves #844 