### PR TITLE
fix: complete zsh subcommands after meta positionals

### DIFF
--- a/cyclopts/completion/_base.py
+++ b/cyclopts/completion/_base.py
@@ -10,6 +10,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args, get_origin
 
+from attrs import field
+
 from cyclopts.annotations import ITERABLE_TYPES, is_annotated, is_union
 from cyclopts.argument import ArgumentCollection
 from cyclopts.exceptions import CycloptsError
@@ -30,11 +32,33 @@ class CompletionAction(Enum):
 
 @frozen
 class CompletionData:
-    """Completion data for a command path."""
+    """Completion data for a command path.
+
+    Attributes
+    ----------
+    arguments : ArgumentCollection
+        Every argument contributing to this path (inherited meta positionals,
+        this path's meta launcher, and this path's plain default), flattened.
+        Keyword specs and the cyclopts-``run`` path consume the full list.
+    commands : list[RegisteredCommand]
+        Subcommands registered at this path.
+    help_format : str
+        Resolved help format for descriptions.
+    launcher_arguments : ArgumentCollection
+        Arguments contributed by *this path's* meta-app launcher
+        (``app.meta.default``). These are consumed before this path's
+        subcommand dispatch and therefore shift the subcommand's word slot.
+    own_arguments : ArgumentCollection
+        Arguments contributed by *this path's* plain ``@app.default``. These
+        are alternatives to the subcommand at the same word slot and must
+        never shift it.
+    """
 
     arguments: "ArgumentCollection"
     commands: list[RegisteredCommand]
     help_format: str
+    launcher_arguments: "ArgumentCollection" = field(factory=ArgumentCollection)
+    own_arguments: "ArgumentCollection" = field(factory=ArgumentCollection)
 
 
 def extract_completion_data(app: "App") -> dict[tuple[str, ...], CompletionData]:
@@ -67,12 +91,27 @@ def extract_completion_data(app: "App") -> dict[tuple[str, ...], CompletionData]
             )
             return
 
-        from cyclopts.core import _iter_resolution_argument_collections
+        from cyclopts.core import _iter_resolution_argument_collections, _walk_metas
 
+        # Classify each contributing app's arguments by provenance (see
+        # ``CompletionData`` for what ``launcher_arguments``/``own_arguments``
+        # mean to the shell generators):
+        #   * inherited -- an ancestor path's meta launcher; already consumed, skip.
+        #   * launcher  -- this path's own meta-app default (``_meta_parent`` set).
+        #   * own       -- this path's plain ``@app.default``.
+        current = list(_walk_metas(command_app))
         arguments = ArgumentCollection()
+        launcher_arguments = ArgumentCollection()
+        own_arguments = ArgumentCollection()
         with app.app_stack(execution_path):
-            for _, app_arguments in _iter_resolution_argument_collections(execution_path, parse_docstring=True):
+            for subapp, app_arguments in _iter_resolution_argument_collections(execution_path, parse_docstring=True):
                 arguments.extend(app_arguments)
+                if not any(subapp is a for a in current):
+                    continue  # inherited (ancestor meta launcher)
+                if subapp._meta_parent is not None:
+                    launcher_arguments.extend(app_arguments)  # this path's meta launcher
+                else:
+                    own_arguments.extend(app_arguments)  # plain @app.default
 
         commands = []
         for group, registered_commands in groups_from_app(command_app, resolve_lazy=True):
@@ -83,7 +122,13 @@ def extract_completion_data(app: "App") -> dict[tuple[str, ...], CompletionData]
 
         help_format = command_app.app_stack.resolve("help_format", fallback="markdown")
 
-        completion_data[command_path] = CompletionData(arguments=arguments, commands=commands, help_format=help_format)
+        completion_data[command_path] = CompletionData(
+            arguments=arguments,
+            commands=commands,
+            help_format=help_format,
+            launcher_arguments=launcher_arguments,
+            own_arguments=own_arguments,
+        )
 
         for registered_command in commands:
             for cmd_name in registered_command.names:

--- a/cyclopts/completion/bash.py
+++ b/cyclopts/completion/bash.py
@@ -411,7 +411,11 @@ def _generate_completions_for_path(
             if not cmd_name.startswith("-"):
                 commands.append(cmd_name)
 
-    positional_args = [arg for arg in data.arguments if arg.index is not None and arg.show]
+    # Exclude inherited (ancestor-meta) positionals: they were consumed before
+    # this path's command name, so they must not claim a slot here. (This PR
+    # does not attempt the full #759-style subcommand shifting for bash.)
+    local_arguments = data.launcher_arguments + data.own_arguments
+    positional_args = [arg for arg in local_arguments if arg.index is not None and arg.show]
     positional_args.sort(key=lambda a: a.index if a.index is not None else 0)
 
     lines.append(f"{indent}if [[ ${{cur}} == -* ]]; then")

--- a/cyclopts/completion/fish.py
+++ b/cyclopts/completion/fish.py
@@ -402,7 +402,11 @@ def _generate_positional_completions(
     if not command_path:
         return []
 
-    positional_args = [arg for arg in data.arguments if arg.index is not None and arg.show]
+    # Exclude inherited (ancestor-meta) positionals: they were consumed before
+    # this path's command name, so they must not claim a slot here. (This PR
+    # does not attempt the full #759-style subcommand shifting for fish.)
+    local_arguments = data.launcher_arguments + data.own_arguments
+    positional_args = [arg for arg in local_arguments if arg.index is not None and arg.show]
     if not positional_args:
         return []
 

--- a/cyclopts/completion/zsh.py
+++ b/cyclopts/completion/zsh.py
@@ -261,6 +261,36 @@ def _generate_describe_completion(
     return lines
 
 
+def _get_local_arguments(
+    completion_data: dict[tuple[str, ...], CompletionData],
+    command_path: tuple[str, ...],
+) -> list["Argument"]:
+    """Return arguments introduced at ``command_path``.
+
+    Completion data includes arguments inherited from parent meta apps. Those
+    arguments were already consumed before the current command, so they must
+    not be assigned another positional slot at a nested path.
+    """
+    arguments = list(completion_data[command_path].arguments)
+    if not command_path:
+        return arguments
+
+    parent_data = completion_data.get(command_path[:-1])
+    if parent_data is None:
+        return arguments
+
+    inherited = list(parent_data.arguments)
+    local = []
+    for argument in arguments:
+        for index, inherited_argument in enumerate(inherited):
+            if argument == inherited_argument:
+                inherited.pop(index)
+                break
+        else:
+            local.append(argument)
+    return local
+
+
 def _generate_completion_for_path(
     completion_data: dict[tuple[str, ...], CompletionData],
     command_path: tuple[str, ...],
@@ -294,6 +324,7 @@ def _generate_completion_for_path(
     data = completion_data[command_path]
     commands = data.commands
     arguments = data.arguments
+    local_arguments = _get_local_arguments(completion_data, command_path)
     indent_str = " " * indent
     lines = []
 
@@ -306,7 +337,7 @@ def _generate_completion_for_path(
 
     # Separate positional from keyword arguments
     # Include all arguments with an index (both positional-only and positional-or-keyword)
-    positional_args = [arg for arg in arguments if arg.index is not None and arg.show]
+    positional_args = [arg for arg in local_arguments if arg.index is not None and arg.show]
     keyword_args = [arg for arg in arguments if not arg.is_positional_only() and arg.show]
 
     # Sort positionals by index (should never be None for positional-only args)
@@ -342,12 +373,22 @@ def _generate_completion_for_path(
         not cmd_name.startswith("-") for registered_command in commands for cmd_name in registered_command.names
     )
 
-    # Generate positional argument specs
-    # Only add positionals if there are no subcommands (they conflict in zsh)
-    if positional_args and not has_non_flag_commands:
+    # Generate positional argument specs. Fixed positionals can precede a
+    # subcommand (most commonly on a meta app); the command state is shifted
+    # past them below. A variadic positional has no deterministic end, so keep
+    # the historical behavior of omitting it when subcommands are present.
+    positionals_for_specs = positional_args
+    if has_non_flag_commands:
+        positionals_for_specs = [
+            arg
+            for arg in positional_args
+            if arg.is_positional_only() and not arg.is_var_positional() and not is_iterable_type(arg.hint)
+        ]
+
+    if positionals_for_specs:
         if command_path:
-            # Nested context: use shifted positional indexing (words[1] is subcommand)
-            positional_specs = _generate_nested_positional_specs(positional_args, data.help_format)
+            # Nested context: position 1 is the first argument after the parent command.
+            positional_specs = _generate_nested_positional_specs(positionals_for_specs, data.help_format)
         else:
             # Root context: standard _arguments works fine. As in the
             # nested helper, only one rest-arg (``*:``) spec is allowed —
@@ -355,11 +396,11 @@ def _generate_completion_for_path(
             # (var-positional preferred). The other iterables remain
             # available via their ``--name`` keyword specs.
             seen_rest = False
-            iterable_args = [a for a in positional_args if a.is_var_positional() or is_iterable_type(a.hint)]
+            iterable_args = [a for a in positionals_for_specs if a.is_var_positional() or is_iterable_type(a.hint)]
             chosen_rest = next((a for a in iterable_args if a.is_var_positional()), None)
             if chosen_rest is None and iterable_args:
                 chosen_rest = iterable_args[0]
-            for argument in positional_args:
+            for argument in positionals_for_specs:
                 is_rest = argument.is_var_positional() or is_iterable_type(argument.hint)
                 if is_rest:
                     if argument is not chosen_rest or seen_rest:
@@ -371,8 +412,12 @@ def _generate_completion_for_path(
         # Add positionals BEFORE options to prioritize them in completion
         args_specs = positional_specs + args_specs
 
+    command_position = 1
+    if positionals_for_specs:
+        command_position = max(1 + (arg.index or 0) for arg in positionals_for_specs) + 1
+
     if has_non_flag_commands:
-        args_specs.append("'1: :->cmds'")
+        args_specs.append(f"'{command_position}: :->cmds'")
         args_specs.append("'*::arg:->args'")
 
     # Eq-form pre-pass: zsh's ``_arguments`` only handles ``--opt=value``
@@ -416,7 +461,7 @@ def _generate_completion_for_path(
         lines.append(f"{indent_str}    ;;")
 
         lines.append(f"{indent_str}  args)")
-        lines.append(f"{indent_str}    case $words[1] in")
+        lines.append(f"{indent_str}    case $words[{command_position}] in")
 
         for registered_command in commands:
             for cmd_name in registered_command.names:

--- a/cyclopts/completion/zsh.py
+++ b/cyclopts/completion/zsh.py
@@ -27,6 +27,44 @@ if TYPE_CHECKING:
     from cyclopts.command_spec import CommandSpec
 
 
+def _is_variadic(arg: "Argument") -> bool:
+    """Whether ``arg`` consumes an unbounded number of words positionally.
+
+    Covers both ``*args`` var-positionals and collection-typed positionals
+    (``list[X]``, ``set[X]``, ``tuple[X, ...]``, ...), which zsh must model with
+    a single rest-arg (``*:``) spec rather than a numbered position.
+
+    Parameters
+    ----------
+    arg : Argument
+        Argument to inspect.
+
+    Returns
+    -------
+    bool
+        True if the argument is variadic/iterable.
+    """
+    return arg.is_var_positional() or is_iterable_type(arg.hint)
+
+
+def _choose_rest_arg(positional_args: list["Argument"]) -> "Argument | None":
+    """Pick the single positional that becomes zsh's rest-arg (``*:``) spec.
+
+    zsh's ``_arguments`` errors with "doubled rest argument definition" if more
+    than one ``*:`` spec is present, so multiple variadic positionals (e.g.
+    several ``list[X]`` defaults) must collapse to one. A true var-positional
+    (``*args``) is preferred; otherwise the first iterable wins. The others
+    remain reachable via their ``--name`` keyword specs emitted elsewhere.
+
+    Returns ``None`` when there is no variadic positional.
+    """
+    variadic_args = [arg for arg in positional_args if _is_variadic(arg)]
+    var_positional = next((a for a in variadic_args if a.is_var_positional()), None)
+    if var_positional is not None:
+        return var_positional
+    return variadic_args[0] if variadic_args else None
+
+
 def generate_completion_script(app: "App", prog_name: str) -> str:
     """Generate zsh completion script.
 
@@ -149,6 +187,7 @@ def _generate_run_command_completion(
 def _generate_nested_positional_specs(
     positional_args: list["Argument"],
     help_format: str,
+    offset: int = 0,
 ) -> list[str]:
     """Generate positional argument specs for nested command context.
 
@@ -163,53 +202,24 @@ def _generate_nested_positional_specs(
         Positional arguments to generate specs for.
     help_format : str
         Help text format.
+    offset : int
+        Number of preceding positional slots to skip (e.g. fixed launcher
+        positionals that come before these arguments on the command line).
 
     Returns
     -------
     list[str]
         List of zsh positional argument specs.
     """
-    specs = []
+    # Emit fixed positionals first (each at ``arg.index + 1 + offset``), then at
+    # most one rest-arg (``*:``) spec -- ``_generate_positional_spec`` computes
+    # both forms from the argument itself.
+    non_variadic_args = [arg for arg in positional_args if not _is_variadic(arg)]
+    specs = [_generate_positional_spec(arg, help_format, offset=offset) for arg in non_variadic_args]
 
-    # Check if we have variadic positionals (including collection types like list[X])
-    variadic_args = [arg for arg in positional_args if arg.is_var_positional() or is_iterable_type(arg.hint)]
-    non_variadic_args = [
-        arg for arg in positional_args if not arg.is_var_positional() and not is_iterable_type(arg.hint)
-    ]
-
-    def _build(arg, position: str) -> str:
-        choices = arg.get_choices(force=True)
-        if choices:
-            escaped_choices = [_escape_choice_for_dq_spec(clean_choice_text(c)) for c in choices]
-            choices_str = " ".join(escaped_choices)
-            action = f"({choices_str})"
-            desc = _escape_zsh_description_dq(_description_text(arg, help_format))
-            quote = '"'
-        else:
-            action = _map_completion_action_to_zsh(get_completion_action(arg.hint))
-            desc = _get_description_from_argument(arg, help_format)
-            quote = "'"
-        return f"{quote}{position}:{desc}:{action}{quote}" if action else f"{quote}{position}:{desc}{quote}"
-
-    # Generate specs for non-variadic positionals
-    for arg in non_variadic_args:
-        # Position in nested context: After *::arg:->args, $words[1] is the subcommand
-        # So positionals start at position 1 (not 2)
-        # Use 1-based indexing: first positional is '1:', second is '2:', etc.
-        pos = 1 + (arg.index or 0)
-        specs.append(_build(arg, str(pos)))
-
-    # Emit at most one rest-arg (``*:``) spec. zsh's ``_arguments`` errors
-    # with "doubled rest argument definition" if more than one is present.
-    # When a function has multiple iterable positional-or-keyword params
-    # (e.g. several ``list[X]`` defaults), only the first can realistically
-    # be filled positionally — the others remain available via their
-    # ``--name`` keyword forms emitted elsewhere.
-    chosen = next((a for a in variadic_args if a.is_var_positional()), None)
-    if chosen is None and variadic_args:
-        chosen = variadic_args[0]
+    chosen = _choose_rest_arg(positional_args)
     if chosen is not None:
-        specs.append(_build(chosen, "*"))
+        specs.append(_generate_positional_spec(chosen, help_format, offset=offset))
 
     return specs
 
@@ -261,34 +271,75 @@ def _generate_describe_completion(
     return lines
 
 
-def _get_local_arguments(
-    completion_data: dict[tuple[str, ...], CompletionData],
-    command_path: tuple[str, ...],
-) -> list["Argument"]:
-    """Return arguments introduced at ``command_path``.
+def _generate_root_positional_specs(
+    positional_args: list["Argument"],
+    help_format: str,
+    offset: int = 0,
+) -> list[str]:
+    """Generate positional specs for the root (non-nested) command context.
 
-    Completion data includes arguments inherited from parent meta apps. Those
-    arguments were already consumed before the current command, so they must
-    not be assigned another positional slot at a nested path.
+    Unlike the nested helper, at the root ``_arguments`` sees the real
+    command line, so positions are ``arg.index + 1`` (plus ``offset``). Only
+    one rest-arg (``*:``) spec is allowed, so multiple iterable positionals
+    collapse to the first (var-positional preferred); the others remain
+    reachable via their ``--name`` keyword specs.
+
+    Parameters
+    ----------
+    positional_args : list[Argument]
+        Positional arguments to generate specs for.
+    help_format : str
+        Help text format.
+    offset : int
+        Number of preceding positional slots to skip.
+
+    Returns
+    -------
+    list[str]
+        List of zsh positional argument specs.
     """
-    arguments = list(completion_data[command_path].arguments)
-    if not command_path:
-        return arguments
+    specs: list[str] = []
+    chosen_rest = _choose_rest_arg(positional_args)
+    for argument in positional_args:
+        # Keep only the one chosen rest-arg; drop every other variadic positional.
+        if _is_variadic(argument) and argument is not chosen_rest:
+            continue
+        specs.append(_generate_positional_spec(argument, help_format, offset=offset))
+    return specs
 
-    parent_data = completion_data.get(command_path[:-1])
-    if parent_data is None:
-        return arguments
 
-    inherited = list(parent_data.arguments)
-    local = []
-    for argument in arguments:
-        for index, inherited_argument in enumerate(inherited):
-            if argument == inherited_argument:
-                inherited.pop(index)
-                break
-        else:
-            local.append(argument)
-    return local
+def _generate_positional_specs(
+    positional_args: list["Argument"],
+    command_path: tuple[str, ...],
+    help_format: str,
+    offset: int = 0,
+) -> list[str]:
+    """Dispatch positional-spec generation to the root or nested helper."""
+    if not positional_args:
+        return []
+    if command_path:
+        return _generate_nested_positional_specs(positional_args, help_format, offset=offset)
+    return _generate_root_positional_specs(positional_args, help_format, offset=offset)
+
+
+def _cap_rest_specs(specs: list[str]) -> list[str]:
+    """Drop every rest-arg (``*:``) spec after the first.
+
+    zsh's ``_arguments`` errors with "doubled rest argument definition" if more
+    than one ``*:`` spec is present. When positional specs from two provenance
+    groups (launcher + own) are concatenated, each group may contribute a rest
+    spec; keep only the first.
+    """
+    result: list[str] = []
+    seen_rest = False
+    for spec in specs:
+        # Specs are quoted (``'...'`` or ``"..."``); a rest spec's body is ``*:``.
+        if spec[1:].startswith("*:"):
+            if seen_rest:
+                continue
+            seen_rest = True
+        result.append(spec)
+    return result
 
 
 def _generate_completion_for_path(
@@ -324,7 +375,6 @@ def _generate_completion_for_path(
     data = completion_data[command_path]
     commands = data.commands
     arguments = data.arguments
-    local_arguments = _get_local_arguments(completion_data, command_path)
     indent_str = " " * indent
     lines = []
 
@@ -335,13 +385,24 @@ def _generate_completion_for_path(
     args_specs = []
     positional_specs = []
 
-    # Separate positional from keyword arguments
-    # Include all arguments with an index (both positional-only and positional-or-keyword)
-    positional_args = [arg for arg in local_arguments if arg.index is not None and arg.show]
-    keyword_args = [arg for arg in arguments if not arg.is_positional_only() and arg.show]
+    # Positional arguments, split by provenance (see ``CompletionData`` for what
+    # each group means): launcher positionals shift the subcommand's word slot,
+    # own positionals never do. Inherited (ancestor-meta) positionals are in
+    # neither group -- consumed before this path's command name, so no slot here.
+    launcher_positionals = sorted(
+        (arg for arg in data.launcher_arguments if arg.index is not None),
+        key=lambda a: a.index or 0,
+    )
+    own_positionals = sorted(
+        (arg for arg in data.own_arguments if arg.index is not None and arg.show),
+        key=lambda a: a.index or 0,
+    )
+    # Fixed (non-variadic) launcher positionals each consume exactly one word.
+    # Count them regardless of ``show`` -- a hidden fixed positional still
+    # occupies a slot on the command line (so it still shifts the subcommand).
+    fixed_launcher = [arg for arg in launcher_positionals if not _is_variadic(arg)]
 
-    # Sort positionals by index (should never be None for positional-only args)
-    positional_args.sort(key=lambda a: a.index or 0)
+    keyword_args = [arg for arg in arguments if not arg.is_positional_only() and arg.show]
 
     # Generate keyword argument specs
     for argument in keyword_args:
@@ -373,48 +434,45 @@ def _generate_completion_for_path(
         not cmd_name.startswith("-") for registered_command in commands for cmd_name in registered_command.names
     )
 
-    # Generate positional argument specs. Fixed positionals can precede a
-    # subcommand (most commonly on a meta app); the command state is shifted
-    # past them below. A variadic positional has no deterministic end, so keep
-    # the historical behavior of omitting it when subcommands are present.
-    positionals_for_specs = positional_args
+    # Positional specs and the subcommand's word slot.
+    command_position = 1
     if has_non_flag_commands:
-        positionals_for_specs = [
-            arg
-            for arg in positional_args
-            if arg.is_positional_only() and not arg.is_var_positional() and not is_iterable_type(arg.hint)
-        ]
+        # The subcommand slot shifts past the fixed launcher positionals only
+        # when every one of them is required (occupies a definite word) and
+        # they form a contiguous prefix (indices 0..k-1) -- a variadic
+        # positional interleaved among them would consume an unbounded number
+        # of words, making every later slot non-deterministic.
+        # Required positional-or-keyword args count the same as positional-only
+        # here: the dominant launcher usage is positional (``prog 5 sub``); the
+        # ``--opt value`` form would offset the slot -- an accepted trade-off.
+        contiguous_prefix = [arg.index for arg in fixed_launcher] == list(range(len(fixed_launcher)))
+        shift_deterministic = contiguous_prefix and all(arg.required for arg in fixed_launcher)
+        if shift_deterministic and fixed_launcher:
+            # ``contiguous_prefix`` guarantees indices are exactly ``0..k-1``, so
+            # the subcommand sits one slot past the last launcher positional.
+            command_position = len(fixed_launcher) + 1
+            # Emit specs for the *shown* fixed launcher positionals only.
+            shown_launcher = [arg for arg in fixed_launcher if arg.show]
+            positional_specs = _generate_positional_specs(shown_launcher, command_path, data.help_format)
+        # Non-deterministic shift (some fixed launcher positional is optional)
+        # or no launcher positionals: ``command_position`` stays 1 and own
+        # positionals get no specs -- they are alternatives to the subcommand
+        # at the same slot (pre-PR rule).
+    else:
+        # No subcommands: launcher and own positionals both complete. Own
+        # indices are offset past the fixed launcher positionals that precede
+        # them on the command line. A single rest-arg (``*:``) cap holds across
+        # both groups combined.
+        launcher_shown = [arg for arg in launcher_positionals if arg.show]
+        positional_specs = _generate_positional_specs(launcher_shown, command_path, data.help_format)
+        positional_specs += _generate_positional_specs(
+            own_positionals, command_path, data.help_format, offset=len(fixed_launcher)
+        )
+        positional_specs = _cap_rest_specs(positional_specs)
 
-    if positionals_for_specs:
-        if command_path:
-            # Nested context: position 1 is the first argument after the parent command.
-            positional_specs = _generate_nested_positional_specs(positionals_for_specs, data.help_format)
-        else:
-            # Root context: standard _arguments works fine. As in the
-            # nested helper, only one rest-arg (``*:``) spec is allowed —
-            # collapse multiple iterable positionals to the first one
-            # (var-positional preferred). The other iterables remain
-            # available via their ``--name`` keyword specs.
-            seen_rest = False
-            iterable_args = [a for a in positionals_for_specs if a.is_var_positional() or is_iterable_type(a.hint)]
-            chosen_rest = next((a for a in iterable_args if a.is_var_positional()), None)
-            if chosen_rest is None and iterable_args:
-                chosen_rest = iterable_args[0]
-            for argument in positionals_for_specs:
-                is_rest = argument.is_var_positional() or is_iterable_type(argument.hint)
-                if is_rest:
-                    if argument is not chosen_rest or seen_rest:
-                        continue
-                    seen_rest = True
-                spec = _generate_positional_spec(argument, data.help_format)
-                positional_specs.append(spec)
-
+    if positional_specs:
         # Add positionals BEFORE options to prioritize them in completion
         args_specs = positional_specs + args_specs
-
-    command_position = 1
-    if positionals_for_specs:
-        command_position = max(1 + (arg.index or 0) for arg in positionals_for_specs) + 1
 
     if has_non_flag_commands:
         args_specs.append(f"'{command_position}: :->cmds'")
@@ -461,7 +519,17 @@ def _generate_completion_for_path(
         lines.append(f"{indent_str}    ;;")
 
         lines.append(f"{indent_str}  args)")
-        lines.append(f"{indent_str}    case $words[{command_position}] in")
+        # Normalize the ``$words`` frame so the subcommand sits at ``$words[1]``.
+        # When ``command_position > 1`` the fixed launcher positionals occupy
+        # ``$words[1..k]`` here (standard zsh precommand idiom); dropping them
+        # lets the recursively-inlined child code use its own command name at
+        # ``$words[1]`` and its own ``pos = 1 + arg.index`` slots, unchanged at
+        # any nesting depth.
+        k = command_position - 1
+        if k >= 1:
+            lines.append(f"{indent_str}    shift {k} words")
+            lines.append(f"{indent_str}    (( CURRENT -= {k} ))")
+        lines.append(f"{indent_str}    case $words[1] in")
 
         for registered_command in commands:
             for cmd_name in registered_command.names:
@@ -799,7 +867,7 @@ def _generate_keyword_specs(argument: "Argument", help_format: str) -> list[str]
     return specs
 
 
-def _generate_positional_spec(argument: "Argument", help_format: str) -> str:
+def _generate_positional_spec(argument: "Argument", help_format: str, offset: int = 0) -> str:
     """Generate zsh _arguments spec for a positional argument.
 
     Parameters
@@ -808,6 +876,8 @@ def _generate_positional_spec(argument: "Argument", help_format: str) -> str:
         Positional argument object.
     help_format : str
         Help text format.
+    offset : int
+        Number of preceding positional slots to skip.
 
     Returns
     -------
@@ -828,14 +898,14 @@ def _generate_positional_spec(argument: "Argument", help_format: str) -> str:
         desc = _get_description_from_argument(argument, help_format)
         quote = "'"
 
-    if argument.is_var_positional() or is_iterable_type(argument.hint):
+    if _is_variadic(argument):
         # Variadic positional (*args) or collection type (list[X], set[X], etc.)
         return f"{quote}*:{desc}:{action}{quote}" if action else f"{quote}*:{desc}{quote}"
 
     # Regular positional - zsh uses 1-based indexing
     if argument.index is None:
         raise ValueError(f"Positional-only argument {argument.names} missing index")
-    pos = argument.index + 1
+    pos = argument.index + 1 + offset
     return f"{quote}{pos}:{desc}:{action}{quote}" if action else f"{quote}{pos}:{desc}{quote}"
 
 

--- a/tests/completion/test_zsh.py
+++ b/tests/completion/test_zsh.py
@@ -156,6 +156,183 @@ def test_meta_positional_before_subcommand(zsh_tester):
     assert "mute" not in tester.get_completions("vban strip ")
 
 
+def _make_meta_wrapped_app(launcher_signature: str = "positional_only") -> App:
+    """Build the vban/strip/mute meta-app shape used by the meta-positional tests."""
+    root = App(name="vban")
+    strip = App(name="strip")
+    root.command(strip.meta, name="strip")
+
+    if launcher_signature == "positional_only":
+
+        @strip.meta.default
+        def strip_launcher(
+            index: int,
+            /,
+            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+        ):
+            pass
+
+    elif launcher_signature == "positional_or_keyword":
+
+        @strip.meta.default
+        def strip_launcher_pos_or_kw(
+            index: int,
+            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+        ):
+            pass
+
+    elif launcher_signature == "optional_positional":
+
+        @strip.meta.default
+        def strip_launcher_optional(
+            index: int = 0,
+            /,
+            *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+        ):
+            pass
+
+    else:
+        raise ValueError(launcher_signature)
+
+    @strip.command
+    def mute(state: Literal["on", "off"] = "off", /, *, verbose: bool = False):
+        pass
+
+    return root
+
+
+def test_default_positional_does_not_shift_subcommands(zsh_tester):
+    """A plain app's default-command positional must not shift subcommand completion.
+
+    For a non-meta app, the default command's positionals and the subcommands are
+    alternatives at the same word slot (``tool 5`` vs ``tool sub``) -- unlike meta
+    launcher positionals, they are never consumed before a subcommand.
+    """
+    app = App(name="tool")
+
+    @app.default
+    def main(x: int, /):
+        pass
+
+    @app.command
+    def sub(y: int, /, *, verbose: bool = False):
+        pass
+
+    tester = zsh_tester(app, "tool")
+
+    assert "sub" in tester.get_completions("tool ")
+    assert "--verbose" in tester.get_completions("tool sub --v")
+
+
+def test_subcommand_positional_identical_to_default(zsh_tester):
+    """A subcommand keeps its own positional even when it's structurally identical
+    to the default command's positional (they are distinct arguments).
+    """
+    app = App(name="tool")
+
+    @app.default
+    def main(mode: Literal["fast", "slow"], /):
+        pass
+
+    @app.command
+    def sub(mode: Literal["fast", "slow"], /):
+        pass
+
+    tester = zsh_tester(app, "tool")
+
+    assert "fast" in tester.get_completions("tool sub ")
+
+
+def test_meta_positional_subcommand_own_arguments(zsh_tester):
+    """After entering a subcommand past a meta positional, the subcommand's own
+    positionals and options must complete (the word frame is shifted by the
+    meta positional).
+    """
+    root = _make_meta_wrapped_app()
+    tester = zsh_tester(root, "vban")
+
+    assert "--verbose" in tester.get_completions("vban strip 0 mute --v")
+    assert "on" in tester.get_completions("vban strip 0 mute ")
+
+
+def test_meta_positional_two_levels(zsh_tester):
+    """Meta positionals at two nesting levels compose; dispatch and the leaf's
+    own completions stay correct.
+    """
+    root = App(name="vban")
+
+    @root.meta.default
+    def root_launcher(
+        channel: int,
+        /,
+        *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+    ):
+        pass
+
+    strip = App(name="strip")
+    root.command(strip.meta, name="strip")
+
+    @strip.meta.default
+    def strip_launcher(
+        index: int,
+        /,
+        *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+    ):
+        pass
+
+    @strip.command
+    def mute(state: Literal["on", "off"] = "off", /):
+        pass
+
+    tester = zsh_tester(root, "vban")
+
+    assert "strip" in tester.get_completions("vban 9 ")
+    assert "mute" in tester.get_completions("vban 9 strip 0 ")
+    assert "on" in tester.get_completions("vban 9 strip 0 mute ")
+
+
+def test_meta_positional_or_keyword_before_subcommand(zsh_tester):
+    """A required meta launcher positional without ``/`` still shifts the
+    subcommand slot (the dominant usage is positional).
+    """
+    root = _make_meta_wrapped_app("positional_or_keyword")
+    tester = zsh_tester(root, "vban")
+
+    assert "mute" in tester.get_completions("vban strip 0 ")
+
+
+def test_meta_optional_positional_keeps_command_slot(zsh_tester):
+    """An optional meta launcher positional makes the subcommand's word index
+    non-deterministic; fall back to offering subcommands at slot 1.
+    """
+    root = _make_meta_wrapped_app("optional_positional")
+    tester = zsh_tester(root, "vban")
+
+    assert "mute" in tester.get_completions("vban strip ")
+
+
+def test_meta_interleaved_variadic_keeps_command_slot(zsh_tester):
+    """A variadic positional interleaved among fixed launcher positionals makes
+    every later word slot non-deterministic; fall back to offering subcommands
+    at slot 1 rather than shifting the dispatch to the wrong slot.
+    """
+    root = App(name="vban")
+    strip = App(name="strip")
+    root.command(strip.meta, name="strip")
+
+    @strip.meta.default
+    def strip_launcher(a: int, b: list[str], c: int, /):
+        pass
+
+    @strip.command
+    def mute(state: Literal["on", "off"] = "off", /):
+        pass
+
+    tester = zsh_tester(root, "vban")
+
+    assert "mute" in tester.get_completions("vban strip ")
+
+
 def test_invalid_prog_name():
     """Test that invalid prog names raise ValueError."""
     with pytest.raises(ValueError, match="Invalid prog_name"):

--- a/tests/completion/test_zsh.py
+++ b/tests/completion/test_zsh.py
@@ -132,6 +132,30 @@ def test_nested_command_uses_correct_word_index(zsh_tester):
     assert len(words_checks) >= 2, "Should have multiple case $words[1] checks for nested commands"
 
 
+def test_meta_positional_before_subcommand(zsh_tester):
+    """Complete subcommands after a meta app's required positional."""
+    root = App(name="vban")
+    strip = App(name="strip")
+    root.command(strip.meta, name="strip")
+
+    @strip.meta.default
+    def strip_launcher(
+        index: int,
+        /,
+        *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
+    ):
+        pass
+
+    @strip.command
+    def mute(new_state: bool = False):
+        pass
+
+    tester = zsh_tester(root, "vban")
+
+    assert "mute" in tester.get_completions("vban strip 0 ")
+    assert "mute" not in tester.get_completions("vban strip ")
+
+
 def test_invalid_prog_name():
     """Test that invalid prog names raise ValueError."""
     with pytest.raises(ValueError, match="Invalid prog_name"):


### PR DESCRIPTION
Fixes #759.

Zsh always placed a nested command in positional slot 1. A required positional on a meta app occupied that slot, so `vban strip 0 <TAB>` could no longer enter the subcommand state.

Generate only the positionals introduced at the current path and shift command completion/dispatch after fixed positional-only arguments. The regression test drives a real zsh session and verifies that `mute` appears after the required index.

Tests: `pytest -q tests/completion` (198 passed, 49 skipped)
