### PR TITLE
Hierarchical scoping followup: structural claims, deduplicated helpers, narrower error handling

### DIFF
--- a/cyclopts/argument/_collection.py
+++ b/cyclopts/argument/_collection.py
@@ -241,6 +241,22 @@ class ArgumentCollection(list[Argument]):
 
         return best_match_argument, best_match_keys, best_implicit_value
 
+    def _match_explicit(self, term: str) -> "Argument | None":
+        """Match ``term`` against explicitly-declared parameters.
+
+        Like :meth:`match`, but returns ``None`` instead of raising when there
+        is no match, and does not count a ``**kwargs`` (VAR_KEYWORD) catch-all
+        as a match — a catch-all matches ANY keyword, which is not evidence
+        that the option was explicitly declared.
+        """
+        try:
+            argument, _, _ = self.match(term)
+        except ValueError:
+            return None
+        if argument.field_info.kind is argument.field_info.VAR_KEYWORD:
+            return None
+        return argument
+
     def _set_marks(self, val: bool):
         for argument in self:
             argument._marked = val

--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -63,13 +63,29 @@ def normalize_tokens(tokens: None | str | Iterable[str]) -> list[str]:
     return tokens
 
 
+class _ProbeResult(NamedTuple):
+    """Result of :func:`_probe_unclaimed`."""
+
+    unclaimed: list[tuple[int, str]]
+    """Ordered ``(original_index, token)`` pairs the collection leaves
+    unconsumed. For partially-consumed combined short options (e.g. ``-vd``
+    where only ``-v`` is known), the unconsumed remainder appears as synthetic
+    single-flag tokens (``-d``) sharing the original index."""
+
+    kw_claims: dict[int, tuple[str, str | None]]
+    """The keyword pass's exact per-index claims (see
+    :func:`_parse_kw_and_flags`). Tokens consumed by the positional pass
+    (``include_positionals=True``) are NOT reflected here — they only
+    disappear from ``unclaimed``."""
+
+
 def _probe_unclaimed(
     argument_collection: ArgumentCollection,
     tokens: list[str],
     *,
     end_of_options_delimiter: str = "--",
     include_positionals: bool = False,
-) -> list[tuple[int, str]] | None:
+) -> _ProbeResult | None:
     """Determine which tokens ``argument_collection`` would NOT consume.
 
     Runs the real parsing passes (:func:`_parse_kw_and_flags`, and optionally
@@ -80,25 +96,20 @@ def _probe_unclaimed(
 
     Returns
     -------
-    list[tuple[int, str]] | None
-        Ordered ``(original_index, token)`` pairs the collection leaves
-        unconsumed. For partially-consumed combined short options (e.g.
-        ``-vd`` where only ``-v`` is known), the unconsumed remainder appears
-        as synthetic single-flag tokens (``-d``) sharing the original index.
-
+    _ProbeResult | None
         ``None`` if the keyword/flag pass raised a :class:`CycloptsError`
         (e.g. a known option missing its value) — the claims cannot be
         determined; the caller decides how to proceed.
     """
     collection_copy = argument_collection.copy(reset_tokens=True)
     try:
-        unused, unused_indices, contiguous_positional_count = _parse_kw_and_flags(
+        unused, unused_indices, contiguous_positional_count, claims = _parse_kw_and_flags(
             collection_copy, tokens, end_of_options_delimiter=end_of_options_delimiter
         )
     except CycloptsError:
         return None
     if not include_positionals:
-        return list(zip(unused_indices, unused, strict=True))
+        return _ProbeResult(list(zip(unused_indices, unused, strict=True)), claims)
 
     try:
         leftover = _parse_pos(
@@ -112,7 +123,7 @@ def _probe_unclaimed(
         # non-allow_leading_hyphen slot). Treat the positional pass as claiming
         # nothing; callers typically re-probe after another collection has
         # claimed the offending token.
-        return list(zip(unused_indices, unused, strict=True))
+        return _ProbeResult(list(zip(unused_indices, unused, strict=True)), claims)
 
     # ``_parse_pos`` consumes from the front of a preprocessed stream that
     # excludes the end_of_options_delimiter token itself; ``leftover`` is a
@@ -123,7 +134,7 @@ def _probe_unclaimed(
     else:
         preprocessed_to_unused = list(range(len(unused)))
     leftover_positions = preprocessed_to_unused[len(preprocessed_to_unused) - len(leftover) :]
-    return [(unused_indices[p], unused[p]) for p in leftover_positions]
+    return _ProbeResult([(unused_indices[p], unused[p]) for p in leftover_positions], claims)
 
 
 def _remove_short_flags(token: str, flags: Sequence[str]) -> str | None:
@@ -145,43 +156,9 @@ def _remove_short_flags(token: str, flags: Sequence[str]) -> str | None:
     return "-" + "".join(chars) if chars else None
 
 
-def _partition_claims(
-    tokens: list[str],
-    unclaimed: list[tuple[int, str]],
-) -> list[str]:
-    """Extract the claimed tokens from ``tokens`` given probe results.
-
-    Parameters
-    ----------
-    tokens: list[str]
-        The token stream that was probed.
-    unclaimed: list[tuple[int, str]]
-        ``(index, token)`` pairs from :func:`_probe_unclaimed`.
-
-    Returns
-    -------
-    claimed: list[str]
-        Tokens (or claimed remainders of combined short options) the
-        collection consumed, in original order.
-    """
-    unclaimed_by_position: dict[int, list[str]] = {}
-    for position, token in unclaimed:
-        unclaimed_by_position.setdefault(position, []).append(token)
-
-    claimed: list[str] = []
-    for position, token in enumerate(tokens):
-        synthetics = unclaimed_by_position.get(position)
-        if synthetics is None:
-            claimed.append(token)
-        elif len(synthetics) == 1 and synthetics[0] == token:
-            pass  # Fully unclaimed.
-        else:
-            # Partially-claimed combined short option: the claimed remainder
-            # is the original token minus the unclaimed flag characters.
-            remainder = _remove_short_flags(token, synthetics)
-            if remainder is not None:
-                claimed.append(remainder)
-    return claimed
+def _claimed_tokens(claims: dict[int, tuple[str, str | None]]) -> list[str]:
+    """Ordered claimed parts from a keyword-pass claims map (see :func:`_parse_kw_and_flags`)."""
+    return [claimed for _, (claimed, _) in sorted(claims.items())]
 
 
 def _scope_tokens_for_meta(
@@ -244,18 +221,18 @@ def _scope_tokens_for_meta(
     # Pre-command region: the meta claims what its keyword parameters match;
     # leftovers pass through to the positional stream (relevant for nested
     # meta patterns where pre-command tokens belong to an inner meta level).
-    pre_unclaimed = _probe_unclaimed(
+    pre_probe = _probe_unclaimed(
         meta_collection, pre, end_of_options_delimiter=end_of_options_delimiter, include_positionals=False
     )
-    if pre_unclaimed is None:
+    if pre_probe is None:
         # The meta's own region is malformed (e.g. option missing its value).
         # Hand everything to the meta's real keyword pass so it raises the
         # proper user-facing error.
         meta_kw_tokens = list(pre)
         pre_passthrough: list[tuple[int, str]] = []
     else:
-        meta_kw_tokens = _partition_claims(pre, pre_unclaimed)
-        pre_passthrough = pre_unclaimed
+        meta_kw_tokens = _claimed_tokens(pre_probe.kw_claims)
+        pre_passthrough = pre_probe.unclaimed
 
     positional_indices: list[int] = [position for position, _ in pre_passthrough]
     positional_tokens: list[str] = [token for _, token in pre_passthrough]
@@ -277,16 +254,14 @@ def _scope_tokens_for_meta(
         segment = tokens[segment_start : command_indices[segment_number + 1]]
         if not segment:
             continue
-        segment_unclaimed = _probe_unclaimed(
-            meta_collection, segment, end_of_options_delimiter=end_of_options_delimiter
-        )
-        if segment_unclaimed is None:
+        segment_probe = _probe_unclaimed(meta_collection, segment, end_of_options_delimiter=end_of_options_delimiter)
+        if segment_probe is None:
             # Malformed for the meta (e.g. option missing its value); hand the
             # segment to the meta's real pass so it raises the proper error.
             meta_kw_tokens.extend(segment)
             continue
-        meta_kw_tokens.extend(_partition_claims(segment, segment_unclaimed))
-        inter_passthrough.extend((segment_start + position, token) for position, token in segment_unclaimed)
+        meta_kw_tokens.extend(_claimed_tokens(segment_probe.kw_claims))
+        inter_passthrough.extend((segment_start + position, token) for position, token in segment_probe.unclaimed)
 
     # Fallthrough: compute the child's claims first (child wins), then let the
     # meta claim from the child's leftovers. Iterate because each side's
@@ -300,18 +275,20 @@ def _scope_tokens_for_meta(
         if child_collection is None:
             child_unclaimed = list(enumerate(stream_tokens))
         else:
-            child_unclaimed = _probe_unclaimed(
+            child_probe = _probe_unclaimed(
                 child_collection,
                 stream_tokens,
                 end_of_options_delimiter=end_of_options_delimiter,
                 include_positionals=True,
             )
-            if child_unclaimed is None:
+            if child_probe is None:
                 # Cannot determine the child's claims this round (e.g. a child
                 # option is missing its value because a meta flag sits between
                 # them); treat the child as claiming nothing and let the meta
                 # claim, then re-probe.
                 child_unclaimed = list(enumerate(stream_tokens))
+            else:
+                child_unclaimed = child_probe.unclaimed
 
         # Candidates the meta may claim: the child's leftovers, but never
         # tokens at/after the end-of-options delimiter (those are positional
@@ -341,10 +318,10 @@ def _scope_tokens_for_meta(
             original = stream_tokens[position]
             if len(synthetics) == 1 and synthetics[0] == original:
                 continue  # Fully unclaimed by the child; handled by run probing below.
-            if (
-                _probe_unclaimed(meta_collection, list(synthetics), end_of_options_delimiter=end_of_options_delimiter)
-                == []
-            ):
+            synthetics_probe = _probe_unclaimed(
+                meta_collection, list(synthetics), end_of_options_delimiter=end_of_options_delimiter
+            )
+            if synthetics_probe is not None and not synthetics_probe.unclaimed:
                 # The meta cleanly resolves the residual flags as-is; honor the
                 # char-level split (child wins its characters) via the run
                 # handling below.
@@ -352,7 +329,7 @@ def _scope_tokens_for_meta(
             whole_token_probe = _probe_unclaimed(
                 meta_collection, [original], end_of_options_delimiter=end_of_options_delimiter
             )
-            if whole_token_probe == []:
+            if whole_token_probe is not None and not whole_token_probe.unclaimed:
                 newly_claimed_positions[position] = [original]
                 bubbled.append(original)
 
@@ -364,10 +341,13 @@ def _scope_tokens_for_meta(
 
         for run in _contiguous_runs(candidates):
             run_tokens = [token for _, token in run]
-            meta_unclaimed = _probe_unclaimed(
-                meta_collection, run_tokens, end_of_options_delimiter=end_of_options_delimiter
-            )
-            if meta_unclaimed is None:
+            if not any(is_option_like(token, allow_numbers=True) for token in run_tokens):
+                # The keyword pass can only claim option-like tokens (and their
+                # values); a pure-positional run needs no probe. This is the
+                # common terminating state of the loop.
+                continue
+            run_probe = _probe_unclaimed(meta_collection, run_tokens, end_of_options_delimiter=end_of_options_delimiter)
+            if run_probe is None:
                 # The meta recognized an option in this run but the run is
                 # malformed for it (e.g. an option missing its value).
                 # Attribute the run to the meta so its real keyword pass raises
@@ -377,23 +357,16 @@ def _scope_tokens_for_meta(
                     newly_claimed_positions.setdefault(position, []).append(token)
                     bubbled.append(token)
                 continue
-            meta_unclaimed_by_run_pos: dict[int, list[str]] = {}
-            for run_pos, token in meta_unclaimed:
-                meta_unclaimed_by_run_pos.setdefault(run_pos, []).append(token)
-            for run_pos, (stream_pos, token) in enumerate(run):
-                synthetics = meta_unclaimed_by_run_pos.get(run_pos)
-                if synthetics is not None and len(synthetics) == 1 and synthetics[0] == token:
+            for run_pos, (stream_pos, _) in enumerate(run):
+                claim = run_probe.kw_claims.get(run_pos)
+                if claim is None:
                     continue  # Meta claimed nothing from this token.
-                if synthetics is None:
-                    # Meta claimed the whole (possibly synthetic) token.
-                    newly_claimed_positions.setdefault(stream_pos, []).append(token)
-                    bubbled.append(token)
-                else:
-                    # Meta claimed part of a combined short-option token.
-                    claimed_part = _remove_short_flags(token, synthetics)
-                    if claimed_part is not None:
-                        newly_claimed_positions.setdefault(stream_pos, []).append(claimed_part)
-                        bubbled.append(claimed_part)
+                # The meta claimed the token wholly (claimed_part == token) or
+                # partially (exact claimed characters of a combined short
+                # option, recorded by the scan itself).
+                claimed_part, _ = claim
+                newly_claimed_positions.setdefault(stream_pos, []).append(claimed_part)
+                bubbled.append(claimed_part)
 
         if not newly_claimed_positions:
             break
@@ -486,7 +459,7 @@ def _parse_kw_and_flags(
     *,
     end_of_options_delimiter: str = "--",
     stop_at_first_unknown: bool = False,
-) -> tuple[list[str], list[int], int | None]:
+) -> tuple[list[str], list[int], int | None, dict[int, tuple[str, str | None]]]:
     """Extract keyword arguments and flags from the token stream.
 
     Returns
@@ -507,10 +480,25 @@ def _parse_kw_and_flags(
         The gap between indices 2 and 6 yields ``contiguous_positional_count=3``.
         This is used by ``_parse_pos`` to prevent positional-only list parameters
         from consuming tokens that appeared after keyword arguments.
+    claims: dict[int, tuple[str, str | None]]
+        Maps each consumed token's original index to ``(claimed_part,
+        remainder)``, recorded exactly as the scan consumed it:
+
+        - A wholly-consumed token (option, flag, or an option's value) maps to
+          ``(token, None)``.
+        - A partially-consumed combined short-option token maps to the exact
+          claimed characters (plus any GNU-style attached value) and the exact
+          unmatched-character remainder, in scan order — e.g. ``-abc`` with
+          only ``-a``/``-c`` known yields ``("-ac", "-b")``.
+
+        Untouched tokens have no entry. Hierarchical scoping consumes this to
+        route token fragments between command levels without reconstructing
+        them from the unused-token stream.
     """
     unused_tokens, positional_only_tokens = [], []
     positional_only_start: int | None = None
     unused_token_original_indices: list[int] = []
+    claims: dict[int, tuple[str, str | None]] = {}
     skip_next_iterations = 0
     stop_parsing = False
     if end_of_options_delimiter:
@@ -526,6 +514,7 @@ def _parse_kw_and_flags(
         # If the previous argument was a keyword, then this is its value
         if skip_next_iterations > 0:
             skip_next_iterations -= 1
+            claims[i] = (token, None)
             continue
 
         if not is_option_like(token, allow_numbers=True):
@@ -563,6 +552,8 @@ def _parse_kw_and_flags(
 
         matches: list[_KeywordMatch] = []
         attached_value: str | None = None  # Track value attached to a GNU-style combined option
+        claimed_part: str = token
+        partial_remainder: str | None = None
         try:
             matches.append(_KeywordMatch(cli_option, *argument_collection.match(cli_option)))
         except ValueError:
@@ -619,6 +610,13 @@ def _parse_kw_and_flags(
                 for unmatched_flag in unmatched_flags:
                     unused_tokens.append(unmatched_flag)
                     unused_token_original_indices.append(i)
+                # Record the exact claimed/unclaimed split of this combined
+                # short-option token, in scan order.
+                claimed_part = "-" + "".join(m.matched_token.lstrip("-") for m in matches)
+                if attached_value is not None:
+                    claimed_part += attached_value
+                if unmatched_flags:
+                    partial_remainder = "-" + "".join(f.lstrip("-") for f in unmatched_flags)
             else:
                 if stop_at_first_unknown:
                     # Unknown option, stop parsing and return all remaining tokens
@@ -808,6 +806,7 @@ def _parse_kw_and_flags(
                     # Normal case: append the pre-created Token objects directly
                     for consumed_token in consumed_tokens:
                         match.argument.append(consumed_token)
+        claims[i] = (claimed_part, partial_remainder)
 
     # Compute the number of contiguous positional (non-option-like) unused tokens
     # before the first gap caused by keyword extraction. This prevents positional-only
@@ -822,7 +821,7 @@ def _parse_kw_and_flags(
         unused_token_original_indices.extend(
             range(positional_only_start, positional_only_start + len(positional_only_tokens))
         )
-    return unused_tokens, unused_token_original_indices, contiguous_positional_count
+    return unused_tokens, unused_token_original_indices, contiguous_positional_count, claims
 
 
 def _future_positional_only_token_count(argument_collection: ArgumentCollection, starting_index: int) -> int:
@@ -1042,7 +1041,7 @@ def create_bound_arguments(
     unused_tokens = tokens
 
     try:
-        unused_tokens, _, contiguous_positional_count = _parse_kw_and_flags(
+        unused_tokens, _, contiguous_positional_count, _ = _parse_kw_and_flags(
             argument_collection, unused_tokens, end_of_options_delimiter=end_of_options_delimiter
         )
         leftover_kw_tokens: list[str] = []

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -234,6 +234,46 @@ def _walk_metas(app: "App"):
     yield from reversed(meta_list)
 
 
+def _count_chain_without_trailing_help_version(
+    chain: Sequence[str],
+    command_apps: Sequence["App"],
+    root_app: "App",
+) -> tuple[int, list[str]]:
+    """Length of ``chain`` once trailing help/version pseudo-commands are stripped.
+
+    When users provide help/version flags after a command (e.g. ``myapp cmd
+    --help --help``), command parsing may treat them as commands in the chain;
+    they must be stripped so downstream logic sees the real command target.
+
+    Parameters
+    ----------
+    chain: Sequence[str]
+        The parsed command chain.
+    command_apps: Sequence[App]
+        Resolved app per command token, parallel to ``chain`` (excluding the
+        root). Entry ``i``'s parent is ``command_apps[i - 1]``, or
+        ``root_app`` for the first entry.
+    root_app: App
+        Parent of the first chain entry.
+
+    Returns
+    -------
+    keep: int
+        Number of leading chain entries to keep.
+    removed: list[str]
+        The stripped tokens, last-first (LIFO).
+    """
+    keep = len(chain)
+    removed: list[str] = []
+    while keep:
+        parent = command_apps[keep - 2] if keep >= 2 else root_app
+        if chain[keep - 1] not in set(parent.help_flags + parent.version_flags):  # pyright: ignore[reportOperatorIssue]
+            break
+        removed.append(chain[keep - 1])
+        keep -= 1
+    return keep, removed
+
+
 def _filter_apps_for_parse_mode(apps_for_params: list["App"], command_app: "App") -> list["App"]:
     """Filter ``apps_for_params`` based on ``command_app``'s resolved ``parse_mode``.
 
@@ -1311,7 +1351,7 @@ class App:
 
                 # Try to consume tokens with this meta app's parameters
                 # stop_at_first_unknown=True ensures we only consume contiguous leading options
-                unused_tokens, _, _ = _parse_kw_and_flags(
+                unused_tokens, _, _, _ = _parse_kw_and_flags(
                     argument_collection,
                     unused_tokens,
                     end_of_options_delimiter=end_of_options_delimiter,
@@ -1706,38 +1746,22 @@ class App:
         )
         command_chain, execution_apps, unused_tokens, _, _ = self._parse_commands(tokens, include_parent_meta=False)
 
-        # We don't want the command_app to be the version/help handler; we handle those specially
-        command_app = execution_apps[-1]
-        removed_help_version_tokens: list[str] = []
-        with suppress(IndexError):
-            # Remove trailing help/version commands from the execution chain.
-            # When users provide multiple flags (e.g., "myapp cmd --help --help"), the parser
-            # may treat trailing help/version flags as commands in the chain. We must remove ALL
-            # such trailing commands and keep command_chain synchronized with execution_apps.
-            while command_chain and command_chain[-1] in set(
-                execution_apps[-2].help_flags + execution_apps[-2].version_flags  # pyright: ignore[reportOperatorIssue]
-            ):
-                removed_help_version_tokens.append(command_chain[-1])
-                execution_apps = execution_apps[:-1]
-                command_chain = command_chain[:-1]
-
-        command_app = execution_apps[-1]
+        # We don't want the command_app to be the version/help handler; we handle those specially.
+        # ``execution_apps`` is ``[self]`` followed by one resolved app per command token.
+        keep, removed_help_version_tokens = _count_chain_without_trailing_help_version(
+            command_chain, execution_apps[1:], execution_apps[0]
+        )
+        command_chain = command_chain[:keep]
+        command_app = execution_apps[keep]
         del execution_apps  # Always use AppStack from here-on.
 
         # Analogously strip trailing help/version pseudo-commands from the
         # meta-aware parse so they don't masquerade as subcommands for
         # hierarchical token scoping (e.g. ``myapp --version`` where a user
         # parameter shadows ``--version``).
-        hier_chain = list(full_chain)
-        hier_command_indices = list(full_command_indices)
-        hier_command_apps = list(full_command_apps)
-        while hier_chain:
-            parent = hier_command_apps[-2] if len(hier_command_apps) >= 2 else self
-            if hier_chain[-1] not in set(parent.help_flags + parent.version_flags):  # pyright: ignore[reportOperatorIssue]
-                break
-            hier_chain.pop()
-            hier_command_indices.pop()
-            hier_command_apps.pop()
+        keep, _ = _count_chain_without_trailing_help_version(full_chain, full_command_apps, self)
+        hier_command_indices = list(full_command_indices[:keep])
+        hier_command_apps = list(full_command_apps[:keep])
 
         ignored: dict[str, Any] = {}
 
@@ -1775,18 +1799,12 @@ class App:
                 # membership is the right gate.)
                 if flag not in tokens:
                     return False
-                for collection in (command_argument_collection, child_argument_collection):
-                    if collection is None:
-                        continue
-                    try:
-                        argument, _, _ = collection.match(flag)
-                    except ValueError:
-                        continue
-                    # A ``**kwargs`` catch-all matches ANY keyword; that is not an
-                    # explicit shadow of the help/version flag.
-                    if argument.field_info.kind is not argument.field_info.VAR_KEYWORD:
-                        return True
-                return False
+                # A ``**kwargs`` catch-all doesn't count (see _match_explicit).
+                return any(
+                    collection._match_explicit(flag) is not None
+                    for collection in (command_argument_collection, child_argument_collection)
+                    if collection is not None
+                )
 
             # If a removed trailing help/version "command" is actually shadowed by a
             # parameter on the resolved command (e.g. ``def sub(version: bool = False)``),

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -274,20 +274,6 @@ def _count_chain_without_trailing_help_version(
     return keep, removed
 
 
-def _filter_apps_for_parse_mode(apps_for_params: list["App"], command_app: "App") -> list["App"]:
-    """Filter ``apps_for_params`` based on ``command_app``'s resolved ``parse_mode``.
-
-    In ``"strict"`` mode, parent meta apps are excluded from the parameter list
-    since their flags are not valid at the child command level. Meta apps whose
-    ``_meta_parent`` is ``command_app`` itself are retained.
-
-    In other parse modes, the input list is returned unchanged.
-    """
-    if command_app.app_stack.resolve("parse_mode") == "strict":
-        return [a for a in apps_for_params if a._meta_parent is None or a._meta_parent is command_app]
-    return apps_for_params
-
-
 def _safe_assemble_argument_collection(app: "App") -> ArgumentCollection | None:
     """Assemble an :class:`ArgumentCollection` from ``app``'s default command, tolerating unresolvable signatures.
 
@@ -344,14 +330,9 @@ def _iter_resolution_argument_collections(
 
     ``execution_path`` is used when available (help/completion paths). ``fallback_app`` is used
     for standalone calls (e.g. docs generation) that walk only the app's own meta chain.
-
-    In ``"strict"`` parse mode, parent meta apps are excluded so their flags do not appear
-    at the child command level.
     """
     if execution_path:
-        command_app = execution_path[-1]
-        resolution_apps = command_app._get_resolution_context(execution_path)
-        resolution_apps = _filter_apps_for_parse_mode(resolution_apps, command_app)
+        resolution_apps = execution_path[-1]._get_resolution_context(execution_path)
     elif fallback_app is not None:
         resolution_apps = list(_walk_metas(fallback_app))
     else:
@@ -1273,6 +1254,11 @@ class App:
 
         This includes parent meta apps and the meta app of the final command app.
 
+        In ``"strict"`` parse mode, parent meta apps are excluded: their flags are
+        rejected at this command's level, so they must not contribute parameters
+        here either. Keeping the exclusion inside this method keeps parsing, help,
+        completion, and docs generation consistent with each other.
+
         Parameters
         ----------
         execution_path : Sequence[App]
@@ -1302,6 +1288,10 @@ class App:
                         is_meta_command = last_app in app._meta._commands.values()
                         if not is_meta_command:
                             apps.append(app._meta)
+
+            if last_app.app_stack.resolve("parse_mode") == "strict":
+                # Meta apps whose _meta_parent is the command itself are retained.
+                apps = [a for a in apps if a._meta_parent is None or a._meta_parent is last_app]
 
         return apps
 
@@ -1346,19 +1336,24 @@ class App:
         # Try to parse with each meta app's parameters
         unused_tokens = tokens
         for meta_app in meta_apps_to_try:
+            argument_collection = _safe_assemble_argument_collection(meta_app)
+            if argument_collection is None:
+                # Unresolvable forward reference (e.g. cyclopts' own internal
+                # help/version handlers); genuine annotation errors propagate.
+                continue
             try:
-                argument_collection = meta_app.assemble_argument_collection()
-
-                # Try to consume tokens with this meta app's parameters
-                # stop_at_first_unknown=True ensures we only consume contiguous leading options
+                # Try to consume tokens with this meta app's parameters.
+                # stop_at_first_unknown=True ensures we only consume contiguous leading options.
                 unused_tokens, _, _, _ = _parse_kw_and_flags(
                     argument_collection,
                     unused_tokens,
                     end_of_options_delimiter=end_of_options_delimiter,
                     stop_at_first_unknown=True,
                 )
-            except Exception:
-                # If parsing fails, try next meta app
+            except CycloptsError:
+                # The leading region is malformed for this meta (e.g. an option
+                # missing its value); leave the tokens for the real parse (or the
+                # next meta) to handle so the proper user-facing error surfaces.
                 continue
 
         return unused_tokens

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -305,15 +305,11 @@ class UnknownOptionError(CycloptsError):
             # Check if a parent scope defines this option (for strict mode hints).
             if self.parent_apps_with_collections is not None:
                 for parent_name, parent_ac in self.parent_apps_with_collections:
-                    try:
-                        # Strip "=value" suffix so "--verbose=true" matches "--verbose".
-                        argument, _, _ = parent_ac.match(keyword.split("=", 1)[0])
-                    except ValueError:
-                        continue
-                    if argument.field_info.kind is argument.field_info.VAR_KEYWORD:
-                        # A ``**kwargs`` catch-all matches ANY keyword; that is not
-                        # evidence the option belongs to the parent scope, and hinting
-                        # here would suppress the nearest-neighbor suggestion below.
+                    # Strip "=value" suffix so "--verbose=true" matches "--verbose".
+                    # A ``**kwargs`` catch-all doesn't count (see _match_explicit) —
+                    # hinting on those would suppress the nearest-neighbor
+                    # suggestion below.
+                    if parent_ac._match_explicit(keyword.split("=", 1)[0]) is None:
                         continue
                     if self.command_chain:
                         yield ' Did you mean to place it directly after "', ""

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -1141,7 +1141,7 @@ def test_parse_kw_and_flags_stop_at_first_unknown_preserves_end_of_options(app):
 
     # Long unknown option followed by positional-only segment.
     tokens = ["--unknown", "--", "raw1", "raw2"]
-    unused_tokens, unused_indices, _ = _parse_kw_and_flags(
+    unused_tokens, unused_indices, _, _ = _parse_kw_and_flags(
         argument_collection,
         tokens,
         stop_at_first_unknown=True,
@@ -1152,7 +1152,7 @@ def test_parse_kw_and_flags_stop_at_first_unknown_preserves_end_of_options(app):
     # Combined short unknown option followed by positional-only segment.
     argument_collection = app.assemble_argument_collection()
     tokens = ["-xyz", "--", "raw1", "raw2"]
-    unused_tokens, unused_indices, _ = _parse_kw_and_flags(
+    unused_tokens, unused_indices, _, _ = _parse_kw_and_flags(
         argument_collection,
         tokens,
         stop_at_first_unknown=True,

--- a/tests/test_parse_mode.py
+++ b/tests/test_parse_mode.py
@@ -1282,3 +1282,95 @@ class TestScopingRegressions:
         captured.clear()
         app.meta(["cmd", "--flag", "--opt", "value"], exit_on_error=False)
         assert captured == {"flag": True, "opt": "value", "args": ()}
+
+
+class TestScopedFlatParity:
+    """Differential guard for hierarchical scoping.
+
+    When only one level defines keyword parameters, the hierarchically-scoped
+    parse must bind exactly what a flat parse of the same (non-command) tokens
+    would — any divergence means the scoping probes and the real parser
+    passes have fallen out of agreement.
+    """
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--verbose", "cmd", "a", "b"],
+            ["cmd", "--verbose", "a", "b"],
+            ["cmd", "a", "--verbose", "b"],
+            ["cmd", "a", "b", "--verbose"],
+            ["--name", "n", "cmd", "a", "b"],
+            ["cmd", "--name", "n", "a", "b"],
+            ["cmd", "a", "b", "--name", "n"],
+            ["--verbose", "cmd", "--name", "n", "a"],
+            ["cmd", "--name=n", "--verbose", "a"],
+        ],
+    )
+    def test_meta_only_params_match_flat_parse(self, argv):
+        app = App(name="myapp", result_action="return_value")
+        captured: dict[str, object] = {}
+
+        @app.meta.default
+        def meta(
+            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+            verbose: bool = False,
+            name: str = "unset",
+        ):
+            captured["meta"] = {"verbose": verbose, "name": name}
+            return app(tokens)
+
+        @app.command
+        def cmd(*args: str):
+            captured["args"] = args
+
+        app.meta(argv, exit_on_error=False)
+
+        flat = App(name="flat", result_action="return_value")
+        flat_captured: dict[str, object] = {}
+
+        @flat.default
+        def flat_main(*args: str, verbose: bool = False, name: str = "unset"):
+            flat_captured["meta"] = {"verbose": verbose, "name": name}
+            flat_captured["args"] = args
+
+        flat([t for t in argv if t != "cmd"], exit_on_error=False)
+
+        assert captured["meta"] == flat_captured["meta"]
+        assert captured["args"] == flat_captured["args"]
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["cmd", "--verbose", "a", "b"],
+            ["cmd", "a", "--verbose", "b"],
+            ["cmd", "a", "b", "--verbose"],
+        ],
+    )
+    def test_child_only_params_match_flat_parse(self, argv):
+        app = App(name="myapp", result_action="return_value")
+        captured: dict[str, object] = {}
+
+        @app.meta.default
+        def meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+            return app(tokens)
+
+        @app.command
+        def cmd(*args: str, verbose: bool = False):
+            captured["verbose"] = verbose
+            captured["args"] = args
+
+        app.meta(argv, exit_on_error=False)
+
+        flat = App(name="flat", result_action="return_value")
+        flat_captured: dict[str, object] = {}
+
+        @flat.default
+        def flat_main(*args: str, verbose: bool = False):
+            flat_captured["verbose"] = verbose
+            flat_captured["args"] = args
+
+        flat(argv[1:], exit_on_error=False)
+
+        assert captured["verbose"] == flat_captured["verbose"]
+        assert captured["args"] == flat_captured["args"]


### PR DESCRIPTION
Followup to #776. No intended user-facing behavior changes, with one deliberate exception noted below. Two commits:

## Make scoping claims structural (92881a1)

Previously, hierarchical scoping figured out *what a keyword pass claimed* by diffing the probe's synthetic unused tokens against the original stream and reconstructing claimed fragments character-by-character (`_partition_claims` + `_remove_short_flags`) — a second decision tree that had to mirror the scan's combined-short-option / GNU-attached-value edge cases exactly.

Now `_parse_kw_and_flags` records an exact per-index claims map — `(claimed_part, remainder)`, captured by the scan itself as it consumes tokens — and `_probe_unclaimed` returns it via a `_ProbeResult` NamedTuple. Scoping consumes the claims directly:

- `_partition_claims` collapses to the trivial `_claimed_tokens`; one of the two duplicated synthetics decision trees is deleted.
- `_remove_short_flags` remains only for removing meta claims from the child's stream.
- Runs containing no option-like tokens skip the meta probe entirely — the keyword pass can't claim from a pure-positional run, and this is the scoping loop's common terminating state.

Also in this commit:

- Merge the two duplicated trailing help/version pseudo-command strip loops into `_count_chain_without_trailing_help_version`; drop the write-only `hier_chain` list.
- Add `ArgumentCollection._match_explicit` (match that ignores `**kwargs` catch-alls) and use it for both the help/version shadow check (`core.py`) and the strict-mode parent-scope hint (`exceptions.py`), which previously duplicated the match-then-skip-VAR_KEYWORD logic.

## Consolidate strict-scope filtering; narrow meta-discovery error handling (239e44f)

- Fold `_filter_apps_for_parse_mode` into `_get_resolution_context`, so "which apps contribute parameters at this command level" has a single parse-mode-aware owner consumed by help, completion, and docs generation alike.
- `_consume_leading_meta_options`: replace the blanket `except Exception: continue` with `_safe_assemble_argument_collection` (NameError-only tolerance, matching the scoping probes' error policy) plus a narrow `except CycloptsError` around the keyword pass.

**Behavior change:** genuine annotation errors during meta-app command discovery now propagate instead of being silently swallowed (which previously manifested as broken command resolution with no indication why). Unresolvable forward references are still tolerated.