### PR TITLE
Breaking: Exit 2 (instead of 1) on parse errors

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2012,7 +2012,7 @@ class App:
             Print a rich-formatted error on error.
             If :obj:`None`, inherits from :attr:`App.print_error`, eventually defaulting to :obj:`True`.
         exit_on_error: bool | None
-            If there is an error parsing the CLI tokens invoke ``sys.exit(1)``.
+            If there is an error parsing the CLI tokens invoke ``sys.exit(2)``.
             Otherwise, continue to raise the exception.
             If :obj:`None`, inherits from :attr:`App.exit_on_error`, eventually defaulting to :obj:`True`.
         help_on_error: bool | None
@@ -2085,7 +2085,7 @@ class App:
                     else:
                         e.console.print(CycloptsPanel(e))
                 if exit_on_error if exit_on_error is not None else True:
-                    sys.exit(1)
+                    sys.exit(2)
                 raise
 
         return command, bound, ignored
@@ -2128,7 +2128,7 @@ class App:
             Print a rich-formatted error on error.
             If :obj:`None`, inherits from :attr:`App.print_error`, eventually defaulting to :obj:`True`.
         exit_on_error: bool | None
-            If there is an error parsing the CLI tokens invoke ``sys.exit(1)``.
+            If there is an error parsing the CLI tokens invoke ``sys.exit(2)``.
             Otherwise, continue to raise the exception.
             If :obj:`None`, inherits from :attr:`App.exit_on_error`, eventually defaulting to :obj:`True`.
         help_on_error: bool | None
@@ -2233,7 +2233,7 @@ class App:
             Print a rich-formatted error on error.
             If :obj:`None`, inherits from :attr:`App.print_error`, eventually defaulting to :obj:`True`.
         exit_on_error: bool | None
-            If there is an error parsing the CLI tokens invoke ``sys.exit(1)``.
+            If there is an error parsing the CLI tokens invoke ``sys.exit(2)``.
             Otherwise, continue to raise the exception.
             If :obj:`None`, inherits from :attr:`App.exit_on_error`, eventually defaulting to :obj:`True`.
         help_on_error: bool | None

--- a/tests/test_error_console.py
+++ b/tests/test_error_console.py
@@ -224,3 +224,19 @@ def test_console_default_is_stdout():
 
     # Verify it's configured for stdout (default)
     assert console.file == sys.stdout
+
+
+def test_parse_error_exit_code_is_2(capfd):
+    """Usage/parse errors exit with code 2 (argparse/click convention),
+    distinguishing them from application failures (result_action False -> 1).
+    """
+    app = App()
+
+    @app.default
+    def main(*, flag: bool = False):
+        pass
+
+    with pytest.raises(SystemExit) as excinfo:
+        app("--invalid-option", exit_on_error=True, print_error=False)
+    assert excinfo.value.code == 2
+    capfd.readouterr()


### PR DESCRIPTION
Split out of #849.

CLI usage errors (unknown option, missing argument, coercion failure) now `sys.exit(2)`, matching argparse/click convention. Previously they exited `1`, indistinguishable from a command that ran and reported failure (the default `result_action` maps a `False` return to exit code `1`). Application-level exit codes and `130` for `KeyboardInterrupt` are unchanged.

Documented in the v5 migration guide (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
