### PR TITLE
Honor an attached `=value` on count flags instead of silently dropping it

### DIFF
--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -626,6 +626,17 @@ class Argument:
         if not self.parse:
             raise ValueError
 
+        if self.parameter.count and self.tokens:
+            # An explicit ``=value`` (marked by a non-empty ``value``) sets the count
+            # and must be the flag's only occurrence; plain repeats may still sum.
+            explicit = next((x for x in (token, *self.tokens) if x.value and x.implicit_value is not UNSET), None)
+            if explicit is not None:
+                raise RepeatArgumentError(
+                    token=token,
+                    msg=f'"{explicit.keyword}={explicit.value}" sets the count explicitly '
+                    "and cannot be combined with other occurrences of the flag.",
+                )
+
         if any(x.address == token.address for x in self.tokens):
             if self.parameter.allow_repeating is False:
                 raise RepeatArgumentError(token=token)

--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -225,7 +225,34 @@ def _parse_kw_and_flags(
                 cli_values.append(attached_value)
 
             if match.argument.parameter.count:
-                match.argument.append(CliToken(keyword=match.matched_token, implicit_value=1))
+                if cli_values:
+                    # An attached ``=value`` (e.g. --verbose=3) explicitly sets the count.
+                    # Plain ``int()`` parse: a count is a number of occurrences, so
+                    # fractional values like "1.5" are rejected rather than rounded
+                    # (unlike general int coercion via ``_int``), as are negatives.
+                    # The non-empty ``value`` marks the token as an explicit
+                    # assignment, which ``Argument.append`` forbids combining with
+                    # other occurrences.
+                    value = cli_values[-1]
+                    try:
+                        count_value = int(value)
+                    except ValueError:
+                        raise CoercionError(
+                            token=CliToken(keyword=match.matched_token, value=value),
+                            argument=match.argument,
+                            target_type=int,
+                        ) from None
+                    if count_value < 0:
+                        raise CoercionError(
+                            token=CliToken(keyword=match.matched_token, value=value),
+                            argument=match.argument,
+                            msg="Count values must be non-negative.",
+                        )
+                    match.argument.append(
+                        CliToken(keyword=match.matched_token, value=value, implicit_value=count_value)
+                    )
+                else:
+                    match.argument.append(CliToken(keyword=match.matched_token, implicit_value=1))
             elif match.implicit_value is not UNSET:
                 # A flag was parsed
                 if cli_values:

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -639,6 +639,9 @@ class RepeatArgumentError(CycloptsError):
     """The repeated token."""
 
     def _segments(self) -> "Iterator[tuple[str, str] | Text]":
+        if self.msg is not None:
+            yield self._resolved_msg()
+            return
         # Invariant: positional duplication is routed to UnusedCliTokensError by the binder,
         # so any token reaching this error path was matched by keyword.
         assert self.token.keyword is not None

--- a/tests/test_parameter_count.py
+++ b/tests/test_parameter_count.py
@@ -32,6 +32,116 @@ def test_count_various_inputs(app, assert_parse_args, tokens, expected):
     assert_parse_args(cmd, tokens, expected)
 
 
+@pytest.mark.parametrize(
+    "tokens,expected",
+    [
+        ("--verbose=3", 3),
+        ("-v=3", 3),
+        ("--verbose=0", 0),
+    ],
+)
+def test_count_equals_value(app, assert_parse_args, tokens, expected):
+    """An attached ``=value`` explicitly sets the count."""
+
+    def cmd(verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    assert_parse_args(cmd, tokens, expected)
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        "-v --verbose=2",
+        "--verbose=2 -v",
+        "-vv --verbose=2",
+        "--verbose=2 --verbose=3",
+    ],
+)
+def test_count_equals_value_mixed_with_repeats(app, tokens):
+    """An explicit ``=value`` must be the flag's only occurrence.
+
+    ``=`` reads as assignment; silently summing it with repeats (or another
+    assignment) would surprise, so mixing raises instead.
+    """
+    from cyclopts.exceptions import RepeatArgumentError
+
+    def cmd(verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    with pytest.raises(RepeatArgumentError):
+        app.parse_args(tokens, exit_on_error=False)
+
+
+def test_count_equals_value_mixed_error_message(app):
+    """The mixed-occurrence error renders ONLY the count-specific message.
+
+    Pins the ``RepeatArgumentError._segments`` msg-override fix: without it the
+    custom message and the stock "specified multiple times" text rendered
+    concatenated.
+    """
+    from cyclopts.exceptions import RepeatArgumentError
+
+    def cmd(verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    with pytest.raises(RepeatArgumentError) as exc_info:
+        app.parse_args("-v --verbose=2", exit_on_error=False)
+    message = str(exc_info.value)
+    assert '"--verbose=2" sets the count explicitly' in message
+    assert "specified multiple times" not in message
+
+
+def test_count_allow_repeating_true_still_rejects_equals_mix(app):
+    """``allow_repeating=True`` does not exempt an explicit ``=value`` from exclusivity."""
+    from cyclopts.exceptions import RepeatArgumentError
+
+    def cmd(
+        verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True, allow_repeating=True)] = 0,
+    ):
+        pass
+
+    app.default(cmd)
+    with pytest.raises(RepeatArgumentError):
+        app.parse_args("-v --verbose=2", exit_on_error=False)
+
+
+def test_count_allow_repeating_false_rejects_bare_repeats(app, assert_parse_args):
+    """``allow_repeating=False`` still forbids plain repeats of a count flag."""
+    from cyclopts.exceptions import RepeatArgumentError
+
+    def cmd(
+        verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True, allow_repeating=False)] = 0,
+    ):
+        pass
+
+    app.default(cmd)
+    assert_parse_args(cmd, "-v", 1)
+    with pytest.raises(RepeatArgumentError):
+        app.parse_args("-v -v", exit_on_error=False)
+
+
+@pytest.mark.parametrize("value", ["garbage", "true", "", "1.5", "2.0", "0x2", "-1"])
+def test_count_equals_value_invalid(app, value):
+    """A non-decimal-int or negative ``=value`` raises instead of being silently discarded.
+
+    Fractional and negative values are rejected rather than rounded/honored: a
+    count is a number of occurrences, so ``--verbose=1.5`` and ``--verbose=-1``
+    are treated as user errors.
+    """
+    from cyclopts.exceptions import CoercionError
+
+    def cmd(verbose: Annotated[int, Parameter(name=("--verbose", "-v"), count=True)] = 0):
+        pass
+
+    app.default(cmd)
+    with pytest.raises(CoercionError):
+        app.parse_args(f"--verbose={value}", exit_on_error=False)
+
+
 def test_count_negative_disabled(app):
     """Ensure --no-verbose is NOT generated."""
 


### PR DESCRIPTION
Count flags (`Parameter(count=True)`) silently discarded anything attached with `=`: `--verbose=3` parsed as 1, and even `--verbose=garbage` was silently accepted as 1. The count branch in `_parse_kw_and_flags` always appended `implicit_value=1` and never inspected the value split off at the `=`.

An attached `=value` now **explicitly sets the count** and must be the flag's only occurrence: mixing it with bare repeats (or a second `=value`) raises `RepeatArgumentError`, since `=` reads as assignment and silently summing `-v --verbose=2` into 3 would surprise. Bare repeats (`-vv`) still sum as always. This is stricter than argparse/Click only in that we accept a lone `=value` at all — both of those reject it outright.

The value must be a plain non-negative decimal integer; anything else raises a `CoercionError` naming the offending value. Deliberately stricter than general int coercion: a count is a number of occurrences, so `--verbose=1.5` is a user error rather than 2, and `--verbose=-1` is rejected rather than producing a negative count.

Behavior:

| Invocation | Before | After |
|---|---|---|
| `-v -v` | 2 | 2 |
| `--verbose=3` | 1 | 3 |
| `-v --verbose=2` | 2 | `RepeatArgumentError` |
| `--verbose=2 --verbose=3` | 2 | `RepeatArgumentError` |
| `--verbose=garbage` | 1 (silent) | `CoercionError` |
| `--verbose=1.5` | 1 (silent) | `CoercionError` |
| `--verbose=-1` | 1 (silent) | `CoercionError` |

Implementation notes:

- The `=value` token carries its text in `Token.value` (previously always empty for count tokens), marking it as an explicit assignment; `Argument.append` enforces the exclusivity so it holds regardless of occurrence order, and independent of `allow_repeating`.
- `RepeatArgumentError._segments` now honors the documented `CycloptsError.msg` override — nothing had ever passed `msg` to it before, and without the fix the custom message and the stock "specified multiple times" text rendered concatenated. A message-level test pins this.

Verified against `v5-develop`: the bug exists there too, and this merges fully clean (`git merge-tree` reports no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)