### PR TITLE
Propagate `consume_multiple` to nested structured-type fields

### DIFF
--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -40,7 +40,6 @@ PARAMETER_SUBKEY_BLOCKER = Parameter(
     converter=None,  # pyright: ignore
     validator=None,
     accepts_keys=None,
-    consume_multiple=None,
     env_var=None,
 )
 

--- a/tests/test_bind_dataclasses.py
+++ b/tests/test_bind_dataclasses.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 import pytest
 
+import cyclopts
 from cyclopts import Parameter
 from cyclopts.exceptions import (
     ArgumentOrderError,
@@ -804,3 +805,34 @@ def test_bind_dataclass_with_parameter_alias_issue_696(app, assert_parse_args, c
         "--source.server=localhost --from.port=9000",
         source=Source(server="localhost", port=9000),
     )
+
+
+def test_bind_dataclass_default_parameter_consume_multiple_propagates(assert_parse_args):
+    """``default_parameter`` settings should propagate to inner dataclass fields.
+
+    Previously ``name_transform`` propagated correctly, but ``consume_multiple`` did
+    not unless the inner class field was explicitly annotated.
+
+    https://github.com/BrianPugh/cyclopts/issues/841
+    """
+    app = cyclopts.App(
+        result_action="return_value",
+        default_parameter=Parameter(consume_multiple=True),
+    )
+
+    @dataclass
+    class Inner:
+        names: list[str]
+
+    @app.command
+    def cmd(office: str, /, *, inner: Inner):
+        pass
+
+    actual_command, actual_bind, _ = app.parse_args(
+        "cmd my_office --inner.names name1 name2",
+        print_error=False,
+        exit_on_error=False,
+    )
+    assert actual_command == cmd
+    assert actual_bind.args == ("my_office",)
+    assert actual_bind.kwargs == {"inner": Inner(names=["name1", "name2"])}


### PR DESCRIPTION
Remove consume_multiple from PARAMETER_SUBKEY_BLOCKER so that a consume_multiple setting (e.g. from App(default_parameter=...)) reaches list fields inside nested dataclasses/attrs/pydantic models, matching how name_transform and negative already propagate.

Previously a global consume_multiple default applied to top-level list flags (greedy) but not to identically-typed nested list fields, an arity inconsistency that depended only on nesting depth. consume_multiple is a token-parsing behavior, not a node-structural one like the remaining blocker members (name, alias, converter, validator, accepts_keys, env_var), so it belongs with the propagating group.

Closes #841.