### PR TITLE
Add regression tests for Literal types with a None member

### DIFF
--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -377,6 +377,28 @@ def test_coerce_literal():
     assert 3 == convert(Literal["foo", "bar", 3], ["3"])
 
 
+def test_coerce_literal_none_member():
+    """A ``None`` Literal member must not break conversion of the other members.
+
+    Regression test: pre-v5 the Literal loop raised an uncaught ``TypeError``
+    (``NoneType takes no arguments``) when trying a ``None`` member against a token.
+    In v5, ``None`` is an enterable choice via "none"/"null" strings.
+    """
+    assert "foo" == convert(Literal[None, "foo"], ["foo"])
+    assert "foo" == convert(Literal["foo", None], ["foo"])
+    assert 3 == convert(Literal[None, "foo", 3], ["3"])
+
+
+@pytest.mark.parametrize("token", NONE_STRINGS)
+def test_coerce_literal_none_member_none_strings(token):
+    assert convert(Literal[None, "foo"], [token]) is None
+
+
+def test_coerce_literal_none_member_invalid_choice():
+    with pytest.raises(CoercionError):
+        convert(Literal[None, "foo"], ["bogus"])
+
+
 def assert_convert_coercion_error(*args, msg, name_transform=None, **kwargs):
     if name_transform is None:
         name_transform = default_name_transform


### PR DESCRIPTION
## Context

Pre-v5, a `None` member in a `Literal` annotation crashed conversion: for `Literal[None, "foo"]`, passing `foo` raised an uncaught `TypeError: NoneType takes no arguments` before later members could be tried (the Literal loop only catches `CoercionError`).

The v5 none/null coercion work (#717) fixed this as a side effect — `_none` raises `CoercionError` for non-matching tokens, which the loop catches — but there was no test covering the `Literal[None, ...]` spelling, so the crash could silently be reintroduced.

## Tests added (tests only, no source changes)

- `test_coerce_literal_none_member` — members before/after a `None` still convert (`Literal[None, "foo"]` + `foo` → `"foo"`).
- `test_coerce_literal_none_member_none_strings` — all `NONE_STRINGS` case variations (`none`, `null`, `NONE`, ...) convert to `None`, codifying the v5 semantics.
- `test_coerce_literal_none_member_invalid_choice` — a non-matching token raises a clean `CoercionError`.

Note: a v4/main fix for the same crash (#869) was withdrawn in favor of letting v5 moot it, since its "None is unreachable via token" semantics contradict v5's enterable `none`/`null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)