### PR TITLE
Fuzz hierarchical scoping; preserve end-of-options delimiter through meta forwarding

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -21,7 +21,7 @@ from cyclopts.exceptions import (
     UnknownOptionError,
     ValidationError,
 )
-from cyclopts.field_info import POSITIONAL_ONLY, POSITIONAL_OR_KEYWORD
+from cyclopts.field_info import POSITIONAL_ONLY, POSITIONAL_OR_KEYWORD, VAR_POSITIONAL
 from cyclopts.token import Token
 from cyclopts.utils import UNSET, is_option_like
 
@@ -840,12 +840,32 @@ def _future_positional_only_token_count(argument_collection: ArgumentCollection,
     return n_tokens_to_leave
 
 
-def _preprocess_positional_tokens(tokens: Sequence[str], end_of_options_delimiter: str) -> list[tuple[str, bool]]:
+def _captures_raw_stream(argument_collection: ArgumentCollection) -> bool:
+    """Whether the collection has a raw-stream capture parameter.
+
+    A ``*args`` parameter with ``allow_leading_hyphen=True`` captures a raw
+    token stream suitable for re-parsing (the meta-app forwarding pattern).
+    """
+    return any(
+        argument.field_info.kind is VAR_POSITIONAL and argument.parameter.allow_leading_hyphen
+        for argument in argument_collection
+    )
+
+
+def _preprocess_positional_tokens(
+    tokens: Sequence[str],
+    end_of_options_delimiter: str,
+    *,
+    preserve_delimiter: bool = False,
+) -> list[tuple[str, bool]]:
     try:
         delimiter_index = tokens.index(end_of_options_delimiter)
-        return [(t, False) for t in tokens[:delimiter_index]] + [(t, True) for t in tokens[delimiter_index + 1 :]]
     except ValueError:  # delimiter not found
         return [(t, False) for t in tokens]
+    delimiter = [(tokens[delimiter_index], True)] if preserve_delimiter else []
+    return (
+        [(t, False) for t in tokens[:delimiter_index]] + delimiter + [(t, True) for t in tokens[delimiter_index + 1 :]]
+    )
 
 
 def _parse_pos(
@@ -854,6 +874,7 @@ def _parse_pos(
     *,
     end_of_options_delimiter: str = "--",
     contiguous_positional_count: int | None = None,
+    preserve_delimiter: bool = False,
 ) -> list[str]:
     """Assign positional tokens to positional parameters.
 
@@ -864,7 +885,14 @@ def _parse_pos(
     tokens: list[str]
         Unused tokens from ``_parse_kw_and_flags``.
     end_of_options_delimiter: str
-        Delimiter after which all tokens are forced positional.
+        Delimiter after which all tokens are forced positional. Consumed as a
+        marker (standard CLI behavior), unless ``preserve_delimiter``.
+    preserve_delimiter: bool
+        Keep the delimiter token itself in the captured values (force-positional)
+        when the collection has a raw-stream capture parameter. Set when the
+        bound tokens are forwarded to another parse — a meta app's
+        ``app(tokens)`` — which needs the delimiter to keep the trailing tokens
+        protected. Leaf commands keep the standard consume-as-marker behavior.
     contiguous_positional_count: int | None
         If not ``None``, the number of leading contiguous positional tokens
         that were adjacent in the original CLI input (before keyword extraction
@@ -878,7 +906,11 @@ def _parse_pos(
     if not tokens:
         return []
 
-    tokens_and_force_positional = _preprocess_positional_tokens(tokens, end_of_options_delimiter)
+    tokens_and_force_positional = _preprocess_positional_tokens(
+        tokens,
+        end_of_options_delimiter,
+        preserve_delimiter=preserve_delimiter and _captures_raw_stream(argument_collection),
+    )
 
     for i in itertools.count():
         try:
@@ -1007,6 +1039,7 @@ def create_bound_arguments(
     end_of_options_delimiter: str = "--",
     positional_tokens: list[str] | None = None,
     positional_contiguous_count: int | None = None,
+    preserve_delimiter: bool = False,
 ) -> tuple[inspect.BoundArguments, list[str]]:
     """Parse and coerce CLI tokens to match a function's signature.
 
@@ -1029,6 +1062,10 @@ def create_bound_arguments(
     positional_contiguous_count: int | None
         ``contiguous_positional_count`` (see :func:`_parse_kw_and_flags`) for
         ``positional_tokens``. Only used when ``positional_tokens`` is provided.
+    preserve_delimiter: bool
+        Keep the end-of-options delimiter in a raw-stream capture parameter's
+        values (see :func:`_parse_pos`). Set when binding a meta level, whose
+        captured tokens are forwarded to another parse.
 
     Returns
     -------
@@ -1058,6 +1095,7 @@ def create_bound_arguments(
             unused_tokens,
             end_of_options_delimiter=end_of_options_delimiter,
             contiguous_positional_count=contiguous_positional_count,
+            preserve_delimiter=preserve_delimiter,
         )
         if leftover_kw_tokens:
             unused_tokens = leftover_kw_tokens + unused_tokens

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1897,6 +1897,12 @@ class App:
                                     end_of_options_delimiter=end_of_options_delimiter,
                                 )
 
+                        # A meta level's captured tokens are forwarded to
+                        # another parse (``app(tokens)``); keep the
+                        # end-of-options delimiter in the captured values so
+                        # the downstream parse still sees the trailing tokens
+                        # as protected.
+                        preserve_delimiter = command_app._meta_parent is not None
                         if scoped is not None:
                             meta_kw_tokens, positional_tokens, positional_contiguous_count = scoped
                             bound, unused_tokens = create_bound_arguments(
@@ -1907,6 +1913,7 @@ class App:
                                 end_of_options_delimiter=end_of_options_delimiter,
                                 positional_tokens=positional_tokens,
                                 positional_contiguous_count=positional_contiguous_count,
+                                preserve_delimiter=preserve_delimiter,
                             )
                         else:
                             bound, unused_tokens = create_bound_arguments(
@@ -1915,6 +1922,7 @@ class App:
                                 unused_tokens,
                                 config,
                                 end_of_options_delimiter=end_of_options_delimiter,
+                                preserve_delimiter=preserve_delimiter,
                             )
                         try:
                             for validator in command_app.validator:

--- a/tests/test_parse_mode.py
+++ b/tests/test_parse_mode.py
@@ -1374,3 +1374,68 @@ class TestScopedFlatParity:
 
         assert captured["verbose"] == flat_captured["verbose"]
         assert captured["args"] == flat_captured["args"]
+
+
+class TestForwardedDelimiter:
+    """A meta level's captured tokens are forwarded to another parse; the
+    end-of-options delimiter must survive forwarding so the inner parse still
+    sees post-delimiter tokens as protected.
+    """
+
+    def test_meta_forwarding_preserves_delimiter(self):
+        """``cmd -- -pvn``: the forwarded stream keeps ``--`` so the child
+        binds ``-pvn`` positionally instead of as its ``-p`` option.
+        """
+        app = App(name="myapp", result_action="return_value")
+        captured: dict[str, object] = {}
+
+        @app.meta.default
+        def meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]):
+            captured["forwarded"] = tokens
+            return app(tokens)
+
+        @app.command
+        def cmd(*args: str, opt: Annotated[str, Parameter(name=["--opt", "-p"])] = "unset"):
+            captured["args"] = args
+            captured["opt"] = opt
+
+        app.meta(["cmd", "--", "w0", "-pvn"], exit_on_error=False)
+        assert captured["forwarded"] == ("cmd", "--", "w0", "-pvn")
+        assert captured["args"] == ("w0", "-pvn")
+        assert captured["opt"] == "unset"
+
+    def test_flat_meta_forwarding_preserves_delimiter(self):
+        """The delimiter also survives when hierarchical scoping does not
+        engage (e.g. a shadowed ``-h`` pseudo-command cuts command
+        discovery short, so the meta binds via the flat path).
+        """
+        app = App(name="myapp", result_action="return_value")
+        captured: dict[str, object] = {}
+
+        @app.meta.default
+        def meta(
+            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+            host: Annotated[bool, Parameter(name=["--host", "-h"])] = False,
+        ):
+            captured["host"] = host
+            return app(tokens)
+
+        @app.command
+        def cmd(*args: str):
+            captured["args"] = args
+
+        app.meta(["-h", "cmd", "w2", "--", "--opt", "-x"], exit_on_error=False)
+        assert captured["host"] is True
+        assert captured["args"] == ("w2", "--opt", "-x")
+
+    def test_leaf_command_still_consumes_delimiter(self):
+        """A leaf command (even with an allow_leading_hyphen ``*args``) keeps
+        standard CLI behavior: the delimiter is a marker, not a value.
+        """
+        app = App(name="myapp", result_action="return_value")
+
+        @app.default
+        def main(*args: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+            return args
+
+        assert app(["w0", "--", "-x"], exit_on_error=False) == ("w0", "-x")

--- a/tests/test_parse_mode_fuzz.py
+++ b/tests/test_parse_mode_fuzz.py
@@ -1,0 +1,357 @@
+"""Randomized differential tests for hierarchical token scoping (parse_mode).
+
+Each case builds a meta-app/subcommand pair from a seeded random signature and
+parses a seeded random token stream. Three oracles:
+
+1. **Meta-only parity** — when only the meta level defines keyword parameters,
+   the scoped parse must bind exactly what a flat parse of the same tokens
+   (command token removed) binds; if one errors, both must error.
+2. **Child-only parity** — same, when only the subcommand defines keyword
+   parameters and all tokens appear after the command.
+3. **Mixed accounting** — both levels define (disjoint) parameters placed
+   randomly around the command, including combined short options, GNU-style
+   attached values, ``=`` syntax, and the ``--`` delimiter. Clean cases must
+   succeed with every flag/option bound at its own level and positionals
+   preserved in order; cases with injected junk must terminate with a
+   :class:`CycloptsError` (never a hang, never any other exception).
+
+Failures report the seed and token stream for reproduction. A daemon-thread
+watchdog turns a non-terminating parse into a clean test failure.
+"""
+
+import random
+import string
+import threading
+from typing import Annotated, NamedTuple
+
+import pytest
+
+from cyclopts import App, Parameter
+from cyclopts.exceptions import CycloptsError
+
+PARSE_TIMEOUT_S = 15
+FAST_SEEDS = range(50)
+BULK_SEEDS = range(1000)
+
+
+class _ParamSpec(NamedTuple):
+    kind: str  # "flag" | "option"
+    pyname: str
+    names: tuple[str, ...]
+
+    @property
+    def short(self) -> str | None:
+        for name in self.names:
+            if len(name) == 2 and name[0] == "-" and name[1] != "-":
+                return name
+        return None
+
+
+def _run_with_watchdog(fn, timeout=PARSE_TIMEOUT_S):
+    """Run ``fn`` in a daemon thread; fail the test if it doesn't finish."""
+    result: dict = {}
+
+    def target():
+        try:
+            result["value"] = fn()
+        except BaseException as e:
+            result["error"] = e
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        pytest.fail(f"parse did not terminate within {timeout}s (probable infinite loop)")
+    if "error" in result:
+        raise result["error"]
+    return result.get("value")
+
+
+def _render_param(spec: _ParamSpec) -> str:
+    names_src = ", ".join(repr(n) for n in spec.names)
+    if spec.kind == "flag":
+        return f"{spec.pyname}: Annotated[bool, Parameter(name=[{names_src}])] = False"
+    return f"{spec.pyname}: Annotated[str, Parameter(name=[{names_src}])] = 'unset'"
+
+
+def _record_expr(specs: list[_ParamSpec]) -> str:
+    return "{" + ", ".join(f"{s.pyname!r}: {s.pyname}" for s in specs) + "}"
+
+
+def _build_hier_app(meta_specs: list[_ParamSpec], child_specs: list[_ParamSpec]) -> tuple[App, dict]:
+    """Build ``app`` with a forwarding meta default and a ``cmd`` subcommand."""
+    app = App(name="fuzz", result_action="return_value")
+    captured: dict = {}
+    ns = {"Annotated": Annotated, "Parameter": Parameter, "app": app, "captured": captured}
+
+    meta_sig = "".join(", " + _render_param(s) for s in meta_specs)
+    exec(  # noqa: S102
+        "def meta(*tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)]"
+        + meta_sig
+        + "):\n"
+        + f"    captured['meta'] = {_record_expr(meta_specs)}\n"
+        + "    return app(tokens)\n",
+        ns,
+    )
+    app.meta.default(ns["meta"])
+
+    child_sig = "".join(", " + _render_param(s) for s in child_specs)
+    exec(  # noqa: S102
+        "def cmd(*args: str"
+        + child_sig
+        + "):\n"
+        + f"    captured['child'] = {_record_expr(child_specs)}\n"
+        + "    captured['args'] = args\n",
+        ns,
+    )
+    app.command(ns["cmd"])
+    return app, captured
+
+
+def _build_flat_app(specs: list[_ParamSpec]) -> tuple[App, dict]:
+    """Reference app: the same keyword parameters, parsed flat (no meta dispatch)."""
+    flat = App(name="flat", result_action="return_value")
+    captured: dict = {}
+    ns = {"Annotated": Annotated, "Parameter": Parameter, "captured": captured}
+    sig = "".join(", " + _render_param(s) for s in specs)
+    exec(  # noqa: S102
+        "def main(*args: str"
+        + sig
+        + "):\n"
+        + f"    captured['params'] = {_record_expr(specs)}\n"
+        + "    captured['args'] = args\n",
+        ns,
+    )
+    flat.default(ns["main"])
+    return flat, captured
+
+
+def _generate_specs(rng: random.Random, prefix: str, shorts: list[str]) -> list[_ParamSpec]:
+    """Generate 0-4 parameter specs consuming (up to) the provided short letters."""
+    specs: list[_ParamSpec] = []
+    n_flags = rng.randint(0, 2)
+    n_options = rng.randint(0, 2)
+    for i in range(n_flags + n_options):
+        kind = "flag" if i < n_flags else "option"
+        pyname = f"{prefix}{kind[0]}{i}"
+        names: tuple[str, ...] = (f"--{pyname}",)
+        if shorts and rng.random() < 0.8:
+            names = (*names, f"-{shorts.pop()}")
+        specs.append(_ParamSpec(kind, pyname, names))
+    return specs
+
+
+def _random_value(rng: random.Random) -> str:
+    return "v" + "".join(rng.choices(string.ascii_lowercase, k=rng.randint(1, 4)))
+
+
+def _emit(rng: random.Random, spec: _ParamSpec, value: str | None) -> list[str]:
+    """Random surface form for one parameter: long/short, ``=``, or attached value."""
+    name = rng.choice(spec.names)
+    if spec.kind == "flag":
+        return [name]
+    assert value is not None
+    style = rng.random()
+    if name.startswith("--"):
+        return [f"{name}={value}"] if style < 0.3 else [name, value]
+    if style < 0.4:
+        return [f"{name}{value}"]  # GNU-style attached: -uroot
+    return [name, value]
+
+
+class _Emission(NamedTuple):
+    groups: list[list[str]]
+    """Atomic token groups (an option and its value never get separated)."""
+    expected: dict
+    """pyname -> expected bound value."""
+    clean: bool
+    """False when junk/duplicates were injected (outcome may legitimately error)."""
+
+
+def _generate_emission(
+    rng: random.Random,
+    specs: list[_ParamSpec],
+    *,
+    allow_junk: bool,
+    combined_pool: list[str] | None = None,
+) -> _Emission:
+    """Random token groups for ``specs``; each spec emitted at most once.
+
+    Flags whose shorts land in ``combined_pool`` (when provided) are emitted by
+    the caller as combined short-option tokens instead.
+    """
+    groups: list[list[str]] = []
+    expected: dict = {}
+    clean = True
+    for spec in specs:
+        if spec.kind == "flag":
+            if combined_pool is not None and spec.short and rng.random() < 0.3:
+                combined_pool.append(spec.short[1])
+                expected[spec.pyname] = True
+                continue
+            if rng.random() < 0.7:
+                groups.append(_emit(rng, spec, None))
+                expected[spec.pyname] = True
+            else:
+                expected[spec.pyname] = False
+        else:
+            if rng.random() < 0.7:
+                value = _random_value(rng)
+                groups.append(_emit(rng, spec, value))
+                expected[spec.pyname] = value
+            else:
+                expected[spec.pyname] = "unset"
+    if allow_junk and rng.random() < 0.2:
+        groups.append([rng.choice(["--junk", "-Z", "-junkk"])])
+        clean = False
+    return _Emission(groups, expected, clean)
+
+
+def _outcome(fn):
+    try:
+        _run_with_watchdog(fn)
+        return "ok"
+    except CycloptsError:
+        return "error"
+
+
+def _check_parity(seed: int, *, meta_side: bool) -> None:
+    """Oracle 1/2: single-level keyword parameters must match a flat parse."""
+    rng = random.Random(seed)
+    shorts = rng.sample(string.ascii_lowercase, k=6)
+    specs = _generate_specs(rng, "m" if meta_side else "c", shorts)
+    meta_specs, child_specs = (specs, []) if meta_side else ([], specs)
+
+    emission = _generate_emission(rng, specs, allow_junk=False)
+    kw_groups = list(emission.groups)
+    rng.shuffle(kw_groups)
+    # Child-side parameters only bind after the command token. Words and junk
+    # must also come after it: a non-option token before the command stops
+    # command discovery entirely (standard CLI semantics), which the flat
+    # reference cannot model.
+    boundary = rng.randint(0, len(kw_groups)) if meta_side else 0
+    pre_groups = kw_groups[:boundary]
+    post_groups = kw_groups[boundary:]
+    if rng.random() < 0.2:
+        post_groups.append([rng.choice(["--junk", "-Z", "-junkk"])])
+    for _ in range(rng.randint(0, 3)):
+        post_groups.append([f"w{rng.randint(0, 5)}"])
+    has_delimiter = rng.random() < 0.15
+    if has_delimiter:
+        post_groups.append(["--"])
+        post_groups.append([f"w{rng.randint(0, 5)}"])
+    rng.shuffle(post_groups)
+
+    pre = [token for group in pre_groups for token in group]
+    post = [token for group in post_groups for token in group]
+    hier_tokens = [*pre, "cmd", *post]
+    flat_tokens = [*pre, *post]
+
+    app, captured = _build_hier_app(meta_specs, child_specs)
+    flat, flat_captured = _build_flat_app(specs)
+
+    hier_outcome = _outcome(lambda: app.meta(hier_tokens, exit_on_error=False, print_error=False))
+    flat_outcome = _outcome(lambda: flat(flat_tokens, exit_on_error=False, print_error=False))
+
+    if has_delimiter:
+        # Pre-existing (v5-develop) quirk unrelated to scoping: a forwarding
+        # meta's ``*tokens`` positional binding consumes the ``--`` marker, so
+        # the inner parse sees the post-delimiter tokens unprotected and can
+        # legitimately diverge from the flat reference. Only termination and
+        # the no-crash guarantee are asserted for these streams.
+        return
+
+    context = f"seed={seed} tokens={hier_tokens!r}"
+    assert hier_outcome == flat_outcome, (
+        f"{context}: scoped parse {hier_outcome} but flat parse {flat_outcome}"
+        f" (hier={captured!r} flat={flat_captured!r})"
+    )
+    if hier_outcome == "ok":
+        bound = captured["meta"] if meta_side else captured["child"]
+        assert bound == flat_captured["params"], f"{context}: {bound!r} != flat {flat_captured['params']!r}"
+        assert captured["args"] == flat_captured["args"], (
+            f"{context}: args {captured['args']!r} != flat {flat_captured['args']!r}"
+        )
+
+
+def _check_mixed(seed: int) -> None:
+    """Oracle 3: disjoint meta/child parameters, random placement, exact accounting."""
+    rng = random.Random(seed)
+    shorts = rng.sample(string.ascii_lowercase, k=12)
+    meta_specs = _generate_specs(rng, "m", shorts[:6])
+    child_specs = _generate_specs(rng, "c", shorts[6:])
+
+    combined_pool: list[str] = []
+    meta_emission = _generate_emission(rng, meta_specs, allow_junk=True, combined_pool=combined_pool)
+    child_emission = _generate_emission(rng, child_specs, allow_junk=False, combined_pool=combined_pool)
+
+    meta_groups = list(meta_emission.groups)
+    child_groups = list(child_emission.groups)
+    combined_junk = False
+    if combined_pool:
+        # One combined short-option token possibly spanning both scopes (e.g. -vd),
+        # sometimes salted with a short flag unknown to BOTH levels — the case
+        # where the claimed/unclaimed split of one token gets contested.
+        if rng.random() < 0.4:
+            unknown = [c for c in string.ascii_lowercase if c not in shorts]
+            combined_pool.append(rng.choice(unknown))
+            combined_junk = True
+        rng.shuffle(combined_pool)
+        child_groups.append(["-" + "".join(combined_pool)])
+
+    for i in range(rng.randint(0, 3)):
+        child_groups.append([f"w{i}"])
+
+    rng.shuffle(meta_groups)
+    rng.shuffle(child_groups)
+    # Positional order is the post-shuffle stream order.
+    words = [group[0] for group in child_groups if group[0].startswith("w")]
+    boundary = rng.randint(0, len(meta_groups))
+    pre = [token for group in meta_groups[:boundary] for token in group]
+    post_meta = [token for group in meta_groups[boundary:] for token in group]
+    post = [token for group in child_groups for token in group]
+    tokens = [*pre, "cmd", *post, *post_meta]
+
+    app, captured = _build_hier_app(meta_specs, child_specs)
+    clean = meta_emission.clean and child_emission.clean and not combined_junk
+    context = f"seed={seed} tokens={tokens!r}"
+
+    try:
+        _run_with_watchdog(lambda: app.meta(tokens, exit_on_error=False, print_error=False))
+    except CycloptsError:
+        assert not clean, f"{context}: clean disjoint case unexpectedly errored (captured={captured!r})"
+        return
+
+    if not clean:
+        return  # Junk that happened to parse (e.g. swallowed by a leading-hyphen path) is fine.
+    assert captured["meta"] == meta_emission.expected, (
+        f"{context}: meta bound {captured['meta']!r}, expected {meta_emission.expected!r}"
+    )
+    assert captured["child"] == child_emission.expected, (
+        f"{context}: child bound {captured['child']!r}, expected {child_emission.expected!r}"
+    )
+    assert list(captured["args"]) == words, f"{context}: args {captured['args']!r}, expected {words!r}"
+
+
+@pytest.mark.parametrize("seed", FAST_SEEDS)
+def test_fuzz_meta_only_parity(seed):
+    _check_parity(seed, meta_side=True)
+
+
+@pytest.mark.parametrize("seed", FAST_SEEDS)
+def test_fuzz_child_only_parity(seed):
+    _check_parity(seed, meta_side=False)
+
+
+@pytest.mark.parametrize("seed", FAST_SEEDS)
+def test_fuzz_mixed_accounting(seed):
+    _check_mixed(seed)
+
+
+@pytest.mark.slow
+def test_fuzz_bulk():
+    """Large corpus; run with ``pytest --run-slow``."""
+    for seed in BULK_SEEDS:
+        _check_parity(seed, meta_side=True)
+        _check_parity(seed, meta_side=False)
+        _check_mixed(seed)

--- a/tests/test_parse_mode_fuzz.py
+++ b/tests/test_parse_mode_fuzz.py
@@ -236,8 +236,7 @@ def _check_parity(seed: int, *, meta_side: bool) -> None:
         post_groups.append([rng.choice(["--junk", "-Z", "-junkk"])])
     for _ in range(rng.randint(0, 3)):
         post_groups.append([f"w{rng.randint(0, 5)}"])
-    has_delimiter = rng.random() < 0.15
-    if has_delimiter:
+    if rng.random() < 0.15:
         post_groups.append(["--"])
         post_groups.append([f"w{rng.randint(0, 5)}"])
     rng.shuffle(post_groups)
@@ -252,14 +251,6 @@ def _check_parity(seed: int, *, meta_side: bool) -> None:
 
     hier_outcome = _outcome(lambda: app.meta(hier_tokens, exit_on_error=False, print_error=False))
     flat_outcome = _outcome(lambda: flat(flat_tokens, exit_on_error=False, print_error=False))
-
-    if has_delimiter:
-        # Pre-existing (v5-develop) quirk unrelated to scoping: a forwarding
-        # meta's ``*tokens`` positional binding consumes the ``--`` marker, so
-        # the inner parse sees the post-delimiter tokens unprotected and can
-        # legitimately diverge from the flat reference. Only termination and
-        # the no-crash guarantee are asserted for these streams.
-        return
 
     context = f"seed={seed} tokens={hier_tokens!r}"
     assert hier_outcome == flat_outcome, (


### PR DESCRIPTION
1. **A randomized differential test corpus for `parse_mode` hierarchical scoping** (`tests/test_parse_mode_fuzz.py`), and
2. **A bug fix that corpus immediately found**: a forwarding meta app silently dropped the `--` end-of-options delimiter, so the downstream re-parse re-interpreted protected tokens as options.

## Fuzz corpus

Seeded, dependency-free (no hypothesis) randomized tests with three oracles:

- **Meta-only / child-only parity** — when only a single level defines keyword parameters, the hierarchically-scoped parse must bind exactly what a flat parse of the same token stream binds (both-error counts as agreement).
- **Mixed accounting** — disjoint meta/child parameters placed randomly around the command — including combined short options spanning both scopes, GNU-style attached values, `=` syntax, junk tokens, and the `--` delimiter — must bind every flag/option at its own level with positionals preserved in order.
- **Error discipline** — junk-bearing streams must fail with a `CycloptsError`, never anything else (and never hang: a daemon-thread watchdog converts a non-terminating parse into a clean test failure instead of a stuck CI run).

50 seeds per oracle run in the default suite (<1s total); a 1000-seed corpus runs under `pytest --run-slow`. The corpus was validated for power against the pre-fix scoping implementation (c7a1a1e), where it catches the combined-short infinite loop.

## Bug fix: `--` lost through meta forwarding

**Before:** a forwarding meta's raw-stream capture parameter (`*tokens` with `allow_leading_hyphen=True`) lost the `--` delimiter — `_parse_pos` consumed it as a marker, so the user's `app(tokens)` re-parse saw the post-delimiter tokens unprotected. E.g. `myapp cmd -- -pvn` bound `-pvn` as the child's `-p` option. Pre-existing on `v5-develop`; surfaced by the fuzz corpus.

**After:** when the command being bound is a meta level (its captured tokens are forwarded to another parse by contract), `_parse_pos` keeps the delimiter in the raw-stream parameter's values as a force-positional token, so the downstream parse still sees the trailing tokens as protected. This applies on both the hierarchically-scoped path and the flat path (reachable e.g. when a shadowed `-h` pseudo-command cuts command discovery short). Leaf commands keep standard CLI behavior: the level that consumes the separator drops it, even for `allow_leading_hyphen` `*args`.

With the fix in place, the fuzz parity oracle fully asserts delimiter streams (the initial termination-only relaxation for `--` is removed), and named regression tests in `tests/test_parse_mode.py` document the forwarding, flat-path, and leaf semantics.
