### PR TITLE
Fix spurious MissingArgumentError for explicitly-supplied empty mappings

### DIFF
--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -775,6 +775,9 @@ class Argument:
         else:
             data = {}
             out = UNSET
+            # An explicitly-supplied empty mapping (e.g. ``x = {}`` in a config file, or
+            # ``--x={}`` on the cli) means "instantiate from defaults", not "missing".
+            explicit_empty_mapping = False
 
             if self._enum_flag_type:
                 out = self._enum_flag_type(0)
@@ -784,26 +787,36 @@ class Argument:
                 out |= reduce(operator.or_, converted_flags) if isinstance(converted_flags, list) else converted_flags
 
             if self._should_attempt_json_dict():
-                while self.tokens:
-                    token = self.tokens.pop(0)
+                json_tokens, self.tokens = self.tokens, []
+                for token in json_tokens:
                     try:
                         parsed_json = json.loads(token.value)
                     except json.JSONDecodeError as e:
                         raise CoercionError(token=token, target_type=self.hint) from e
                     _validate_json_extra_keys(parsed_json, self.hint, token)
-                    update_argument_collection(
-                        {self.name.lstrip("-"): parsed_json},
-                        token.source,
-                        self.children_recursive,
-                        root_keys=(),
-                        allow_unknown=False,
-                    )
+                    if parsed_json:
+                        update_argument_collection(
+                            {self.name.lstrip("-"): parsed_json},
+                            token.source,
+                            self.children_recursive,
+                            root_keys=(),
+                            allow_unknown=False,
+                        )
+                    else:
+                        explicit_empty_mapping = True
+                        # Placeholder so ``has_tokens`` still reports this argument as supplied.
+                        self.tokens.append(token.evolve(value="", implicit_value={}))
 
             if self._use_pydantic_type_adapter:
                 return self._convert_pydantic()
 
             if self.tokens and not self._enum_flag_type:
                 positional_tokens = [token for token in self.tokens if not token.keys]
+                if any(isinstance(token.implicit_value, dict) for token in positional_tokens):
+                    explicit_empty_mapping = True
+                    positional_tokens = [
+                        token for token in positional_tokens if not isinstance(token.implicit_value, dict)
+                    ]
                 if positional_tokens:
                     return safe_converter(self.hint, tuple(positional_tokens))
 
@@ -838,7 +851,7 @@ class Argument:
                 out |= enum_flag_from_dict(self._enum_flag_type, data, self.parameter.name_transform)
                 if not out:
                     out = UNSET
-            elif data:
+            elif data or explicit_empty_mapping:
                 target_hint = self.hint
                 if self._union_branches:
                     # ``instantiate_from_dict`` cannot build a bare ``Union``; pick the branch
@@ -1189,6 +1202,10 @@ class Argument:
         out = {}
         if self._accepts_keywords:
             for token in self.tokens:
+                if not token.keys and isinstance(token.implicit_value, dict):
+                    # An explicitly-supplied empty mapping (e.g. ``x = {}`` in a config file);
+                    # contributes no keys, but ``has_tokens`` already marks the argument as supplied.
+                    continue
                 node = out
                 for key in token.keys[:-1]:
                     node = node.setdefault(key, {})

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -379,7 +379,7 @@ def walk_leaves(
     if parent_keys is None:
         parent_keys = ()
 
-    if isinstance(d, dict):
+    if isinstance(d, dict) and d:
         for key, value in d.items():
             current_keys = parent_keys + (key,)
             if isinstance(value, dict):
@@ -387,7 +387,9 @@ def walk_leaves(
             else:
                 yield current_keys, value
     else:
-        yield (), d
+        # An empty dict is a leaf: an explicitly-supplied empty mapping (e.g. ``x = {}``)
+        # must produce a token, like an empty list does.
+        yield parent_keys, d
 
 
 def to_cli_option_name(*keys: str) -> str:

--- a/tests/config/test_dict.py
+++ b/tests/config/test_dict.py
@@ -409,6 +409,34 @@ def test_config_dict_empty():
     assert result == "Default is 0 years old."
 
 
+def test_config_dict_empty_dict_value():
+    """An empty dict config value binds as ``{}`` instead of raising MissingArgumentError, like an empty list does."""
+    app = App(config=Dict({"x": {}}), result_action="return_value")
+
+    @app.default
+    def main(x: dict):
+        return x
+
+    assert app([]) == {}
+
+
+def test_config_dict_empty_dict_value_dataclass():
+    """An empty dict config value constructs an all-defaults dataclass."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class Options:
+        threshold: int = 5
+
+    app = App(config=Dict({"options": {}}), result_action="return_value")
+
+    @app.default
+    def main(options: Options):
+        return options
+
+    assert app([]) == Options(threshold=5)
+
+
 def test_config_dict_nested_structure():
     """Test Dict config with nested dataclass-like structures."""
     from dataclasses import dataclass

--- a/tests/config/test_end2end.py
+++ b/tests/config/test_end2end.py
@@ -15,6 +15,7 @@ def test_config_end2end(app, tmp_path, assert_parse_args):
             key1 = "foo1"
             key2 = "foo2"
             list1 = []
+            dict1 = {}
 
             [tool.cyclopts.function1]
             key3 = "bar1"
@@ -26,16 +27,16 @@ def test_config_end2end(app, tmp_path, assert_parse_args):
     app.config = Toml(config_fn, root_keys=["tool", "cyclopts"])
 
     @app.default
-    def default(key1, key2, *, list1: list[int]):
+    def default(key1, key2, *, list1: list[int], dict1: dict[str, int]):
         pass
 
     @app.command
     def function1(key3, key4):
         pass
 
-    assert_parse_args(default, "foo", key1="foo", key2="foo2", list1=[])
-    assert_parse_args(default, "foo --key2=fizz", key1="foo", key2="fizz", list1=[])
-    assert_parse_args(default, "foo --list1 1", key1="foo", key2="foo2", list1=[1])
+    assert_parse_args(default, "foo", key1="foo", key2="foo2", list1=[], dict1={})
+    assert_parse_args(default, "foo --key2=fizz", key1="foo", key2="fizz", list1=[], dict1={})
+    assert_parse_args(default, "foo --list1 1", key1="foo", key2="foo2", list1=[1], dict1={})
     assert_parse_args(function1, "function1 --key4=fizz", key3="bar1", key4="fizz")
 
 

--- a/tests/test_json_string_dict.py
+++ b/tests/test_json_string_dict.py
@@ -59,6 +59,21 @@ def test_bind_dataclass_from_cli_json(app, assert_parse_args, cmd_str):
     assert_parse_args(main, cmd_str, Coordinate(1, 2))
 
 
+def test_bind_dataclass_from_cli_json_empty(app, assert_parse_args):
+    """An explicit empty JSON dict instantiates the dataclass from its defaults."""
+
+    @dataclass
+    class Coordinate:
+        x: int = 0
+        y: int = 0
+
+    @app.default
+    def main(origin: Coordinate):
+        pass
+
+    assert_parse_args(main, "--origin={}", Coordinate())
+
+
 def test_nested_dataclass_from_env_json(app, assert_parse_args, monkeypatch):
     """Test parsing nested dataclasses from environment variable JSON."""
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1016,6 +1016,22 @@ def test_attrs_command_factory(app, assert_parse_args):
     assert app(["test"], result_action=("call_if_callable", "return_value"), exit_on_error=False) == "[1, 2, 3]"
 
 
+def test_pydantic_empty_dict_config_value(app, assert_parse_args):
+    """An empty dict config value constructs an all-defaults model instead of raising MissingArgumentError."""
+    from cyclopts.config import Dict
+
+    class Options(BaseModel):
+        threshold: int = 5
+
+    app.config = (Dict({"options": {}}),)
+
+    @app.default
+    def main(options: Options):
+        pass
+
+    assert_parse_args(main, "", Options(threshold=5))
+
+
 def test_pydantic_default_factory_help(app, console):
     """Zero-arg ``default_factory`` values render in help, consistent with dataclass/attrs.
 


### PR DESCRIPTION
## Problem

An explicitly-supplied empty mapping for a required `dict` / dataclass / pydantic-model parameter raised a spurious `MissingArgumentError`, while the analogous empty list already worked:

```toml
[tool.cyclopts]
list1 = []   # worked
dict1 = {}   # MissingArgumentError: Parameter --dict1 requires an argument.
```

Root cause: `walk_leaves` yielded nothing for an empty dict, so no token ever reached the argument and the binding layer treated it as never supplied.

## Semantics

An explicit empty mapping means "instantiate from defaults", mirroring the existing empty-list behavior: a `dict` parameter binds `{}`, and a dataclass/pydantic model with all-default fields is constructed from its defaults. This also applies to an explicit `--x={}` JSON value on the CLI, which previously raised the same spurious error for dataclass parents.

## Fix

- `cyclopts/argument/utils.py` (`walk_leaves`): an empty dict is now a leaf and yields a token (also yields `parent_keys` instead of `()`, keeping key paths correct for nested empty dicts).
- `cyclopts/argument/_argument.py`: the JSON-dict path keeps a placeholder token (`implicit_value={}`) for empty mappings so `has_tokens` stays true; an `explicit_empty_mapping` flag lets the instantiate-from-dict branch fire with no child data; the positional path and `_json()` (pydantic payload) exclude the placeholder tokens.

## Tests

- `tests/config/test_dict.py` — empty dict config value binds `{}`; empty table constructs an all-defaults dataclass.
- `tests/test_pydantic.py` — empty dict config value constructs an all-defaults pydantic model.
- `tests/test_json_string_dict.py` — CLI `--origin={}` instantiates an all-defaults dataclass.
- `tests/config/test_end2end.py` — `dict1 = {}` exercised end-to-end alongside the existing `list1 = []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)