### PR TITLE
Make `--version` respect the `--` delimiter

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1828,7 +1828,7 @@ class App:
             active_help_flags = tuple(f for f in command_app.help_flags if not _flag_shadowed_by_user_param(f))
             active_version_flags = tuple(f for f in command_app.version_flags if not _flag_shadowed_by_user_param(f))
 
-            help_flag_index = _get_help_flag_index(tokens, active_help_flags, end_of_options_delimiter)
+            help_flag_index = _get_flag_index(tokens, active_help_flags, end_of_options_delimiter)
 
             try:
                 if help_flag_index is not None:
@@ -1849,7 +1849,7 @@ class App:
                     bound = inspect.signature(command).bind(tokens, console=command_app.console)
                     unused_tokens = []
                     argument_collection = ArgumentCollection()
-                elif any(flag in tokens for flag in active_version_flags):
+                elif _get_flag_index(tokens, active_version_flags, end_of_options_delimiter) is not None:
                     command = _get_version_command(command_app)
                     while meta_parent := meta_parent._meta_parent:
                         command = _get_version_command(meta_parent)
@@ -3028,15 +3028,16 @@ class App:
         return f"{type(self).__name__}({signature})"
 
 
-def _get_help_flag_index(tokens, help_flags, end_of_options_delimiter) -> int | None:
+def _get_flag_index(tokens, flags, end_of_options_delimiter) -> int | None:
+    """Index of the first of ``flags`` in ``tokens``, ignoring tokens at/after the end-of-options delimiter."""
     delimiter_index = None
     if end_of_options_delimiter:
         with suppress(ValueError):
             delimiter_index = tokens.index(end_of_options_delimiter)
 
-    for help_flag in help_flags:
+    for flag in flags:
         with suppress(ValueError):
-            index = tokens.index(help_flag)
+            index = tokens.index(flag)
             if delimiter_index is None or index < delimiter_index:
                 break
     else:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -493,3 +493,31 @@ def test_shadowed_version_with_help_flag_shows_help(console):
         app(["sub", "--version", "--help"], console=console)
 
     assert "Usage: myapp sub" in capture.get()
+
+
+def test_version_flag_after_end_of_options_delimiter_is_positional():
+    """``--version`` after ``--`` is positional data, not a version request."""
+    from cyclopts import App
+
+    app = App(name="myapp", version="1.0.0", result_action="return_value")
+
+    @app.default
+    def main(*args: str):
+        return args
+
+    assert app(["--", "--version"], exit_on_error=False) == ("--version",)
+
+
+def test_version_flag_before_end_of_options_delimiter_still_intercepts(console):
+    from cyclopts import App
+
+    app = App(name="myapp", version="1.0.0", result_action="return_value")
+
+    @app.default
+    def main(*args: str):
+        return args
+
+    with console.capture() as capture:
+        app(["--version", "--", "x"], console=console)
+
+    assert "1.0.0\n" == capture.get()


### PR DESCRIPTION
Split out of #849.

Version interception now uses the same delimiter-aware flag lookup as help (`_get_help_flag_index` renamed to `_get_flag_index`): a `--version` token after `--` is positional data, not a version request — matching how `--help` already behaved.

Documented in the v5 migration guide (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
