### PR TITLE
Fix search_parents=False still walking parent directories

### DIFF
--- a/cyclopts/config/_common.py
+++ b/cyclopts/config/_common.py
@@ -160,11 +160,9 @@ class ConfigFromFile(ConfigBase):
                         msg += exception_msg
                     raise CycloptsError(msg=msg) from e
                 return self._config
-            elif self.search_parents:
-                # Continue iterating over parents.
-                continue
-            elif self.must_exist:
-                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(self.path))
+            if not self.search_parents:
+                # Only look at the specified path; do not walk parent directories.
+                break
 
         # No matching file was found.
         if self.must_exist:

--- a/tests/config/test_common.py
+++ b/tests/config/test_common.py
@@ -157,8 +157,7 @@ def test_config_common_search_parents_absolute_true_exists(tmp_path, must_exist,
 
 
 def test_config_common_search_parents_false_ignores_parent(tmp_path, config, mocker):
-    """With the default ``search_parents=False``, a missing path must not fall
-    back to a same-named config file in a parent directory."""
+    """A missing path must not fall back to a parent's same-named config when ``search_parents=False``."""
     spy_load_config = mocker.spy(config, "_load_config")
 
     original_path = config.path

--- a/tests/config/test_common.py
+++ b/tests/config/test_common.py
@@ -156,6 +156,20 @@ def test_config_common_search_parents_absolute_true_exists(tmp_path, must_exist,
     spy_load_config.assert_called_once_with(original_path)
 
 
+def test_config_common_search_parents_false_ignores_parent(tmp_path, config, mocker):
+    """With the default ``search_parents=False``, a missing path must not fall
+    back to a same-named config file in a parent directory."""
+    spy_load_config = mocker.spy(config, "_load_config")
+
+    original_path = config.path
+    original_path.touch()  # a same-named file exists in the parent directory
+    config.path = tmp_path / "folder1" / "folder2" / config.path.name  # missing
+    # search_parents and must_exist both default to False
+
+    assert config.config == {}
+    spy_load_config.assert_not_called()
+
+
 def test_config_common_search_parents_relative_true_exists(tmp_path, mocker, monkeypatch):
     """Tests finding an existing parent if path is relative."""
     config_path = tmp_path / "cyclopts-config-test-file.dummy"


### PR DESCRIPTION
### The bug

With the default `search_parents=False`, a config whose `path` doesn't exist still loads a same-named config file from an **ancestor** directory:

```python
import cyclopts
from cyclopts import App

# /tmp/base/pyproject.toml exists with [tool.myapp.count] character = "PARENT_VALUE"
# /tmp/base/sub/pyproject.toml does NOT exist
app = App(name="myapp", config=cyclopts.config.Toml(
    "/tmp/base/sub/pyproject.toml", root_keys=["tool", "myapp"]))
# search_parents defaults to False, must_exist defaults to False

@app.command
def count(filename: str, *, character: str = "DEFAULT"):
    return character

app(["count", "README.md"], result_action="return_value")
# Actual:  'PARENT_VALUE'  (loaded from the ancestor)
# Expected: 'DEFAULT'      (search_parents=False must not consult ancestors)
```

The documented contract (`docs/source/api.rst`, and the primary example in `docs/source/config_file.rst`) makes parent search opt-in: the attribute defaults to `False`, and every example that wants ancestor lookup sets `search_parents=True` explicitly. So with the default, only the specified `path` should be consulted.

Impact: any tool using the headline `config=cyclopts.config.Toml("pyproject.toml", ...)` pattern (default flags) silently absorbs the repo-root `pyproject.toml` when run from a subdirectory, even though the user never opted into parent search.

### Root cause

`ConfigFromFile.config` (`cyclopts/config/_common.py`) walks `self.path...parents`. When a candidate doesn't exist, only two cases were handled:

```python
elif self.search_parents:
    continue
elif self.must_exist:
    raise FileNotFoundError(...)
```

With both `search_parents=False` and `must_exist=False` (the default), neither branch runs, so the `for` loop simply advances to the next parent — the flag is inert. It only ever had an effect because `must_exist=True` happened to raise early.

### The fix

`break` out of the loop after the specified path unless `search_parents` is set. `must_exist` is still honored by the existing post-loop check, so all four flag combinations behave as documented:

- `search_parents=False` (default) → only the given path; missing → `{}` (or `FileNotFoundError` if `must_exist=True`).
- `search_parents=True` → walk ancestors as before.

### Verification

- The repro above now returns `'DEFAULT'`; `search_parents=True` still returns `'PARENT_VALUE'`; `must_exist=True` on a missing path still raises `FileNotFoundError`.
- Added `test_config_common_search_parents_false_ignores_parent`: it fails on `main` (the ancestor config is loaded) and passes with the fix.
- `tests/config/` → 109 passed. Full suite → 2395 passed, 139 skipped (the only failures are pre-existing `test_docs_snapshots`/`test_sphinx_ext` cases that need `docutils`, which isn't installed here — they fail identically without this change). `ruff check` / `ruff format --check` clean.

This is a behavior change for the default configuration, so it's your call whether it should land as a fix or wait for a major version — happy to adjust the framing. It's distinct from #370 (that was `search_parents=True` failing for *relative* paths, fixed in v3.10.1 by adding `.resolve()`); this is the default `False` not being honored.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
