### PR TITLE
Add `--empty-*` flags for abstract collection hints

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -63,6 +63,8 @@ _implicit_iterable_type_mapping: dict[type, type] = {
 
 # Mapping from abstract collection types to their concrete implementations.
 # Used to convert abstract types like collections.abc.Set to concrete types like set.
+# ``Iterator``/``Generator`` are intentionally absent: ``list`` is not a valid
+# instance of either, so there is no concrete stand-in that satisfies the hint.
 _abstract_to_concrete_type_mapping: dict[type, type] = {
     Iterable: list,
     typing.Sequence: list,
@@ -70,6 +72,9 @@ _abstract_to_concrete_type_mapping: dict[type, type] = {
     collections.abc.Set: set,
     collections.abc.MutableSet: set,
     collections.abc.MutableSequence: list,
+    collections.abc.Collection: list,
+    collections.abc.Container: list,
+    collections.abc.Reversible: list,
     collections.abc.Mapping: dict,
     collections.abc.MutableMapping: dict,
 }

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -22,6 +22,7 @@ else:
     from typing_extensions import Self
 
 import cyclopts._env_var
+from cyclopts._convert import _abstract_to_concrete_type_mapping
 from cyclopts.annotations import (
     ITERABLE_TYPES,
     NoneType,
@@ -58,7 +59,23 @@ ITERATIVE_BOOL_IMPLICIT_VALUE = frozenset(
 
 T = TypeVar("T")
 
-_NEGATIVE_FLAG_TYPES = frozenset([bool, None, NoneType, *ITERABLE_TYPES, *ITERATIVE_BOOL_IMPLICIT_VALUE])
+# Abstract collections get the same negative flag as the concrete type they resolve to,
+# so e.g. ``Sequence[int]`` and ``MutableSequence[int]`` both offer ``--empty-*``.
+# Mappings are excluded for free: ``dict`` is not in ``ITERABLE_TYPES``.
+_ABSTRACT_NEGATIVE_FLAG_TYPES = frozenset(
+    abstract for abstract, concrete in _abstract_to_concrete_type_mapping.items() if concrete in ITERABLE_TYPES
+)
+
+_NEGATIVE_FLAG_TYPES = frozenset(
+    [
+        bool,
+        None,
+        NoneType,
+        *ITERABLE_TYPES,
+        *_ABSTRACT_NEGATIVE_FLAG_TYPES,
+        *ITERATIVE_BOOL_IMPLICIT_VALUE,
+    ]
+)
 
 
 def _not_hyphen_validator(instance, attribute, values):

--- a/tests/test_bind_empty_iterable.py
+++ b/tests/test_bind_empty_iterable.py
@@ -99,10 +99,14 @@ def test_abstract_iterable_consume_multiple_empty(app, hint, expected, assert_pa
 @pytest.mark.parametrize(
     "hint,expected",
     [
-        # Only the hints that cyclopts already exposes an ``--empty-*`` flag for
-        # (i.e. members of ``ITERABLE_TYPES``).
         (collections.abc.Iterable[int], []),
         (collections.abc.Sequence[int], []),
+        (collections.abc.MutableSequence[int], []),
+        (collections.abc.Collection[int], []),
+        (collections.abc.Container[int], []),
+        (collections.abc.Reversible[int], []),
+        (collections.abc.Set[int], set()),
+        (collections.abc.MutableSet[int], set()),
     ],
 )
 def test_abstract_iterable_empty_flag(app, hint, expected, assert_parse_args):

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -1,8 +1,11 @@
 import inspect
 import sys
+from collections.abc import Collection as AbcCollection
+from collections.abc import Container as AbcContainer
 from collections.abc import Iterable, Sequence
 from collections.abc import MutableSequence as AbcMutableSequence
 from collections.abc import MutableSet as AbcMutableSet
+from collections.abc import Reversible as AbcReversible
 from collections.abc import Set as AbcSet
 from datetime import date, datetime, timedelta
 from enum import Enum, auto
@@ -319,9 +322,15 @@ def test_coerce_frozenset():
         (AbcSet[str], {"123", "456"}),
         (AbcMutableSet[str], {"123", "456"}),
         (AbcMutableSequence[str], ["123", "456"]),
+        (AbcCollection[str], ["123", "456"]),
+        (AbcContainer[str], ["123", "456"]),
+        (AbcReversible[str], ["123", "456"]),
         (AbcSet, {"123", "456"}),
         (AbcMutableSet, {"123", "456"}),
         (AbcMutableSequence, ["123", "456"]),
+        (AbcCollection, ["123", "456"]),
+        (AbcContainer, ["123", "456"]),
+        (AbcReversible, ["123", "456"]),
     ],
 )
 def test_coerce_abstract_collection_types(hint, expected):

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,3 +1,4 @@
+import collections.abc
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -731,6 +732,25 @@ def test_help_format_group_parameters_bool_or_none_custom_negative(capture_forma
 def test_help_format_group_parameters_list_flag(capture_format_group_parameters):
     def cmd(
         foo: Annotated[list[int] | None, Parameter(help="Docstring for foo.")] = None,
+    ):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO --foo --empty-foo  Docstring for foo.                          │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
+def test_help_format_group_parameters_abstract_collection_flag(capture_format_group_parameters):
+    """Abstract collection hints get the same ``--empty-*`` flag as their concrete counterparts."""
+
+    def cmd(
+        foo: Annotated[collections.abc.MutableSequence[int] | None, Parameter(help="Docstring for foo.")] = None,
     ):
         pass
 


### PR DESCRIPTION
Stacked on #882.

`Sequence[int]` offered `--empty-*` but `MutableSequence[int]`, `Set[int]`, `MutableSet[int]`, `Collection[int]`, `Container[int]`, and `Reversible[int]` did not. Eligibility is now derived from the abstract-to-concrete mapping, so an abstract hint qualifies exactly when its concrete counterpart does. Mappings are excluded for free (`dict` is not in `ITERABLE_TYPES`).

Adds flags to `--help` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)