### PR TITLE
Fix `TypeError` when an abstract collection parameter is given no values

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -77,6 +77,19 @@ _abstract_to_concrete_type_mapping: dict[type, type] = {
 NestedCliArgs = dict[str, Union[Sequence[str], "NestedCliArgs"]]
 
 
+def create_empty_instance(hint: Any) -> Any:
+    """Create an empty instance of ``hint``'s container type.
+
+    Abstract collections (e.g. ``collections.abc.Sequence[int]``) cannot be
+    instantiated, so they are first normalized to the same concrete type that
+    :func:`convert` would produce (e.g. ``list``).
+    """
+    type_ = get_origin(hint) or hint
+    if type_ in _abstract_to_concrete_type_mapping:
+        type_ = _abstract_to_concrete_type_mapping[type_]
+    return type_()
+
+
 def _bool(s: str) -> bool:
     s = s.lower()
     if s in {"no", "n", "0", "false", "f"}:

--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -15,6 +15,7 @@ from attrs import define, field
 from cyclopts._convert import (
     _validate_json_extra_keys,
     convert,
+    create_empty_instance,
     instantiate_from_dict,
     token_count,
 )
@@ -592,8 +593,7 @@ class Argument:
                         elif is_nonetype(hint) or hint is None:
                             implicit_value = None
                         else:
-                            hint = resolve_optional(hint)
-                            implicit_value = (get_origin(hint) or hint)()
+                            implicit_value = create_empty_instance(resolve_optional(hint))
                         if trailing:
                             if trailing[0] == delimiter:
                                 trailing = trailing[1:]

--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -351,7 +351,17 @@ def _parse_kw_and_flags(
                                 actual_count=0,
                             )
                         # Allow empty iterables (e.g., --urls with no values behaves like --empty-urls)
-                        empty_container = create_empty_instance(resolve_optional(match.argument.hint))
+                        try:
+                            empty_container = create_empty_instance(resolve_optional(match.argument.hint))
+                        except TypeError as e:
+                            # ``n_tokens=-1`` sets ``consume_all`` for any type, so the hint
+                            # here isn't necessarily a constructible container.
+                            raise CoercionError(
+                                msg=e.args[0] if e.args else None,
+                                argument=match.argument,
+                                target_type=match.argument.hint,
+                                token=CliToken(keyword=match.matched_token),
+                            ) from e
                         match.argument.append(
                             CliToken(keyword=match.matched_token, implicit_value=empty_container, keys=match.keys)
                         )

--- a/cyclopts/bind.py
+++ b/cyclopts/bind.py
@@ -6,9 +6,9 @@ import sys
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import suppress
 from functools import partial
-from typing import TYPE_CHECKING, Any, NamedTuple, get_origin
+from typing import TYPE_CHECKING, Any, NamedTuple
 
-from cyclopts._convert import _bool
+from cyclopts._convert import _bool, create_empty_instance
 from cyclopts.annotations import resolve_optional
 from cyclopts.argument import Argument, ArgumentCollection
 from cyclopts.exceptions import (
@@ -351,8 +351,7 @@ def _parse_kw_and_flags(
                                 actual_count=0,
                             )
                         # Allow empty iterables (e.g., --urls with no values behaves like --empty-urls)
-                        hint = resolve_optional(match.argument.hint)
-                        empty_container = (get_origin(hint) or hint)()
+                        empty_container = create_empty_instance(resolve_optional(match.argument.hint))
                         match.argument.append(
                             CliToken(keyword=match.matched_token, implicit_value=empty_container, keys=match.keys)
                         )

--- a/tests/test_bind_empty_iterable.py
+++ b/tests/test_bind_empty_iterable.py
@@ -7,7 +7,7 @@ import pytest
 from rich.console import Console
 
 from cyclopts import CycloptsPanel, Parameter
-from cyclopts.exceptions import ConsumeMultipleError, MissingArgumentError
+from cyclopts.exceptions import CoercionError, ConsumeMultipleError, MissingArgumentError
 
 
 @pytest.mark.parametrize(
@@ -113,6 +113,30 @@ def test_abstract_iterable_empty_flag(app, hint, expected, assert_parse_args):
         pass
 
     assert_parse_args(foo, "--empty-values", values=expected)
+
+
+def test_unconstructible_empty_container_raises_cyclopts_error(app):
+    """An unconstructible hint should surface a CycloptsError, not a raw TypeError.
+
+    ``n_tokens=-1`` sets ``consume_all`` for *any* type, bypassing the iterable
+    gating that normally keeps unconstructible types away from the empty-container
+    path. Supplying values to the same annotation already raises ``CoercionError``,
+    so the zero-value case should too.
+    """
+
+    class AbstractSeq(collections.abc.Sequence):
+        """Subclasses an ABC without implementing it; cannot be instantiated."""
+
+    @app.default
+    def foo(*, values: Annotated[AbstractSeq, Parameter(n_tokens=-1, consume_multiple=True)]):
+        pass
+
+    # Sanity check: the non-empty case is already a well-formed cyclopts error.
+    with pytest.raises(CoercionError):
+        app.parse_args("--values 1 2", print_error=False, exit_on_error=False)
+
+    with pytest.raises(CoercionError):
+        app.parse_args("--values", print_error=False, exit_on_error=False)
 
 
 # --- consume_multiple=int (minimum count) ---

--- a/tests/test_bind_empty_iterable.py
+++ b/tests/test_bind_empty_iterable.py
@@ -1,3 +1,4 @@
+import collections.abc
 import textwrap
 from io import StringIO
 from typing import Annotated
@@ -70,6 +71,48 @@ def test_optional_list_consume_multiple(app, cmd_str, expected, assert_parse_arg
         assert_parse_args(foo, cmd_str)
     else:
         assert_parse_args(foo, cmd_str, expected)
+
+
+# --- Abstract collection types (https://github.com/BrianPugh/cyclopts/issues/880) ---
+
+
+@pytest.mark.parametrize(
+    "hint,expected",
+    [
+        (collections.abc.Iterable[int], []),
+        (collections.abc.Sequence[int], []),
+        (collections.abc.MutableSequence[int], []),
+        (collections.abc.Set[int], set()),
+        (collections.abc.MutableSet[int], set()),
+    ],
+)
+def test_abstract_iterable_consume_multiple_empty(app, hint, expected, assert_parse_args):
+    """An abstract collection hint should resolve to its concrete type when consuming zero values."""
+
+    @app.default
+    def foo(*, values: Annotated[hint, Parameter(consume_multiple=True, allow_repeating=False)]):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    assert_parse_args(foo, "--values", values=expected)
+
+
+@pytest.mark.parametrize(
+    "hint,expected",
+    [
+        # Only the hints that cyclopts already exposes an ``--empty-*`` flag for
+        # (i.e. members of ``ITERABLE_TYPES``).
+        (collections.abc.Iterable[int], []),
+        (collections.abc.Sequence[int], []),
+    ],
+)
+def test_abstract_iterable_empty_flag(app, hint, expected, assert_parse_args):
+    """The ``--empty-*`` flag should resolve an abstract collection hint to its concrete type."""
+
+    @app.default
+    def foo(*, values: hint):  # pyright: ignore[reportInvalidTypeForm]
+        pass
+
+    assert_parse_args(foo, "--empty-values", values=expected)
 
 
 # --- consume_multiple=int (minimum count) ---


### PR DESCRIPTION
Closes #880.

`--values` with zero tokens built the empty container by calling the hint directly, which fails for `collections.abc` types. Also converts the remaining raw `TypeError` on that path (reachable via `n_tokens=-1`) into a `CoercionError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)