### PR TITLE
Fix Literal types containing a None member

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -658,6 +658,9 @@ def _convert(
         # Try coercing the token into each allowed Literal value (left-to-right).
         last_coercion_error = None
         for choice in get_args(type_):
+            if choice is None:
+                # Like ``Optional``, a ``None`` member is only reachable via the default, not a token.
+                continue
             try:
                 res = convert(type(choice), token)
             except CoercionError as e:

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -100,7 +100,8 @@ def get_choices_from_hint(type_: type, name_transform: Callable[[str], str]) -> 
             if x:
                 choices.extend(x)
     elif _origin is Literal:
-        choices.extend(str(x) for x in get_args(type_))
+        # A ``None`` member is only reachable via the default, not a token (like ``Optional``).
+        choices.extend(str(x) for x in get_args(type_) if x is not None)
     elif _origin in ITERABLE_TYPES:
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -360,7 +360,7 @@ class CoercionError(CycloptsError):
         choice_strs: list[str] | None = None
         plain_choices: list[str] | None = None
         if get_origin(self.target_type) is Literal:
-            args = get_args(self.target_type)
+            args = [x for x in get_args(self.target_type) if x is not None]  # ``None`` cannot be entered as a token.
             choice_strs = [f'"{x}"' if isinstance(x, str) else repr(x) for x in args]
             plain_choices = [x for x in args if isinstance(x, str)]
         elif isinstance(self.target_type, type) and issubclass(self.target_type, Enum):

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -340,6 +340,13 @@ def test_coerce_literal():
     assert 3 == convert(Literal["foo", "bar", 3], ["3"])
 
 
+def test_coerce_literal_none_member():
+    """A ``None`` Literal member is only reachable via the default, like ``Optional``; issue: valid tokens after it must still match."""
+    assert "foo" == convert(Literal[None, "foo"], ["foo"])
+    assert "foo" == convert(Literal["foo", None], ["foo"])
+    assert 3 == convert(Literal[None, "foo", 3], ["3"])
+
+
 def assert_convert_coercion_error(*args, msg, name_transform=None, **kwargs):
     if name_transform is None:
         name_transform = default_name_transform
@@ -386,6 +393,15 @@ def test_coerce_literal_invalid_choice_keyword_non_cli_token():
         Literal["foo", "bar", 3],
         [Token(keyword="--MY-KEYWORD", value="invalid-choice", source="TEST")],
         msg='Invalid value "invalid-choice" for --MY-KEYWORD from TEST. Choose from: "foo", "bar", 3.',
+    )
+
+
+def test_coerce_literal_none_member_invalid_choice():
+    """``None`` cannot be entered as a CLI token, so it is omitted from the choices list."""
+    assert_convert_coercion_error(
+        Literal["foo", None],
+        ["invalid-choice"],
+        msg='Invalid value "invalid-choice" for MOCKED_ARGUMENT_NAME. Choose from: "foo".',
     )
 
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -922,6 +922,25 @@ def test_help_format_group_parameters_choices_literal_no_show(capture_format_gro
     assert actual == expected
 
 
+def test_help_format_group_parameters_choices_literal_none_member(capture_format_group_parameters):
+    """A ``None`` Literal member cannot be entered as a token, so it is not a displayed choice (like ``Optional``)."""
+
+    def cmd(
+        foo: Annotated[Literal[None, "fizz", "buzz"], Parameter(help="Docstring for foo.")] = None,
+    ):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO --foo  Docstring for foo. [choices: fizz, buzz]                │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
 def test_help_format_group_parameters_choices_literal_union(capture_format_group_parameters):
     def cmd(
         foo: Annotated[int | Literal["fizz", "buzz"] | Literal["bar"], Parameter(help="Docstring for foo.")] = "fizz",


### PR DESCRIPTION
## Problem

A `Literal` annotation containing a `None` member crashed on valid input: for `Literal[None, "foo"]`, passing `foo` raised an uncaught `TypeError: NoneType takes no arguments`, because the Literal conversion loop tries `convert(type(choice), token)` for each member left-to-right and only `CoercionError` is caught.

`Optional[Literal["foo"]]` already worked correctly (the Union path skips the `None` member), so the equivalent `Literal[None, "foo"]` spelling should behave the same.

## Fix

Treat a `None` Literal member like `Optional`: reachable only via the default value, never via a token. The `None` member leaked in three places, all fixed to match:

- `cyclopts/_convert.py`: skip `None` choices during token conversion (the crash itself).
- `cyclopts/exceptions.py`: omit `None` from "Choose from:" coercion-error messages.
- `cyclopts/argument/utils.py` (`get_choices_from_hint`): omit `None` from help/completion choices, so help renders `[choices: fizz, buzz]` instead of including a spurious `None`.

## Tests

- `test_coercion.py::test_coerce_literal_none_member` — valid tokens convert regardless of `None` member position.
- `test_coercion.py::test_coerce_literal_none_member_invalid_choice` — error message lists only enterable choices.
- `test_help.py::test_help_format_group_parameters_choices_literal_none_member` — help choices omit `None`.

No behavior change for Literals without a `None` member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)