### PR TITLE
fix: reject malformed duration strings instead of silently ignoring garbage

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -141,6 +141,7 @@ def _datetime(s: str) -> datetime:
 
 def _timedelta(s: str) -> timedelta:
     """Parse a timedelta string."""
+    s = s.strip()
     negative = False
     if s.startswith("-"):
         negative = True
@@ -148,7 +149,10 @@ def _timedelta(s: str) -> timedelta:
 
     matches = re.findall(r"((\d+\.\d+|\d+)([smhdwMy]))", s)
 
-    if not matches:
+    # Every character must belong to a "<number><unit>" token. Without this
+    # check, ``re.findall`` silently ignores stray characters, so a malformed
+    # duration like "5sfoo" would be accepted as 5s instead of raising.
+    if not matches or "".join(match[0] for match in matches) != s:
         raise ValueError(f"Could not parse duration string: {s}")
 
     seconds = 0

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -503,6 +503,10 @@ def test_parse_timedelta_valid(input_string, expected_output):
         "1x",  # Invalid unit
         "h1",  # Unit before number
         "3 days",  # Full unit names with spaces not supported
+        "5sfoo",  # Trailing garbage after a valid token
+        "garbage1h",  # Leading garbage before a valid token
+        "1h!!30m",  # Garbage between valid tokens
+        "1h-30m",  # Stray sign between valid tokens
     ],
 )
 def test_parse_timedelta_invalid(invalid_input):


### PR DESCRIPTION
## What

`_timedelta` collected `<number><unit>` tokens with `re.findall` but never
checked that they covered the whole input, so any characters outside a valid
token were silently dropped:

```python
convert(timedelta, ["5sfoo"])      # -> 0:00:05  (the "foo" is ignored)
convert(timedelta, ["garbage1h"])  # -> 1:00:00  (the "garbage" is ignored)
convert(timedelta, ["1h!!30m"])    # -> 1:30:00  (the "!!" is ignored)
```

A CLI value like `--timeout 5sfoo` should be a coercion error, not silently
reinterpreted as 5 seconds.

This also contradicts the converter's own contract: `test_parse_timedelta_invalid`
already treats `"3 days"` and `"1x"` as invalid *because* they contain
characters that aren't part of a valid token — but that only worked when there
was **no** valid token at all. As soon as one valid token was present, the rest
was ignored.

## Fix

Require every character (after an optional leading sign and surrounding
whitespace) to belong to a `<number><unit>` token; otherwise raise, exactly as
the existing no-token path already does. The check is a single comparison of the
reconstructed tokens against the input.

Valid durations are unaffected — the existing `test_parse_timedelta_valid` cases
(mixed order `30m1h`, repeated `1h1h`, decimal `1.5h`, negative `-1h`, etc.) all
still pass, and surrounding whitespace like `"  10m  "` is still accepted.

## Verification

- Added `5sfoo`, `garbage1h`, `1h!!30m`, and `1h-30m` to
  `test_parse_timedelta_invalid`. They fail on `main` (silently accepted) and
  pass with this change.
- `pytest tests/test_coercion.py` — 129 passed (125 existing + 4 new).
- `ruff check`, `ruff format --check`, and `pyright` (strict) are clean on both
  changed files.

## AI assistance

This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug while fuzzing the `_convert` coercers for round-trip/validation
gaps, confirmed the silent-acceptance against `main` (both via the private
converter and end-to-end through an `App`), wrote the failing cases first
(red → green), checked that no valid case regressed, and wrote this description.
The verification above is real and re-runnable from the diff. The human account
holder reviews every change and is accountable for it. If this isn't the kind of
contribution you want, just say so and I'll close it.
