### PR TITLE
Validate `result_action` eagerly

### DIFF
--- a/cyclopts/_result_action.py
+++ b/cyclopts/_result_action.py
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Callable, Iterable
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, get_args, get_origin
 
 from cyclopts.utils import is_iterable
 
@@ -26,6 +26,25 @@ ResultActionSingle = (
 )
 
 ResultAction = ResultActionSingle | Iterable[ResultActionSingle]
+
+_RESULT_ACTION_NAMES: frozenset[str] = frozenset(
+    get_args(next(arg for arg in get_args(ResultActionSingle) if get_origin(arg) is Literal))
+)
+
+
+def validate_result_action(action: Any) -> None:
+    """Validate a single result action, raising a descriptive :class:`ValueError`.
+
+    Called eagerly (at :class:`App` construction and at invocation-time
+    overrides) so that a typo'd action name fails before any command executes.
+    """
+    if callable(action) or (isinstance(action, str) and action in _RESULT_ACTION_NAMES):
+        return
+    raise ValueError(
+        f"Invalid result_action {action!r}; must be a callable or one of: "
+        + ", ".join(map(repr, sorted(_RESULT_ACTION_NAMES)))
+        + "."
+    )
 
 
 def resolve_returncode(result: Any, default: int = 0) -> int:
@@ -172,4 +191,7 @@ def handle_result_action(
             print_fn(result)
             sys.exit(resolve_returncode(result))
         case _:
-            raise ValueError
+            # Values that bypassed eager validation (e.g. injected through a
+            # config layer) still get the descriptive error.
+            validate_result_action(action)
+            raise ValueError(f"Unhandled result_action: {action!r}")  # pragma: no cover

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -83,7 +83,7 @@ if TYPE_CHECKING:
     from cyclopts.help import HelpPanel
     from cyclopts.help.protocols import HelpFormatter
 
-from cyclopts._result_action import ResultAction, ResultActionSingle
+from cyclopts._result_action import ResultAction, ResultActionSingle, validate_result_action
 from cyclopts._run import _run_maybe_async_command
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -107,6 +107,9 @@ def _result_action_converter(
 
     if not result:
         raise ValueError("result_action cannot be an empty sequence")
+
+    for action in result:
+        validate_result_action(action)
 
     return result
 
@@ -2148,7 +2151,7 @@ class App:
         result_action: ResultAction | None
             Controls how command return values are handled. Can be a predefined literal string
             or a custom callable that takes the result and returns a processed value.
-            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_return_int_as_exit_code".
+            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_sys_exit".
             See :attr:`App.result_action` for available modes.
 
         Returns
@@ -2171,7 +2174,7 @@ class App:
                 "help_on_error": help_on_error,
                 "verbose": verbose,
                 "backend": backend,
-                "result_action": result_action,
+                "result_action": _result_action_converter(result_action),
                 "error_formatter": error_formatter,
             }.items()
             if v is not None
@@ -2253,7 +2256,7 @@ class App:
         result_action: ResultAction | None
             Controls how command return values are handled. Can be a predefined literal string
             or a custom callable that takes the result and returns a processed value.
-            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_return_int_as_exit_code".
+            If :obj:`None`, inherits from :attr:`App.result_action`, eventually defaulting to "print_non_int_sys_exit".
             See :attr:`App.result_action` for available modes.
 
         Returns
@@ -2300,7 +2303,7 @@ class App:
                 "help_on_error": help_on_error,
                 "verbose": verbose,
                 "backend": backend,
-                "result_action": result_action,
+                "result_action": _result_action_converter(result_action),
                 "error_formatter": error_formatter,
             }.items()
             if v is not None

--- a/tests/test_result_action.py
+++ b/tests/test_result_action.py
@@ -1618,3 +1618,39 @@ def test_cyclopts_returncode_default_zero_when_not_defined():
 
     assert result == 0
     assert buf.getvalue() == "Hello Alice!\n"
+
+
+def test_invalid_result_action_constructor_raises_eagerly():
+    """A typo'd action name fails at App construction, not at result-handling time."""
+    with pytest.raises(ValueError, match="Invalid result_action 'bogus'"):
+        App(result_action="bogus")  # pyright: ignore[reportArgumentType]
+
+
+def test_invalid_result_action_in_chain_constructor_raises_eagerly():
+    with pytest.raises(ValueError, match="Invalid result_action 'bogus'"):
+        App(result_action=["return_value", "bogus"])  # pyright: ignore[reportArgumentType]
+
+
+def test_invalid_result_action_runtime_override_raises_before_execution():
+    """An invalid invocation-time override fails before the command runs."""
+    app = App()
+    ran = []
+
+    @app.default
+    def main():
+        ran.append(True)
+
+    with pytest.raises(ValueError, match="Invalid result_action 'return'"):
+        app([], result_action="return", exit_on_error=False)  # pyright: ignore[reportArgumentType]
+    assert not ran
+
+
+def test_invalid_result_action_assignment_raises_eagerly():
+    app = App()
+    with pytest.raises(ValueError, match="Invalid result_action 'bogus'"):
+        app.result_action = "bogus"  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_result_action_error_lists_valid_actions():
+    with pytest.raises(ValueError, match="'return_value'"):
+        App(result_action="bogus")  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Split out of #849.

Invalid `result_action` names now raise a descriptive `ValueError` (naming the valid actions) at `App` construction, attribute assignment, or invocation-time override — **before** any command executes. Previously an invalid name was accepted everywhere and only exploded as a bare, message-less `raise ValueError` at result-handling time, after the command had already run its side effects.

- The `handle_result_action` fallback also raises descriptively now.
- Fixes the `__call__`/`run_async` parameter docstrings, which claimed the inherited default is `"print_non_int_return_int_as_exit_code"`; the actual fallback (and the documented behavior everywhere else) is `"print_non_int_sys_exit"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
