### PR TITLE
Breaking: `cyclopts tree`: `-d` now disables descriptions

### DIFF
--- a/cyclopts/cli/tree.py
+++ b/cyclopts/cli/tree.py
@@ -14,7 +14,7 @@ def tree(
     script: str,
     /,
     *,
-    description: Annotated[bool, Parameter(alias="-d")] = True,
+    description: Annotated[bool, Parameter(negative_alias="-d")] = True,
     max_depth: Annotated[int | None, Parameter(alias="-m")] = None,
 ):
     """Display a tree of a Cyclopts application's commands.


### PR DESCRIPTION
Stacked on #851 (uses `Parameter.negative_alias`); split out of #849. When #851 merges, this retargets to `v5-develop`.

In the bundled `cyclopts tree` CLI tool, `-d` was a positive alias for `--description` — a no-op, since descriptions default to on. It is now a negative alias (`--no-description`), as originally intended.

```console
$ cyclopts tree demo.py
demo
└── hello  Say hello to the world.
$ cyclopts tree -d demo.py
demo
└── hello
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
