### PR TITLE
fix: split iterable Parameter(env_var=...) values via env_var_split

### DIFF
--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -521,7 +521,17 @@ def _parse_env(argument_collection: ArgumentCollection):
             except KeyError:
                 pass
             else:
-                argument.tokens.append(Token(keyword=env_var_name, value=env_var_value, source="env"))
+                # A JSON-looking value is a single token (mirrors the CLI path); otherwise
+                # split it per ``Parameter.env_var_split`` (e.g. whitespace for iterables,
+                # ``os.pathsep`` for path iterables).
+                if argument._should_attempt_json_dict([env_var_value]) or argument._should_attempt_json_list(
+                    [env_var_value]
+                ):
+                    values = [env_var_value]
+                else:
+                    values = argument.env_var_split(env_var_value)
+                for index, value in enumerate(values):
+                    argument.tokens.append(Token(keyword=env_var_name, value=value, index=index, source="env"))
                 break
 
 

--- a/tests/test_bind_env_var.py
+++ b/tests/test_bind_env_var.py
@@ -98,3 +98,28 @@ def test_env_var_path_list_value_pathsep_split(app, assert_parse_args, monkeypat
 
     monkeypatch.setenv("BAR", "/a/b:/c/d")
     assert_parse_args(foo, [], [Path("/a/b"), Path("/c/d")])
+
+
+def test_env_var_str_value_with_spaces_not_split(app, assert_parse_args, monkeypatch):
+    """A scalar-typed env value is passed through as a single token, spaces and all."""
+
+    @app.default
+    def foo(bar: Annotated[str, Parameter(env_var="BAR")] = ""):
+        pass
+
+    monkeypatch.setenv("BAR", "a b c")
+    assert_parse_args(foo, [], "a b c")
+
+
+def test_env_var_single_path_value_with_pathsep_not_split(app, assert_parse_args, monkeypatch, mocker):
+    """A scalar ``Path`` env value containing ``os.pathsep`` stays a single path."""
+    from pathlib import Path
+
+    mocker.patch("cyclopts._env_var.os.pathsep", ":")
+
+    @app.default
+    def foo(bar: Annotated[Path, Parameter(env_var="BAR")] = Path()):
+        pass
+
+    monkeypatch.setenv("BAR", "/a/b:/c/d")
+    assert_parse_args(foo, [], Path("/a/b:/c/d"))

--- a/tests/test_bind_env_var.py
+++ b/tests/test_bind_env_var.py
@@ -55,3 +55,46 @@ def test_env_var_unset_list_use_signature_default(app, assert_parse_args, monkey
     monkeypatch.delenv("BAZ", raising=False)
 
     assert_parse_args(foo, [])
+
+
+def test_env_var_list_value_whitespace_split(app, assert_parse_args, monkeypatch):
+    """An iterable-typed ``Parameter(env_var=...)`` value is split by ``env_var_split``.
+
+    ``Parameter.env_var_split`` is documented as the function that "splits up the
+    read-in ``Parameter.env_var`` value"; its default splits iterables on
+    whitespace.  Regression: the env-sourcing path appended the raw value as a
+    single token without splitting, so ``list[int]`` from ``"1 2 3"`` raised a
+    CoercionError instead of yielding ``[1, 2, 3]``.
+    """
+
+    @app.default
+    def foo(bar: Annotated[list[int], Parameter(env_var="BAR")] = []):  # noqa: B006
+        pass
+
+    monkeypatch.setenv("BAR", "1 2 3")
+    assert_parse_args(foo, [], [1, 2, 3])
+
+
+def test_env_var_tuple_value_whitespace_split(app, assert_parse_args, monkeypatch):
+    """A multi-token (``tuple[int, int]``) env value is whitespace-split into elements."""
+
+    @app.default
+    def foo(bar: Annotated[tuple[int, int], Parameter(env_var="BAR")] = (0, 0)):
+        pass
+
+    monkeypatch.setenv("BAR", "5 6")
+    assert_parse_args(foo, [], (5, 6))
+
+
+def test_env_var_path_list_value_pathsep_split(app, assert_parse_args, monkeypatch, mocker):
+    """A ``list[Path]`` env value is split on ``os.pathsep`` (mirrors PATH-style vars)."""
+    from pathlib import Path
+
+    mocker.patch("cyclopts._env_var.os.pathsep", ":")
+
+    @app.default
+    def foo(bar: Annotated[list[Path], Parameter(env_var="BAR")] = []):  # noqa: B006
+        pass
+
+    monkeypatch.setenv("BAR", "/a/b:/c/d")
+    assert_parse_args(foo, [], [Path("/a/b"), Path("/c/d")])


### PR DESCRIPTION
`Parameter(env_var=...)` reads the whole environment string as a single token and never calls `env_var_split`, so iterable-typed parameters can't be populated from the environment the way the docs describe.

```python
from pathlib import Path
from typing import Annotated
import cyclopts

app = cyclopts.App()

@app.default
def main(nums: Annotated[list[int], cyclopts.Parameter(env_var="NUMS")]):
    print(nums)

# NUMS="1 2 3"  ->  CoercionError: unable to convert "1 2 3" to int
```

`docs/source/api.rst` documents `env_var_split` as the splitter for `Parameter.env_var` (whitespace for iterables, `os.pathsep` for path iterables), and the sibling `config.Env` path already splits correctly — only the `Parameter(env_var=)` path in `bind.py:_parse_env` was missing it. Result today:

- `list[int]` from `"1 2 3"` → `CoercionError`
- `tuple[int, int]` from `"5 6"` → `CoercionError` (expected 2, got 1)
- `list[Path]` from `"/a/b:/c/d"` → a single `Path("/a/b:/c/d")` instead of two paths

The fix mirrors the CLI path: a JSON-looking value (`_should_attempt_json_dict/list`) stays a single token so JSON-from-env keeps working, otherwise the value goes through `env_var_split` and each piece is appended with its index. A naive unconditional split would break the existing JSON-from-env behaviour, so the conditional is load-bearing — the `test_json_string_list.py` / `test_pydantic.py` suites cover that and stay green.

Verification (re-runnable from the diff): the three new tests in `test_bind_env_var.py` fail on `main` and pass with the fix; the full suite is green (2404 passed); `ruff check`, `ruff format --check`, and `pyright` are clean on the changed files. `config.Env` is intentionally left untouched.

---
This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
