### PR TITLE
Singularize the ConsumeMultipleError noun when the count is 1

### DIFF
--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -596,9 +596,12 @@ class ConsumeMultipleError(MissingArgumentError):
         param_name = self.keyword or self.argument.name
 
         if self.actual_count < self.min_required:
-            constraint = f"requires at least {self.min_required}"
+            count = self.min_required
+            constraint = f"requires at least {count}"
         else:
-            constraint = f"accepts at most {self.max_allowed}"
+            count = self.max_allowed
+            constraint = f"accepts at most {count}"
+        noun = "element" if count == 1 else "elements"
 
         # Skip MissingArgumentError._segments; we want just the base verbose preamble.
         yield from CycloptsError._segments(self)
@@ -610,7 +613,7 @@ class ConsumeMultipleError(MissingArgumentError):
         else:
             yield "Parameter ", ""
         yield param_name, STYLE_NAME
-        yield f" {constraint} elements. Got {self.actual_count}.", ""
+        yield f" {constraint} {noun}. Got {self.actual_count}.", ""
 
 
 @define(kw_only=True)

--- a/tests/test_bind_empty_iterable.py
+++ b/tests/test_bind_empty_iterable.py
@@ -82,7 +82,7 @@ def test_consume_multiple_int_rejects_empty(app):
     def foo(*, my_list: Annotated[list[str] | None, Parameter(consume_multiple=1)] = None):
         pass
 
-    with pytest.raises(ConsumeMultipleError, match="requires at least 1 elements. Got 0"):
+    with pytest.raises(ConsumeMultipleError, match="requires at least 1 element. Got 0"):
         app.parse_args("--my-list", print_error=False, exit_on_error=False)
 
 
@@ -202,6 +202,20 @@ def test_consume_multiple_error_message_max(app):
 
     with pytest.raises(ConsumeMultipleError, match="accepts at most 5 elements. Got 6"):
         app.parse_args("--urls a b c d e f", print_error=False, exit_on_error=False)
+
+
+def test_consume_multiple_error_message_singular(app):
+    """A constraint of exactly 1 should say "element", not "elements"."""
+
+    @app.default
+    def foo(*, urls: Annotated[list[str] | None, Parameter(consume_multiple=(1, 1))] = None):
+        pass
+
+    with pytest.raises(ConsumeMultipleError, match=r"requires at least 1 element\. Got 0\."):
+        app.parse_args("--urls", print_error=False, exit_on_error=False)
+
+    with pytest.raises(ConsumeMultipleError, match=r"accepts at most 1 element\. Got 2\."):
+        app.parse_args("--urls a b", print_error=False, exit_on_error=False)
 
 
 def test_consume_multiple_error_panel_min(app):


### PR DESCRIPTION
"requires at least 1 elements" now reads "requires at least 1 element". Applies to both the min and max constraint messages.

Closes #878