### PR TITLE
Fix Issue 857: pydantic dataclass default factory

### DIFF
--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -275,7 +275,10 @@ class Argument:
                     continue
                 if field_info.kind is field_info.VAR_KEYWORD:
                     self._default = field_info.annotation
-                else:
+                elif field_info.name not in self._lookup:
+                    # Fields already registered via ``get_field_infos`` have richer metadata
+                    # (e.g. resolved ``default_factory`` values) than the raw ``__init__``
+                    # signature; don't re-register them.
                     self._update_lookup({field_info.name: field_info})
 
         if self._accepts_keywords and len(hints) > 1:

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -363,34 +363,15 @@ def signature_parameters(f: Any) -> dict[str, FieldInfo]:
         annotation = type_hints.get(name, iparam.annotation)
         out[name] = FieldInfo.from_iparam(iparam, annotation=annotation)
 
-    if inspect.isclass(func) and is_dataclass(func):
-        # A dataclass's ``__init__`` signature uses a private sentinel as the default
-        # for ``default_factory`` fields; resolve it to the actual factory value.
-        import dataclasses
-
-        for dataclass_field in dataclasses.fields(func):
-            if dataclass_field.default_factory is not dataclasses.MISSING and dataclass_field.name in out:
-                out[dataclass_field.name] = out[dataclass_field.name].evolve(default=dataclass_field.default_factory())
-    elif inspect.isclass(func) and is_attrs(func):
-        # An attrs class's ``__init__`` signature uses the ``attrs.NOTHING`` sentinel as the
-        # default for factory fields; resolve it to the actual factory value.
-        # ``takes_self`` factories cannot be invoked without an instance; treat those
-        # fields as having no introspectable default.
-        for attribute in func.__attrs_attrs__:
-            if isinstance(attribute.default, attrs.Factory) and attribute.alias in out:  # pyright: ignore
-                default = FieldInfo.empty if attribute.default.takes_self else attribute.default.factory()
-                out[attribute.alias] = out[attribute.alias].evolve(default=default)
-    elif inspect.isclass(func) and is_pydantic(func):
-        # Pydantic's generated ``__signature__`` reuses dataclasses' private
-        # ``_HAS_DEFAULT_FACTORY`` sentinel as the default for ``default_factory`` fields.
-        # Pydantic factories may require validated data, so they cannot always be invoked;
-        # treat those fields as having no introspectable default (matching
-        # ``_pydantic_field_infos``).
-        for name, pydantic_field in getattr(func, "model_fields", {}).items():
-            if pydantic_field.default_factory is None:
-                continue
-            for candidate in (name, pydantic_field.alias):
-                if candidate and candidate in out:
-                    out[candidate] = out[candidate].evolve(default=FieldInfo.empty)
+    if inspect.isclass(func):
+        # ``inspect.signature`` on a class surfaces raw ``__init__`` defaults, which use
+        # library-private sentinels for factory fields (dataclasses' ``_HAS_DEFAULT_FACTORY``
+        # — also reused by pydantic's generated ``__signature__`` — and attrs' ``NOTHING``).
+        # ``get_field_infos`` already resolves defaults per-library; merge its
+        # default/requiredness over the raw signature values.
+        for name, field_info in get_field_infos(func).items():
+            for candidate in field_info.names or (name,):
+                if candidate in out:
+                    out[candidate] = out[candidate].evolve(default=field_info.default, required=field_info.required)
 
     return out

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -360,4 +360,14 @@ def signature_parameters(f: Any) -> dict[str, FieldInfo]:
     for name, iparam in inspect.signature(f).parameters.items():
         annotation = type_hints.get(name, iparam.annotation)
         out[name] = FieldInfo.from_iparam(iparam, annotation=annotation)
+
+    if inspect.isclass(func) and is_dataclass(func):
+        # A dataclass's ``__init__`` signature uses a private sentinel as the default
+        # for ``default_factory`` fields; resolve it to the actual factory value.
+        import dataclasses
+
+        for dataclass_field in dataclasses.fields(func):
+            if dataclass_field.default_factory is not dataclasses.MISSING and dataclass_field.name in out:
+                out[dataclass_field.name] = out[dataclass_field.name].evolve(default=dataclass_field.default_factory())
+
     return out

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -202,11 +202,23 @@ def _pydantic_field_infos(model) -> dict[str, FieldInfo]:
         else:
             annotation = pydantic_field.annotation
 
+        if pydantic_field.default_factory is not None:
+            try:
+                default = pydantic_field.get_default(call_default_factory=True)
+            except (TypeError, ValueError):
+                # Factories that require validated data cannot be invoked during introspection;
+                # treat those fields as having no introspectable default.
+                default = FieldInfo.empty
+        elif pydantic_field.default is PydanticUndefined:
+            default = FieldInfo.empty
+        else:
+            default = pydantic_field.default
+
         out[python_name] = FieldInfo(
             names=tuple(names),
             kind=inspect.Parameter.KEYWORD_ONLY if pydantic_field.kw_only else inspect.Parameter.POSITIONAL_OR_KEYWORD,
             annotation=annotation,
-            default=FieldInfo.empty if pydantic_field.default is PydanticUndefined else pydantic_field.default,
+            default=default,
             required=pydantic_field.is_required(),
             help=help,
         )

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -238,7 +238,9 @@ def _attrs_field_infos(hint) -> dict[str, FieldInfo]:
 
         if isinstance(attribute.default, attrs.Factory):  # pyright: ignore
             required = False
-            default = None  # Not strictly True, but we don't want to invoke factory
+            # ``takes_self`` factories cannot be invoked without an instance; treat those
+            # fields as having no introspectable default.
+            default = FieldInfo.empty if attribute.default.takes_self else attribute.default.factory()
         elif attribute.default is attrs.NOTHING:
             required = True
             default = FieldInfo.empty

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -380,5 +380,17 @@ def signature_parameters(f: Any) -> dict[str, FieldInfo]:
             if isinstance(attribute.default, attrs.Factory) and attribute.alias in out:  # pyright: ignore
                 default = FieldInfo.empty if attribute.default.takes_self else attribute.default.factory()
                 out[attribute.alias] = out[attribute.alias].evolve(default=default)
+    elif inspect.isclass(func) and is_pydantic(func):
+        # Pydantic's generated ``__signature__`` reuses dataclasses' private
+        # ``_HAS_DEFAULT_FACTORY`` sentinel as the default for ``default_factory`` fields.
+        # Pydantic factories may require validated data, so they cannot always be invoked;
+        # treat those fields as having no introspectable default (matching
+        # ``_pydantic_field_infos``).
+        for name, pydantic_field in getattr(func, "model_fields", {}).items():
+            if pydantic_field.default_factory is None:
+                continue
+            for candidate in (name, pydantic_field.alias):
+                if candidate and candidate in out:
+                    out[candidate] = out[candidate].evolve(default=FieldInfo.empty)
 
     return out

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -369,5 +369,14 @@ def signature_parameters(f: Any) -> dict[str, FieldInfo]:
         for dataclass_field in dataclasses.fields(func):
             if dataclass_field.default_factory is not dataclasses.MISSING and dataclass_field.name in out:
                 out[dataclass_field.name] = out[dataclass_field.name].evolve(default=dataclass_field.default_factory())
+    elif inspect.isclass(func) and is_attrs(func):
+        # An attrs class's ``__init__`` signature uses the ``attrs.NOTHING`` sentinel as the
+        # default for factory fields; resolve it to the actual factory value.
+        # ``takes_self`` factories cannot be invoked without an instance; treat those
+        # fields as having no introspectable default.
+        for attribute in func.__attrs_attrs__:
+            if isinstance(attribute.default, attrs.Factory) and attribute.alias in out:  # pyright: ignore
+                default = FieldInfo.empty if attribute.default.takes_self else attribute.default.factory()
+                out[attribute.alias] = out[attribute.alias].evolve(default=default)
 
     return out

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
@@ -413,7 +413,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--auth.provider`: Authentication provider type.  *[choices: oauth2, jwt, basic, none]*  *[default: jwt]*
 * `--auth.token-expiry`: Token expiration time in seconds.  *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh.  *[default: True]*
-* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.
+* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.  *[default: ['*']]*
 
 ### complex-cli server stop
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
@@ -27,7 +27,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--auth.provider`: Authentication provider type.  *[choices: oauth2, jwt, basic, none]*  *[default: jwt]*
 * `--auth.token-expiry`: Token expiration time in seconds.  *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh.  *[default: True]*
-* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.
+* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.  *[default: ['*']]*
 
 ### complex-cli server stop
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
@@ -112,7 +112,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--auth.provider`: Authentication provider type.  *[choices: oauth2, jwt, basic, none]*  *[default: jwt]*
 * `--auth.token-expiry`: Token expiration time in seconds.  *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh.  *[default: True]*
-* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.
+* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.  *[default: ['*']]*
 
 ### complex-cli server stop
 

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_full_app_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_full_app_rst.rst
@@ -633,7 +633,7 @@ Demonstrates Pydantic model support for CLI parameters.
     Enable token refresh. [Default: ``True``]
 
 ``--auth.allowed-origins, --auth.empty-allowed-origins``
-    List of allowed CORS origins.
+    List of allowed CORS origins. [Default: ``['*']``]
 
 .. _cyclopts-complex-cli-server-stop:
 

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_server_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_server_commands_rst.rst
@@ -90,7 +90,7 @@ Demonstrates Pydantic model support for CLI parameters.
     Enable token refresh. [Default: ``True``]
 
 ``--auth.allowed-origins, --auth.empty-allowed-origins``
-    List of allowed CORS origins.
+    List of allowed CORS origins. [Default: ``['*']``]
 
 .. _cyclopts-complex-cli-server-stop:
 

--- a/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_simple_directive_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_simple_directive_rst.rst
@@ -563,7 +563,7 @@ Demonstrates Pydantic model support for CLI parameters.
     Enable token refresh. [Default: ``True``]
 
 ``--auth.allowed-origins, --auth.empty-allowed-origins``
-    List of allowed CORS origins.
+    List of allowed CORS origins. [Default: ``['*']``]
 
 .. _cyclopts-complex-cli-server-stop:
 

--- a/tests/test_bind_attrs.py
+++ b/tests/test_bind_attrs.py
@@ -248,3 +248,23 @@ def test_attrs_inheritance_simple(app, console):
     # Check that both base and derived docstrings are present
     assert "BaseClass.some_arg docstring." in actual
     assert "DerivedClass.some_other_arg docstring." in actual
+
+
+def test_bind_attrs_command_factory_help(app, console):
+    """Attrs commands must not leak the ``attrs.NOTHING`` sentinel into help text.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+
+    @app.command
+    @define
+    class Test:
+        numbers: list[int] = field(factory=lambda: [1, 2, 3])
+
+    with console.capture() as capture:
+        app("test --help", console=console)
+
+    actual = capture.get()
+
+    assert "NOTHING" not in actual
+    assert "[default: [1, 2, 3]]" in actual

--- a/tests/test_bind_attrs.py
+++ b/tests/test_bind_attrs.py
@@ -53,7 +53,7 @@ def test_bind_attrs(app, assert_parse_args, console):
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  USER.ID --user.id      [required]                               │
         │    USER.NAME --user.name  [default: John Doe]                      │
-        │    --user.tastes                                                   │
+        │    --user.tastes          [default: {}]                            │
         │    --user.outfit.body                                              │
         │    --user.outfit.head                                              │
         │    --user.admin           [default: False]                         │
@@ -93,7 +93,7 @@ def test_bind_attrs_flatten(app, assert_parse_args, console):
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ *  ID --id              [required]                                 │
         │    NAME --name          [default: John Doe]                        │
-        │    --tastes                                                        │
+        │    --tastes             [default: {}]                              │
         │    --outfit.body                                                   │
         │    --outfit.head                                                   │
         │    --admin --not-admin  [default: False]                           │

--- a/tests/test_bind_attrs.py
+++ b/tests/test_bind_attrs.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 from typing import Annotated
 
 import pytest
-from attrs import define, field
+from attrs import Factory, define, field
 
 from cyclopts import Parameter
 from cyclopts.exceptions import MissingArgumentError, UnknownOptionError
@@ -268,3 +268,42 @@ def test_bind_attrs_command_factory_help(app, console):
 
     assert "NOTHING" not in actual
     assert "[default: [1, 2, 3]]" in actual
+
+
+def test_bind_attrs_command_takes_self_factory(app, console):
+    """``takes_self`` factories cannot be resolved during introspection.
+
+    The factory needs a constructed instance, so the field has no introspectable
+    default: help must not show one (and must not leak the ``attrs.NOTHING``
+    sentinel), yet the factory still runs at construction time when no token is
+    given, and an explicit token overrides it.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+
+    @app.command
+    @define
+    class Test:
+        base: int = 5
+        derived: int = field(default=Factory(lambda self: self.base * 2, takes_self=True))
+
+        def __call__(self) -> int:
+            return self.derived
+
+    with console.capture() as capture:
+        app("test --help", console=console)
+
+    actual = capture.get()
+
+    assert "NOTHING" not in actual
+    # ``derived`` has no introspectable default; only ``base`` shows one.
+    assert "[default: 5]" in actual
+    assert actual.count("[default:") == 1
+
+    # Factory resolves at construction when no token is provided.
+    assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == 10
+    assert app(["test", "--base", "10"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == 20
+    # Explicit token overrides the factory.
+    assert (
+        app(["test", "--derived", "99"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == 99
+    )

--- a/tests/test_bind_dataclasses.py
+++ b/tests/test_bind_dataclasses.py
@@ -836,3 +836,26 @@ def test_bind_dataclass_default_parameter_consume_multiple_propagates(assert_par
     assert actual_command == cmd
     assert actual_bind.args == ("my_office",)
     assert actual_bind.kwargs == {"inner": Inner(names=["name1", "name2"])}
+
+
+def test_bind_dataclass_accepts_keys_default_factory(app, assert_parse_args):
+    """Explicit ``accepts_keys=True`` on a dataclass with a ``default_factory`` field.
+
+    The field was registered twice — once via ``_dataclass_field_infos`` (factory
+    resolved) and once via ``signature_parameters(hint.__init__)`` (raw
+    ``_HAS_DEFAULT_FACTORY`` sentinel) — and the mismatch raised a bare
+    ``NotImplementedError``.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+
+    @dataclass
+    class Config:
+        numbers: list[int] = field(default_factory=lambda: [1, 2, 3])
+
+    @app.command
+    def cmd(config: Annotated[Config | None, Parameter(accepts_keys=True)] = None):
+        pass
+
+    assert_parse_args(cmd, "cmd")
+    assert_parse_args(cmd, "cmd --config.numbers=5", Config(numbers=[5]))

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -3175,7 +3175,7 @@ def test_help_pydantic_dict_list_basemodel_is_leaf(app, console):
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --models.{NAME}.path       path to data                            │
-        │ --models.{NAME}.items --m  list of items                           │
+        │ --models.{NAME}.items --m  list of items [default: []]             │
         │   odels.{NAME}.empty-item                                          │
         │   s                                                                │
         ╰────────────────────────────────────────────────────────────────────╯
@@ -3220,7 +3220,7 @@ def test_help_pydantic_dict_circular_reference(app, console):
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --root.{NAME}.label        node label                              │
-        │ --root.{NAME}.children.{N  child nodes                             │
+        │ --root.{NAME}.children.{N  child nodes [default: {}]               │
         │   AME}                                                             │
         ╰────────────────────────────────────────────────────────────────────╯
         """

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -940,4 +940,4 @@ def test_stdlib_dataclass_command_default_factory(app, assert_parse_args):
 
     assert_parse_args(Test, "test")
 
-    assert app(["test"], result_action="return_value", exit_on_error=False) == "[1, 2, 3]"
+    assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -943,6 +943,31 @@ def test_stdlib_dataclass_command_default_factory(app, assert_parse_args):
     assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"
 
 
+def test_attrs_nested_factory(app, assert_parse_args):
+    """Attrs fields with a ``factory`` must not have a substituted ``None`` default pydantic-validated.
+
+    ``_attrs_field_infos`` substituted ``default=None`` for factory fields; with
+    pydantic installed, that ``None`` was passed to
+    ``pydantic.TypeAdapter.validate_python`` against the field's real annotation
+    (e.g. ``list[int]``), raising a ValidationError even though the user provided
+    no tokens.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+    import attrs
+
+    @attrs.define
+    class Config:
+        numbers: list[int] = attrs.field(factory=lambda: [1, 2, 3])
+
+    @app.command
+    def cmd(config: Config | None = None):
+        pass
+
+    assert_parse_args(cmd, "cmd")
+    assert_parse_args(cmd, "cmd --config.numbers=5", Config(numbers=[5]))
+
+
 def test_attrs_command_factory(app, assert_parse_args):
     """Attrs commands with a ``factory`` must not be pydantic-validated against the ``NOTHING`` sentinel.
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -943,6 +943,29 @@ def test_stdlib_dataclass_command_default_factory(app, assert_parse_args):
     assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"
 
 
+def test_pydantic_basemodel_command_default_factory(app, assert_parse_args):
+    """BaseModel commands with a ``default_factory`` must not be validated against the sentinel.
+
+    Pydantic's generated ``__signature__`` reuses dataclasses'
+    ``_HAS_DEFAULT_FACTORY`` sentinel as the default for ``default_factory``
+    fields, which was passed to ``pydantic.TypeAdapter.validate_python``,
+    raising a ValidationError even though the user provided no tokens.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+
+    @app.command
+    class Test(BaseModel):
+        numbers: list[int] = Field(default_factory=lambda: [1, 2, 3])
+
+        def __call__(self) -> str:
+            return str(self.numbers)
+
+    assert_parse_args(Test, "test")
+
+    assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"
+
+
 def test_attrs_nested_factory(app, assert_parse_args):
     """Attrs fields with a ``factory`` must not have a substituted ``None`` default pydantic-validated.
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from textwrap import dedent
 from typing import Annotated, Literal
@@ -918,3 +918,26 @@ def test_pydantic_inheritance_simple(app, console):
     # Check that both base and derived field descriptions are present
     assert "Field from base pydantic model" in actual
     assert "Field from derived pydantic model" in actual
+
+
+def test_stdlib_dataclass_command_default_factory(app, assert_parse_args):
+    """Stdlib dataclass commands with a ``default_factory`` must not be pydantic-validated against the sentinel.
+
+    With pydantic installed, the unfilled ``default_factory`` sentinel
+    (``_HAS_DEFAULT_FACTORY``) was passed to ``pydantic.TypeAdapter.validate_python``,
+    raising a ValidationError even though the user provided no tokens.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+
+    @app.command
+    @dataclass
+    class Test:
+        numbers: list[int] = field(default_factory=lambda: [1, 2, 3])
+
+        def __call__(self) -> str:
+            return str(self.numbers)
+
+    assert_parse_args(Test, "test")
+
+    assert app(["test"], result_action="return_value", exit_on_error=False) == "[1, 2, 3]"

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -941,3 +941,28 @@ def test_stdlib_dataclass_command_default_factory(app, assert_parse_args):
     assert_parse_args(Test, "test")
 
     assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"
+
+
+def test_attrs_command_factory(app, assert_parse_args):
+    """Attrs commands with a ``factory`` must not be pydantic-validated against the ``NOTHING`` sentinel.
+
+    Attrs' generated ``__init__`` signature uses ``attrs.NOTHING`` as the default for
+    factory fields; with pydantic installed it was passed to
+    ``pydantic.TypeAdapter.validate_python``, raising a ValidationError even though
+    the user provided no tokens.
+
+    https://github.com/BrianPugh/cyclopts/issues/857
+    """
+    import attrs
+
+    @app.command
+    @attrs.define
+    class Test:
+        numbers: list[int] = attrs.field(factory=lambda: [1, 2, 3])
+
+        def __call__(self) -> str:
+            return str(self.numbers)
+
+    assert_parse_args(Test, "test")
+
+    assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1014,3 +1014,30 @@ def test_attrs_command_factory(app, assert_parse_args):
     assert_parse_args(Test, "test")
 
     assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"
+
+
+def test_pydantic_default_factory_help(app, console):
+    """Zero-arg ``default_factory`` values render in help, consistent with dataclass/attrs.
+
+    Factories that require validated data cannot be invoked during introspection,
+    so those fields show no default.
+    """
+
+    class Config(BaseModel):
+        numbers: list[int] = Field(default_factory=lambda: [1, 2, 3])
+        derived: int = Field(default_factory=lambda data: len(data["numbers"]))
+
+    @app.command
+    def nested(config: Config | None = None):
+        pass
+
+    @app.command
+    class Direct(BaseModel):
+        numbers: list[int] = Field(default_factory=lambda: [1, 2, 3])
+
+    for cmd in ("nested --help", "direct --help"):
+        with console.capture() as capture:
+            app(cmd, console=console)
+        actual = capture.get()
+        assert "[default: [1, 2, 3]]" in actual
+        assert "factory" not in actual


### PR DESCRIPTION
Fixes #857.

## Root cause

When a class is registered directly as a command, its parameters are derived from `inspect.signature(cls)` — and the raw `__init__` signature uses library-private sentinels as the "default" for factory fields:

| Library | Sentinel in `__init__` signature |
|---|---|
| `dataclasses` | `_HAS_DEFAULT_FACTORY` |
| pydantic `BaseModel` | `_HAS_DEFAULT_FACTORY` (reused by pydantic's generated `__signature__`) |
| attrs | `attrs.NOTHING` |

With pydantic installed, cyclopts validates argument defaults through `pydantic.TypeAdapter.validate_python`, which rejects these sentinels — so merely `import pydantic` broke otherwise-working dataclass commands. The sentinels also leaked into help text as `[default: <factory>]` / `[default: _Nothing.NOTHING]`.

Investigating the issue surfaced the same bug family in sibling paths, all fixed here (each with a regression test written and confirmed failing first):

## Fixes

- **Dataclass as command** (the original report): `default_factory` sentinel validated by pydantic; help showed `<factory>`.
- **attrs class as command**: same failure via the `attrs.NOTHING` sentinel; help showed `_Nothing.NOTHING`.
- **pydantic `BaseModel` as command**: same failure via pydantic's reuse of the dataclasses sentinel.
- **Nested attrs field with a factory**: `_attrs_field_infos` substituted `default=None` for factory fields, which pydantic then rejected against the real annotation (e.g. `list[int]`).
- **`Parameter(accepts_keys=True)` on a dataclass with a `default_factory` field**: raised a bare `NotImplementedError` — the field was registered twice (resolved default vs. raw sentinel) and the mismatch hit `_update_lookup`'s fallback. The `__init__`-signature fall-through now skips already-registered fields while retaining its real jobs (`**kwargs` capture, unrecognized types).

## Design

`signature_parameters` now resolves class defaults with a single merge of `get_field_infos()` values over the raw signature, so each library's factory policy lives in exactly one place (its `_*_field_infos` helper). That policy is now **consistent across dataclasses, attrs, and pydantic**: invoke the factory during introspection and use the result as the default. Factories that cannot be invoked without an instance — attrs `takes_self=True` and pydantic data-taking factories (`lambda data: ...`, pydantic ≥2.10) — are treated as having no introspectable default (nothing shown in help, nothing validated).

## User-visible behavior changes

Beyond the crash fixes, factory defaults now render in help text where they previously showed nothing (or a sentinel):

```text
╭─ Parameters ───────────────────────────────────────╮
│ NUMBERS --numbers  [default: [1, 2, 3]]            │
╰────────────────────────────────────────────────────╯
```

This applies to nested attrs fields and pydantic `default_factory` fields (dataclasses already behaved this way). Note that factories are now invoked at introspection time for attrs (they already were for dataclasses), so factories with side effects will run during help generation/parsing. Docs snapshots and expected help strings updated accordingly.

## Testing

- 7 new regression tests across `test_pydantic.py`, `test_bind_attrs.py`, and `test_bind_dataclasses.py`, each confirmed failing before its fix.
- Full suite passes (2536 passed); snapshot diffs audited to contain only the new `[default: ...]` annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
