### PR TITLE
exit 2 on parse errors, `Parameter.negative_alias`, eager `result_action` validation, migration guide

### DIFF
--- a/cyclopts/_result_action.py
+++ b/cyclopts/_result_action.py
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Callable, Iterable
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, get_args, get_origin
 
 from cyclopts.utils import is_iterable
 
@@ -26,6 +26,25 @@ ResultActionSingle = (
 )
 
 ResultAction = ResultActionSingle | Iterable[ResultActionSingle]
+
+_RESULT_ACTION_NAMES: frozenset[str] = frozenset(
+    get_args(next(arg for arg in get_args(ResultActionSingle) if get_origin(arg) is Literal))
+)
+
+
+def validate_result_action(action: Any) -> None:
+    """Validate a single result action, raising a descriptive :class:`ValueError`.
+
+    Called eagerly (at :class:`App` construction and at invocation-time
+    overrides) so that a typo'd action name fails before any command executes.
+    """
+    if callable(action) or (isinstance(action, str) and action in _RESULT_ACTION_NAMES):
+        return
+    raise ValueError(
+        f"Invalid result_action {action!r}; must be a callable or one of: "
+        + ", ".join(map(repr, sorted(_RESULT_ACTION_NAMES)))
+        + "."
+    )
 
 
 def resolve_returncode(result: Any, default: int = 0) -> int:
@@ -172,4 +191,7 @@ def handle_result_action(
             print_fn(result)
             sys.exit(resolve_returncode(result))
         case _:
-            raise ValueError
+            # Values that bypassed eager validation (e.g. injected through a
+            # config layer) still get the descriptive error.
+            validate_result_action(action)
+            raise ValueError(f"Unhandled result_action: {action!r}")  # pragma: no cover

--- a/cyclopts/cli/tree.py
+++ b/cyclopts/cli/tree.py
@@ -14,7 +14,7 @@ def tree(
     script: str,
     /,
     *,
-    description: Annotated[bool, Parameter(alias="-d")] = True,
+    description: Annotated[bool, Parameter(negative_alias="-d")] = True,
     max_depth: Annotated[int | None, Parameter(alias="-m")] = None,
 ):
     """Display a tree of a Cyclopts application's commands.

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1831,7 +1831,7 @@ class App:
             active_help_flags = tuple(f for f in command_app.help_flags if not _flag_shadowed_by_user_param(f))
             active_version_flags = tuple(f for f in command_app.version_flags if not _flag_shadowed_by_user_param(f))
 
-            help_flag_index = _get_help_flag_index(tokens, active_help_flags, end_of_options_delimiter)
+            help_flag_index = _get_flag_index(tokens, active_help_flags, end_of_options_delimiter)
 
             try:
                 if help_flag_index is not None:
@@ -1852,7 +1852,7 @@ class App:
                     bound = inspect.signature(command).bind(tokens, console=command_app.console)
                     unused_tokens = []
                     argument_collection = ArgumentCollection()
-                elif any(flag in tokens for flag in active_version_flags):
+                elif _get_flag_index(tokens, active_version_flags, end_of_options_delimiter) is not None:
                     command = _get_version_command(command_app)
                     while meta_parent := meta_parent._meta_parent:
                         command = _get_version_command(meta_parent)
@@ -2015,7 +2015,7 @@ class App:
             Print a rich-formatted error on error.
             If :obj:`None`, inherits from :attr:`App.print_error`, eventually defaulting to :obj:`True`.
         exit_on_error: bool | None
-            If there is an error parsing the CLI tokens invoke ``sys.exit(1)``.
+            If there is an error parsing the CLI tokens invoke ``sys.exit(2)``.
             Otherwise, continue to raise the exception.
             If :obj:`None`, inherits from :attr:`App.exit_on_error`, eventually defaulting to :obj:`True`.
         help_on_error: bool | None
@@ -2088,7 +2088,7 @@ class App:
                     else:
                         e.console.print(CycloptsPanel(e))
                 if exit_on_error if exit_on_error is not None else True:
-                    sys.exit(1)
+                    sys.exit(2)
                 raise
 
         return command, bound, ignored
@@ -2131,7 +2131,7 @@ class App:
             Print a rich-formatted error on error.
             If :obj:`None`, inherits from :attr:`App.print_error`, eventually defaulting to :obj:`True`.
         exit_on_error: bool | None
-            If there is an error parsing the CLI tokens invoke ``sys.exit(1)``.
+            If there is an error parsing the CLI tokens invoke ``sys.exit(2)``.
             Otherwise, continue to raise the exception.
             If :obj:`None`, inherits from :attr:`App.exit_on_error`, eventually defaulting to :obj:`True`.
         help_on_error: bool | None
@@ -2236,7 +2236,7 @@ class App:
             Print a rich-formatted error on error.
             If :obj:`None`, inherits from :attr:`App.print_error`, eventually defaulting to :obj:`True`.
         exit_on_error: bool | None
-            If there is an error parsing the CLI tokens invoke ``sys.exit(1)``.
+            If there is an error parsing the CLI tokens invoke ``sys.exit(2)``.
             Otherwise, continue to raise the exception.
             If :obj:`None`, inherits from :attr:`App.exit_on_error`, eventually defaulting to :obj:`True`.
         help_on_error: bool | None
@@ -3031,15 +3031,16 @@ class App:
         return f"{type(self).__name__}({signature})"
 
 
-def _get_help_flag_index(tokens, help_flags, end_of_options_delimiter) -> int | None:
+def _get_flag_index(tokens, flags, end_of_options_delimiter) -> int | None:
+    """Index of the first of ``flags`` in ``tokens``, ignoring tokens at/after the end-of-options delimiter."""
     delimiter_index = None
     if end_of_options_delimiter:
         with suppress(ValueError):
             delimiter_index = tokens.index(end_of_options_delimiter)
 
-    for help_flag in help_flags:
+    for flag in flags:
         with suppress(ValueError):
-            index = tokens.index(help_flag)
+            index = tokens.index(flag)
             if delimiter_index is None or index < delimiter_index:
                 break
     else:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -83,7 +83,7 @@ if TYPE_CHECKING:
     from cyclopts.help import HelpPanel
     from cyclopts.help.protocols import HelpFormatter
 
-from cyclopts._result_action import ResultAction, ResultActionSingle
+from cyclopts._result_action import ResultAction, ResultActionSingle, validate_result_action
 from cyclopts._run import _run_maybe_async_command
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -107,6 +107,9 @@ def _result_action_converter(
 
     if not result:
         raise ValueError("result_action cannot be an empty sequence")
+
+    for action in result:
+        validate_result_action(action)
 
     return result
 
@@ -2148,7 +2151,7 @@ class App:
         result_action: ResultAction | None
             Controls how command return values are handled. Can be a predefined literal string
             or a custom callable that takes the result and returns a processed value.
-            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_return_int_as_exit_code".
+            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_sys_exit".
             See :attr:`App.result_action` for available modes.
 
         Returns
@@ -2171,7 +2174,7 @@ class App:
                 "help_on_error": help_on_error,
                 "verbose": verbose,
                 "backend": backend,
-                "result_action": result_action,
+                "result_action": _result_action_converter(result_action),
                 "error_formatter": error_formatter,
             }.items()
             if v is not None
@@ -2253,7 +2256,7 @@ class App:
         result_action: ResultAction | None
             Controls how command return values are handled. Can be a predefined literal string
             or a custom callable that takes the result and returns a processed value.
-            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_return_int_as_exit_code".
+            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_sys_exit".
             See :attr:`App.result_action` for available modes.
 
         Returns
@@ -2300,7 +2303,7 @@ class App:
                 "help_on_error": help_on_error,
                 "verbose": verbose,
                 "backend": backend,
-                "result_action": result_action,
+                "result_action": _result_action_converter(result_action),
                 "error_formatter": error_formatter,
             }.items()
             if v is not None

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -237,6 +237,13 @@ class Parameter:
         kw_only=True,
     )
 
+    # This can ONLY ever be a Tuple[str, ...]
+    negative_alias: None | str | Iterable[str] = field(
+        default=None,
+        converter=_str_tuple_converter,
+        kw_only=True,
+    )
+
     # This can ONLY ever be a Tuple[Union[Group, str], ...]
     group: None | Group | str | Iterable[Group | str] = field(
         default=None,
@@ -419,7 +426,7 @@ class Parameter:
                 (out if negative.startswith("-") else user_negatives).append(negative)
 
             if not user_negatives:
-                return tuple(out)
+                return self._extend_negative_aliases(out)
 
         assert isinstance(self.name, tuple)
         for name in self.name:
@@ -445,7 +452,20 @@ class Parameter:
             else:
                 for negative in user_negatives:
                     out.append(f"--{name_prefix}{negative}")
-        return tuple(out)
+        return self._extend_negative_aliases(out)
+
+    def _extend_negative_aliases(self, negatives: list[str]) -> tuple[str, ...]:
+        """Append :attr:`negative_alias` entries to the computed negative names.
+
+        Unlike :attr:`negative` (which *replaces* the generated negative names),
+        aliases are additive — mirroring the :attr:`name`/:attr:`alias`
+        relationship for positive names.
+        """
+        assert isinstance(self.negative_alias, tuple)
+        for negative_alias in self.negative_alias:
+            if negative_alias not in negatives:
+                negatives.append(negative_alias)
+        return tuple(negatives)
 
     def __repr__(self):
         """Only shows non-default values."""

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1176,6 +1176,38 @@ API
          │ --verbose --quiet  [default: False]                            │
          ╰────────────────────────────────────────────────────────────────╯
 
+   .. attribute:: negative_alias
+      :type: Union[None, str, Iterable[str]]
+      :value: None
+
+      *Additional* name(s) for the negative form of the flag, appended to the
+      generated (or :attr:`negative`-supplied) negative names. The
+      :attr:`negative`/:attr:`negative_alias` pair mirrors :attr:`name`/:attr:`alias`:
+      ``negative`` replaces, ``negative_alias`` appends.
+
+      The primary use-case is a short flag that *disables* a default-on boolean:
+
+      .. code-block:: python
+
+         from cyclopts import App, Parameter
+         from typing import Annotated
+
+         app = App()
+
+         @app.default
+         def main(*, description: Annotated[bool, Parameter(negative_alias="-d")] = True):
+            print(f"{description=}")
+
+         app()
+
+      .. code-block:: console
+
+         $ my-script -d
+         description=False
+
+         $ my-script --no-description
+         description=False
+
    .. attribute:: negative_bool
       :type: Optional[str]
       :value: None

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,6 +65,7 @@ For extensive documentation on all the features Cyclopts has to offer, checkout 
    :maxdepth: 2
    :caption: Migration
 
+   migration/v5.rst
    migration/typer.rst
 
 .. toctree::

--- a/docs/source/migration/v5.rst
+++ b/docs/source/migration/v5.rst
@@ -1,0 +1,167 @@
+.. _Migrating to v5:
+
+===============
+Migrating to v5
+===============
+Cyclopts v5 introduces hierarchical parsing for :ref:`Meta Apps <Meta App>`
+(see :ref:`Parse Mode`), along with several intentional behavior changes.
+This page documents each breaking change and how to migrate.
+
+------------------------------------------
+1. Fallthrough Parsing: Child Wins
+------------------------------------------
+Previously, a meta app claimed any keyword parameter it recognized regardless of
+where the token appeared — even after a subcommand, and even if the subcommand
+defined a parameter with the same name. In v5, the default
+:attr:`.App.parse_mode` is ``"fallthrough"``: meta parameters may still appear
+anywhere, but when both the meta and the subcommand define the same name, the
+**subcommand wins** for tokens placed after it.
+
+.. code-block:: python
+
+   from cyclopts import App, Parameter
+   from typing import Annotated
+
+   app = App()
+
+   @app.meta.default
+   def main(
+       *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+       verbose: Annotated[bool, Parameter(alias="-v")] = False,
+   ):
+       app(tokens)
+
+   @app.command
+   def greet(name: str, *, version: Annotated[bool, Parameter(alias="-v")] = False):
+       ...
+
+.. code-block:: console
+
+   $ myapp greet -v Alice
+   # v4: meta's verbose=True; greet's version=False
+   # v5: meta's verbose=False; greet's version=True  (child wins)
+
+Placement before the subcommand is unchanged (``myapp -v greet Alice`` binds the
+meta's ``verbose`` in both versions). If you want each parameter to bind
+*only* at the level where it appears — and an error when a meta parameter is
+placed after a subcommand — set ``parse_mode="strict"`` (see :ref:`Parse Mode`).
+
+------------------------------------------------------
+2. Forwarded ``*tokens`` Preserve the ``--`` Delimiter
+------------------------------------------------------
+A forwarding meta's raw-stream capture parameter (``*tokens`` with
+:attr:`~.Parameter.allow_leading_hyphen` set to :obj:`True`) now keeps the
+literal end-of-options delimiter ``--`` when the user typed one, so the
+re-parse inside your ``app(tokens)`` call still treats the trailing tokens as
+positional.
+
+.. code-block:: console
+
+   $ myapp sub -- -x
+   # v4: meta captured ("sub", "-x")        → inner parse saw -x unprotected
+   # v5: meta captured ("sub", "--", "-x")  → inner parse keeps -x positional
+
+If your wrapper manually re-inserted the delimiter as a workaround, remove that
+workaround — otherwise the inner parse will receive it twice. Leaf commands
+(commands that don't forward) are unchanged: the delimiter is consumed as a
+marker and never appears in bound values.
+
+---------------------------------------------------------------------
+3. A Greedy ``*args`` Subcommand Claims All Post-Command Tokens
+---------------------------------------------------------------------
+A subcommand whose only positional parameter is ``*args`` with
+:attr:`~.Parameter.allow_leading_hyphen` set to :obj:`True` genuinely claims
+**every** token after the command. Meta parameters placed after such a
+subcommand no longer bubble up to the meta; they are captured by the
+subcommand's ``*args``.
+
+.. code-block:: python
+
+   @app.meta.default
+   def main(
+       *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+       user: str = "default",
+   ):
+       app(tokens)
+
+   @app.command
+   def sub(*args: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+       ...
+
+.. code-block:: console
+
+   $ myapp sub --user=alice
+   # v4: meta's user="alice"; sub's args=()
+   # v5: meta's user="default"; sub's args=("--user=alice",)
+
+Place meta parameters before the subcommand (``myapp --user=alice sub``), or
+give the subcommand explicit keyword parameters instead of a catch-all.
+
+-----------------------------------------------------
+4. User Parameters Shadow ``--help`` / ``--version``
+-----------------------------------------------------
+A command may now define its own parameter named like an auto-registered
+``--help`` or ``--version`` flag. The user parameter *shadows* the auto flag on
+that command: the token binds to your parameter instead of triggering the
+help/version handler, and the command's help page lists your parameter.
+
+.. code-block:: python
+
+   @app.command
+   def sub(*, version: bool = False):
+       return version
+
+.. code-block:: console
+
+   $ myapp sub --version
+   # v4: printed the app version
+   # v5: binds the version parameter to True
+
+Note that shadowing is per-flag: with ``--version`` shadowed, ``--help`` still
+shows help. Conversely, if a command shadows ``--help``, a ``--version`` token
+in the same invocation triggers the version handler (interception runs before
+binding), and the shadowed ``--help`` token is discarded along with all other
+tokens — the same as any other invocation that triggers version printing.
+
+If you previously relied on a parameter named ``version``/``help`` *not*
+capturing those tokens, rename the parameter or its
+:attr:`~.Parameter.name`.
+
+------------------------------------------------------
+5. ``result_action`` Validation and Exit-Code Contract
+------------------------------------------------------
+:attr:`.App.result_action` accepts a set of string action names and/or
+callables. Invalid action names now raise :class:`ValueError` **eagerly** —
+at :class:`.App` construction, attribute assignment, or invocation-time
+override — *before* any command executes:
+
+.. code-block:: python
+
+   App(result_action="bogus")               # ValueError, raised immediately
+   app(tokens, result_action="bogus")       # ValueError, command never runs
+
+The default action for :meth:`.App.__call__` is ``"print_non_int_sys_exit"``,
+which calls :func:`sys.exit` with an exit code derived from the command's
+return value:
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Return value
+     - Behavior
+   * - :obj:`True`
+     - ``sys.exit(0)``
+   * - :obj:`False`
+     - ``sys.exit(1)``
+   * - :obj:`int`
+     - ``sys.exit(value)``
+   * - Other non-:obj:`None` value
+     - Printed, then ``sys.exit`` with ``__cyclopts_returncode__()`` if the
+       value defines it, else ``0``.
+   * - :obj:`None`
+     - ``sys.exit(0)`` (or ``__cyclopts_returncode__()`` if defined).
+
+To receive the return value instead of exiting (e.g. in tests), use
+``result_action="return_value"``. See :attr:`.App.result_action` for all
+available actions and composition rules.

--- a/docs/source/migration/v5.rst
+++ b/docs/source/migration/v5.rst
@@ -165,3 +165,36 @@ return value:
 To receive the return value instead of exiting (e.g. in tests), use
 ``result_action="return_value"``. See :attr:`.App.result_action` for all
 available actions and composition rules.
+
+------------------------------------
+6. Parse Errors Exit With Code 2
+------------------------------------
+CLI usage errors (unknown option, missing argument, coercion failure, …) now
+exit with code ``2``, matching :mod:`argparse` and Click. Previously they
+exited with code ``1``, which made them indistinguishable from a command that
+ran and reported failure (the default :attr:`.App.result_action` maps a
+:obj:`False` return to exit code ``1``).
+
+.. code-block:: console
+
+   $ myapp --bogus; echo $?
+   # v4: 1
+   # v5: 2
+
+Update any scripts that check for exit code ``1`` on malformed input.
+Application-level exit codes (from command return values via
+:attr:`.App.result_action`) are unchanged, as is ``130`` for keyboard
+interrupts.
+
+----------------------------------------------
+7. ``--version`` Respects the ``--`` Delimiter
+----------------------------------------------
+A ``--version`` token appearing after the end-of-options delimiter is now
+treated as positional data instead of triggering version printing, matching
+how ``--help`` already behaved.
+
+.. code-block:: console
+
+   $ myapp -- --version
+   # v4: printed the app version (command never ran)
+   # v5: the command runs; "--version" is bound positionally

--- a/tests/test_bind_boolean_flag.py
+++ b/tests/test_bind_boolean_flag.py
@@ -275,3 +275,15 @@ def test_boolean_flag_uppercase_short_negative(app, cmd_str, expected, assert_pa
         pass
 
     assert_parse_args(foo, cmd_str, expected)
+
+
+def test_boolean_negative_alias_binds_false(app, assert_parse_args):
+    """A short negative alias sets the flag to False; generated negative is kept."""
+
+    @app.default
+    def foo(*, description: Annotated[bool, Parameter(negative_alias="-d")] = True):
+        pass
+
+    assert_parse_args(foo, "-d", description=False)
+    assert_parse_args(foo, "--no-description", description=False)
+    assert_parse_args(foo, "--description", description=True)

--- a/tests/test_error_console.py
+++ b/tests/test_error_console.py
@@ -224,3 +224,19 @@ def test_console_default_is_stdout():
 
     # Verify it's configured for stdout (default)
     assert console.file == sys.stdout
+
+
+def test_parse_error_exit_code_is_2(capfd):
+    """Usage/parse errors exit with code 2 (argparse/click convention),
+    distinguishing them from application failures (result_action False -> 1).
+    """
+    app = App()
+
+    @app.default
+    def main(*, flag: bool = False):
+        pass
+
+    with pytest.raises(SystemExit) as excinfo:
+        app("--invalid-option", exit_on_error=True, print_error=False)
+    assert excinfo.value.code == 2
+    capfd.readouterr()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -156,3 +156,36 @@ def test_parameter_attributes_are_kw_only():
         elif field.init:  # Only check fields that are part of __init__
             # All other init fields should be keyword-only
             assert field.kw_only, f"Field '{field.name}' should be keyword-only"
+
+
+def test_parameter_negative_alias_appends_to_generated():
+    """negative_alias is additive: the generated ``--no-*`` names are kept."""
+    p = Parameter(name=("--foo",), negative_alias="-F")
+    assert ("--no-foo", "-F") == p.get_negatives(bool)
+
+
+def test_parameter_negative_alias_multiple():
+    p = Parameter(name=("--foo",), negative_alias=("-F", "--nope"))
+    assert ("--no-foo", "-F", "--nope") == p.get_negatives(bool)
+
+
+def test_parameter_negative_alias_with_custom_negative():
+    """Also additive when ``negative`` replaces the generated names."""
+    p = Parameter(name=("--foo",), negative="--quiet", negative_alias="-q")
+    assert ("--quiet", "-q") == p.get_negatives(bool)
+
+
+def test_parameter_negative_alias_iterable():
+    p = Parameter(name=("--foo",), negative_alias="-E")
+    assert ("--empty-foo", "-E") == p.get_negatives(list)
+
+
+def test_parameter_negative_alias_non_negatable_type():
+    """Types without a negative-flag concept stay without negatives."""
+    p = Parameter(name=("--foo",), negative_alias="-F")
+    assert () == p.get_negatives(int)
+
+
+def test_parameter_negative_alias_no_duplicates():
+    p = Parameter(name=("--foo",), negative="--quiet", negative_alias="--quiet")
+    assert ("--quiet",) == p.get_negatives(bool)

--- a/tests/test_result_action.py
+++ b/tests/test_result_action.py
@@ -1618,3 +1618,39 @@ def test_cyclopts_returncode_default_zero_when_not_defined():
 
     assert result == 0
     assert buf.getvalue() == "Hello Alice!\n"
+
+
+def test_invalid_result_action_constructor_raises_eagerly():
+    """A typo'd action name fails at App construction, not at result-handling time."""
+    with pytest.raises(ValueError, match="Invalid result_action 'bogus'"):
+        App(result_action="bogus")  # pyright: ignore[reportArgumentType]
+
+
+def test_invalid_result_action_in_chain_constructor_raises_eagerly():
+    with pytest.raises(ValueError, match="Invalid result_action 'bogus'"):
+        App(result_action=["return_value", "bogus"])  # pyright: ignore[reportArgumentType]
+
+
+def test_invalid_result_action_runtime_override_raises_before_execution():
+    """An invalid invocation-time override fails before the command runs."""
+    app = App()
+    ran = []
+
+    @app.default
+    def main():
+        ran.append(True)
+
+    with pytest.raises(ValueError, match="Invalid result_action 'return'"):
+        app([], result_action="return", exit_on_error=False)  # pyright: ignore[reportArgumentType]
+    assert not ran
+
+
+def test_invalid_result_action_assignment_raises_eagerly():
+    app = App()
+    with pytest.raises(ValueError, match="Invalid result_action 'bogus'"):
+        app.result_action = "bogus"  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_result_action_error_lists_valid_actions():
+    with pytest.raises(ValueError, match="'return_value'"):
+        App(result_action="bogus")  # pyright: ignore[reportArgumentType]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -493,3 +493,31 @@ def test_shadowed_version_with_help_flag_shows_help(console):
         app(["sub", "--version", "--help"], console=console)
 
     assert "Usage: myapp sub" in capture.get()
+
+
+def test_version_flag_after_end_of_options_delimiter_is_positional():
+    """``--version`` after ``--`` is positional data, not a version request."""
+    from cyclopts import App
+
+    app = App(name="myapp", version="1.0.0", result_action="return_value")
+
+    @app.default
+    def main(*args: str):
+        return args
+
+    assert app(["--", "--version"], exit_on_error=False) == ("--version",)
+
+
+def test_version_flag_before_end_of_options_delimiter_still_intercepts(console):
+    from cyclopts import App
+
+    app = App(name="myapp", version="1.0.0", result_action="return_value")
+
+    @app.default
+    def main(*args: str):
+        return args
+
+    with console.capture() as capture:
+        app(["--version", "--", "x"], console=console)
+
+    assert "1.0.0\n" == capture.get()


### PR DESCRIPTION
## Summary

Final polish on top of `v5-develop` before tagging: two breaking-change cleanups that are cheapest to ship inside a major release (parse-error exit codes, `cyclopts tree -d`), one small feature that closes a `negative=` footgun (`Parameter.negative_alias`), eager validation of `result_action` names, and a "Migrating to v5" docs page covering every intentional breaking change accumulated on the v5 branch.

## Parse errors exit with code 2

CLI usage errors (unknown option, missing argument, coercion failure, ...) now `sys.exit(2)`, matching argparse and Click. Previously they exited `1` — indistinguishable from a command that ran and reported failure, since the default `result_action` maps a `False` return to exit code `1`. Application-level exit codes and `130` for `KeyboardInterrupt` are unchanged.

```console
$ myapp --bogus; echo $?
# before: 1
# after:  2
```

## `--version` respects the `--` delimiter

Version interception now uses the same delimiter-aware flag lookup as help (`_get_help_flag_index` generalized to `_get_flag_index`): a `--version` token after the end-of-options delimiter is positional data, not a version request.

```console
$ myapp -- --version
# before: printed the app version (command never ran)
# after:  the command runs; "--version" is bound positionally
```

## `Parameter.negative_alias`

*Additional* name(s) for a flag's negative form, appended to the generated `--no-*`/`--empty-*` (or `negative`-supplied) names. The `negative`/`negative_alias` pair mirrors `name`/`alias`: `negative` **replaces**, `negative_alias` **appends**. This closes the footgun where `negative="-d"` silently drops the generated `--no-*` long form, and avoids hardcoding the long negative just to add a short one. Primary use-case: a short flag that disables a default-on boolean.

```python
def main(*, description: Annotated[bool, Parameter(negative_alias="-d")] = True): ...
# -d               -> False
# --no-description -> False  (still generated)
# --description    -> True
```

## `cyclopts tree`: `-d` now *disables* descriptions (breaking)

`-d` was a positive alias for `--description` — a no-op, since descriptions default to on. It is now a negative alias (equivalent to `--no-description`), as originally intended, using `negative_alias` above.

## `result_action` names are validated eagerly

An invalid action name now raises a descriptive `ValueError` (listing the valid actions) at `App` construction, attribute assignment, or invocation-time override — **before** any command executes. Previously an invalid name was silently accepted and only raised a bare, message-less `ValueError` at result-handling time, after the command had already run its side effects.

```python
App(result_action="bogus")          # ValueError, raised immediately
app(tokens, result_action="bogus")  # ValueError, command never runs
```

Also fixes the `__call__`/`run_async` parameter docstrings, which claimed the inherited default is `"print_non_int_return_int_as_exit_code"`; the actual fallback (and the documented behavior everywhere else) is `"print_non_int_sys_exit"`.

## "Migrating to v5" docs page

New `docs/source/migration/v5.rst`, linked from the docs index, with before/after examples for each intentional breaking change on the v5 branch: fallthrough child-wins scoping, forwarded `*tokens` preserving the `--` delimiter, greedy `allow_leading_hyphen` `*args` subcommands claiming all post-command tokens, user parameters shadowing `--help`/`--version`, parse-error exit code 2, delimiter-aware `--version`, `cyclopts tree -d`, and the `result_action` validation + default exit-code contract.
