### PR TITLE
Support `Collection`, `Container`, and `Reversible` type hints

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -63,6 +63,8 @@ _implicit_iterable_type_mapping: dict[type, type] = {
 
 # Mapping from abstract collection types to their concrete implementations.
 # Used to convert abstract types like collections.abc.Set to concrete types like set.
+# ``Iterator``/``Generator`` are intentionally absent: ``list`` is not a valid
+# instance of either, so there is no concrete stand-in that satisfies the hint.
 _abstract_to_concrete_type_mapping: dict[type, type] = {
     Iterable: list,
     typing.Sequence: list,
@@ -70,6 +72,9 @@ _abstract_to_concrete_type_mapping: dict[type, type] = {
     collections.abc.Set: set,
     collections.abc.MutableSet: set,
     collections.abc.MutableSequence: list,
+    collections.abc.Collection: list,
+    collections.abc.Container: list,
+    collections.abc.Reversible: list,
     collections.abc.Mapping: dict,
     collections.abc.MutableMapping: dict,
 }

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -1,8 +1,11 @@
 import inspect
 import sys
+from collections.abc import Collection as AbcCollection
+from collections.abc import Container as AbcContainer
 from collections.abc import Iterable, Sequence
 from collections.abc import MutableSequence as AbcMutableSequence
 from collections.abc import MutableSet as AbcMutableSet
+from collections.abc import Reversible as AbcReversible
 from collections.abc import Set as AbcSet
 from datetime import date, datetime, timedelta
 from enum import Enum, auto
@@ -319,9 +322,15 @@ def test_coerce_frozenset():
         (AbcSet[str], {"123", "456"}),
         (AbcMutableSet[str], {"123", "456"}),
         (AbcMutableSequence[str], ["123", "456"]),
+        (AbcCollection[str], ["123", "456"]),
+        (AbcContainer[str], ["123", "456"]),
+        (AbcReversible[str], ["123", "456"]),
         (AbcSet, {"123", "456"}),
         (AbcMutableSet, {"123", "456"}),
         (AbcMutableSequence, ["123", "456"]),
+        (AbcCollection, ["123", "456"]),
+        (AbcContainer, ["123", "456"]),
+        (AbcReversible, ["123", "456"]),
     ],
 )
 def test_coerce_abstract_collection_types(hint, expected):


### PR DESCRIPTION
Stacked on #881.

These are satisfied by `list` but were missing from the abstract-to-concrete mapping, so they raised `CoercionError: Collection() takes no arguments`. `Iterator`/`Generator` stay out: `list` is not a valid instance of either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)