### PR TITLE
Report a clean error when a config node expected to be a table is not

### DIFF
--- a/cyclopts/config/_common.py
+++ b/cyclopts/config/_common.py
@@ -54,11 +54,19 @@ class ConfigBase(ABC):
         arguments: ArgumentCollection,
     ):
         config: dict[str, Any] = self.config.copy()
-        try:
-            for key in chain(self.root_keys, commands if self.use_commands_as_keys else ()):
+        traversed: list[str] = []
+        for key in chain(self.root_keys, commands if self.use_commands_as_keys else ()):
+            try:
                 config = config[key]
-        except KeyError:
-            return
+            except KeyError:
+                return
+            traversed.append(key)
+            if not isinstance(config, dict):
+                keyword = "".join(f"[{k}]" for k in traversed)
+                raise CycloptsError(
+                    msg=f'Configuration key {keyword} in "{self.source}" must be a mapping, '
+                    f"but got {type(config).__name__}."
+                )
 
         # Hierarchical config uses current app; flat config uses root app to filter sibling commands
         if self.use_commands_as_keys:

--- a/tests/config/test_dict.py
+++ b/tests/config/test_dict.py
@@ -437,6 +437,48 @@ def test_config_dict_empty_dict_value_dataclass():
     assert app([]) == Options(threshold=5)
 
 
+def test_config_dict_root_keys_non_mapping_node():
+    """A non-mapping value where ``root_keys`` expects a table raises a clean CycloptsError, not AttributeError."""
+    from cyclopts import CycloptsError
+
+    app = App(config=Dict({"tool": 5}, root_keys=("tool",)), result_action="return_value")
+
+    @app.default
+    def main(x: int = 0):
+        return x
+
+    with pytest.raises(CycloptsError, match=r"\[tool\].*mapping.*int"):
+        app([], exit_on_error=False)
+
+
+def test_config_dict_root_keys_non_mapping_intermediate_node():
+    """A non-mapping partway through the ``root_keys`` path raises a clean CycloptsError, not TypeError."""
+    from cyclopts import CycloptsError
+
+    app = App(config=Dict({"tool": [1, 2]}, root_keys=("tool", "cyclopts")), result_action="return_value")
+
+    @app.default
+    def main(x: int = 0):
+        return x
+
+    with pytest.raises(CycloptsError, match=r"\[tool\].*mapping.*list"):
+        app([], exit_on_error=False)
+
+
+def test_config_dict_command_key_non_mapping_node():
+    """A non-mapping value at a command's key raises a clean CycloptsError, not AttributeError."""
+    from cyclopts import CycloptsError
+
+    app = App(config=Dict({"sub": 5}), result_action="return_value")
+
+    @app.command
+    def sub(x: int = 0):
+        return x
+
+    with pytest.raises(CycloptsError, match=r"\[sub\].*mapping.*int"):
+        app(["sub"], exit_on_error=False)
+
+
 def test_config_dict_nested_structure():
     """Test Dict config with nested dataclass-like structures."""
     from dataclasses import dataclass


### PR DESCRIPTION
## Summary

When descending through `root_keys` (or command keys) of a config file, the node at each key was assumed to be a mapping. If a user's config file has a scalar or list at one of those keys, cyclopts crashed with a raw `AttributeError`/`TypeError` traceback that bypasses `exit_on_error`/`print_error` entirely.

The descended node's type is user-controlled external input (whatever the config file contains), so this is the config-file analog of a parse error and should report cleanly. Now each descended node is validated and a `CycloptsError` is raised naming the full key path, the config source, and the actual type:

```
Configuration key [tool][mycli][build] in "/path/to/mycli.toml" must be a mapping, but got bool.
```

## Realistic triggers (both verified with real TOML files)

Scalar where the tool table is expected — `root_keys=("tool", "mycli")` against a pyproject.toml containing `[tool]` / `mycli = "enabled"` (legal TOML) → `AttributeError: 'str' object has no attribute 'items'`.

Config key colliding with a subcommand name — the app has a `build` subcommand and the config contains `build = true` under `[tool.mycli]`. Running `mycli build` descends `config["build"]` → `True` → `AttributeError: 'bool' object has no attribute 'items'`. Since command names are used as config keys by default, any config value whose name matches a subcommand crashed the CLI.

## Changes

- `cyclopts/config/_common.py`: validate each node during the `root_keys`/command-key descent; raise `CycloptsError` (no new public API) with the traversed key path and source. A missing key still returns silently, as before.
- `tests/config/test_dict.py`: tests for a non-mapping at the `root_keys` leaf, partway through the `root_keys` path, and at a command key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
