### PR TITLE
Report the offending value when a boolean flag gets a non-bool =value

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -233,7 +233,7 @@ def _parse_kw_and_flags(
                         coerced_value = _bool(cli_values[-1])
                     except CoercionError as e:
                         if e.token is None:
-                            e.token = CliToken(keyword=match.matched_token)
+                            e.token = CliToken(keyword=match.matched_token, value=cli_values[-1])
                         if e.argument is None:
                             e.argument = match.argument
                         raise

--- a/tests/test_bind_boolean_flag.py
+++ b/tests/test_bind_boolean_flag.py
@@ -125,6 +125,27 @@ def test_boolean_flag_app_parameter_negative(app, assert_parse_args):
         app("--no-my-flag=", exit_on_error=False)
 
 
+@pytest.mark.parametrize("cmd_str", ["--my-flag=2", "--no-my-flag=2"])
+def test_boolean_flag_equals_coercion_error_reports_value(app, cmd_str):
+    """A bad ``--flag=VALUE`` bool value must appear in the error message.
+
+    ``rules.rst`` states that a keyword bool with an ``=`` value is parsed by
+    the same rules as a positional bool, whose error message includes the
+    offending value (e.g. ``unable to convert "2" into bool``).  Regression:
+    the token was rebuilt without its value, yielding an empty ``""``.
+    """
+
+    @app.default
+    def foo(my_flag: bool = False):
+        pass
+
+    with pytest.raises(CoercionError) as e:
+        app.parse_args(cmd_str, exit_on_error=False, print_error=False)
+    assert e.value.token is not None
+    assert e.value.token.value == "2"
+    assert '"2"' in str(e.value)
+
+
 def test_boolean_flag_app_parameter_default_annotated_override(app, assert_parse_args):
     app.default_parameter = Parameter(negative="")
 


### PR DESCRIPTION
When a boolean flag is given a value via `=` that can't be coerced, the error message drops the offending value:

```
$ mytool --verbose=2
Invalid value for --verbose: unable to convert "" into bool.   # the "2" is lost
```

The positional path reports it correctly:

```
$ mytool 2      # (positional bool)
Invalid value for VERBOSE: unable to convert "2" into bool.
```

`docs/source/rules.rst` says the keyword `=` form "is parsed according to positional argument rules", so both should include the value.

**Root cause** (`cyclopts/bind.py`, `_parse_kw_and_flags`): on `CoercionError`, the token is rebuilt as `CliToken(keyword=match.matched_token)` with no `value`, so `Token.value` defaults to `""` and the renderer emits an empty string.

**Fix** (1 line): thread the offending value through — `cli_values[-1]` is exactly the string that was just passed to `_bool()`:

```python
e.token = CliToken(keyword=match.matched_token, value=cli_values[-1])
```

After the fix, `--verbose=2` → `unable to convert "2" into bool.`, `--verbose=banana` → `"banana"`, matching the positional path.

**Verification** (re-runnable from the diff): added `test_boolean_flag_equals_coercion_error_reports_value` (parametrized `--my-flag=2` / `--no-my-flag=2`), which fails on the current tree (`assert '' == '2'`) and passes with the fix. The affected modules (`test_bind_boolean_flag`, `test_coercion`) pass; full suite is green apart from pre-existing `docutils`-missing failures in the sphinx/docs-snapshot tests (unrelated).

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
