### PR TITLE
Add `Parameter.negative_alias`

### DIFF
--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -237,6 +237,13 @@ class Parameter:
         kw_only=True,
     )
 
+    # This can ONLY ever be a Tuple[str, ...]
+    negative_alias: None | str | Iterable[str] = field(
+        default=None,
+        converter=_str_tuple_converter,
+        kw_only=True,
+    )
+
     # This can ONLY ever be a Tuple[Union[Group, str], ...]
     group: None | Group | str | Iterable[Group | str] = field(
         default=None,
@@ -419,7 +426,7 @@ class Parameter:
                 (out if negative.startswith("-") else user_negatives).append(negative)
 
             if not user_negatives:
-                return tuple(out)
+                return self._extend_negative_aliases(out)
 
         assert isinstance(self.name, tuple)
         for name in self.name:
@@ -445,7 +452,20 @@ class Parameter:
             else:
                 for negative in user_negatives:
                     out.append(f"--{name_prefix}{negative}")
-        return tuple(out)
+        return self._extend_negative_aliases(out)
+
+    def _extend_negative_aliases(self, negatives: list[str]) -> tuple[str, ...]:
+        """Append :attr:`negative_alias` entries to the computed negative names.
+
+        Unlike :attr:`negative` (which *replaces* the generated negative names),
+        aliases are additive — mirroring the :attr:`name`/:attr:`alias`
+        relationship for positive names.
+        """
+        assert isinstance(self.negative_alias, tuple)
+        for negative_alias in self.negative_alias:
+            if negative_alias not in negatives:
+                negatives.append(negative_alias)
+        return tuple(negatives)
 
     def __repr__(self):
         """Only shows non-default values."""

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1176,6 +1176,38 @@ API
          │ --verbose --quiet  [default: False]                            │
          ╰────────────────────────────────────────────────────────────────╯
 
+   .. attribute:: negative_alias
+      :type: Union[None, str, Iterable[str]]
+      :value: None
+
+      *Additional* name(s) for the negative form of the flag, appended to the
+      generated (or :attr:`negative`-supplied) negative names. The
+      :attr:`negative`/:attr:`negative_alias` pair mirrors :attr:`name`/:attr:`alias`:
+      ``negative`` replaces, ``negative_alias`` appends.
+
+      The primary use-case is a short flag that *disables* a default-on boolean:
+
+      .. code-block:: python
+
+         from cyclopts import App, Parameter
+         from typing import Annotated
+
+         app = App()
+
+         @app.default
+         def main(*, description: Annotated[bool, Parameter(negative_alias="-d")] = True):
+            print(f"{description=}")
+
+         app()
+
+      .. code-block:: console
+
+         $ my-script -d
+         description=False
+
+         $ my-script --no-description
+         description=False
+
    .. attribute:: negative_bool
       :type: Optional[str]
       :value: None

--- a/tests/test_bind_boolean_flag.py
+++ b/tests/test_bind_boolean_flag.py
@@ -275,3 +275,15 @@ def test_boolean_flag_uppercase_short_negative(app, cmd_str, expected, assert_pa
         pass
 
     assert_parse_args(foo, cmd_str, expected)
+
+
+def test_boolean_negative_alias_binds_false(app, assert_parse_args):
+    """A short negative alias sets the flag to False; generated negative is kept."""
+
+    @app.default
+    def foo(*, description: Annotated[bool, Parameter(negative_alias="-d")] = True):
+        pass
+
+    assert_parse_args(foo, "-d", description=False)
+    assert_parse_args(foo, "--no-description", description=False)
+    assert_parse_args(foo, "--description", description=True)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -156,3 +156,36 @@ def test_parameter_attributes_are_kw_only():
         elif field.init:  # Only check fields that are part of __init__
             # All other init fields should be keyword-only
             assert field.kw_only, f"Field '{field.name}' should be keyword-only"
+
+
+def test_parameter_negative_alias_appends_to_generated():
+    """negative_alias is additive: the generated ``--no-*`` names are kept."""
+    p = Parameter(name=("--foo",), negative_alias="-F")
+    assert ("--no-foo", "-F") == p.get_negatives(bool)
+
+
+def test_parameter_negative_alias_multiple():
+    p = Parameter(name=("--foo",), negative_alias=("-F", "--nope"))
+    assert ("--no-foo", "-F", "--nope") == p.get_negatives(bool)
+
+
+def test_parameter_negative_alias_with_custom_negative():
+    """Also additive when ``negative`` replaces the generated names."""
+    p = Parameter(name=("--foo",), negative="--quiet", negative_alias="-q")
+    assert ("--quiet", "-q") == p.get_negatives(bool)
+
+
+def test_parameter_negative_alias_iterable():
+    p = Parameter(name=("--foo",), negative_alias="-E")
+    assert ("--empty-foo", "-E") == p.get_negatives(list)
+
+
+def test_parameter_negative_alias_non_negatable_type():
+    """Types without a negative-flag concept stay without negatives."""
+    p = Parameter(name=("--foo",), negative_alias="-F")
+    assert () == p.get_negatives(int)
+
+
+def test_parameter_negative_alias_no_duplicates():
+    p = Parameter(name=("--foo",), negative="--quiet", negative_alias="--quiet")
+    assert ("--quiet",) == p.get_negatives(bool)


### PR DESCRIPTION
Split out of #849.

`negative_alias` provides *additional* name(s) for a flag's negative form, appended to the generated `--no-*`/`--empty-*` (or `negative`-supplied) names. The `negative`/`negative_alias` pair mirrors `name`/`alias`: `negative` replaces, `negative_alias` appends. This avoids the footgun where `negative="-d"` silently drops the generated `--no-*` long form, and avoids hardcoding the long negative just to add a short one.

The `cyclopts tree -d` fix that motivated this is stacked on top as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
