### PR TITLE
Fix inconsistent whitespace after parameter colon in markdown docs (#887)

### DIFF
--- a/cyclopts/help/formatters/markdown.py
+++ b/cyclopts/help/formatters/markdown.py
@@ -156,8 +156,11 @@ class MarkdownFormatter:
                     else:
                         name_str = ", ".join(long_opts)
 
-                # Start the entry (no type display)
-                self._output.write(f"* `{name_str}`: ")
+                # Start the entry (no type display). No trailing space after the
+                # colon; each following piece (description/metadata) supplies its
+                # own single leading space so there is never trailing whitespace
+                # or multiple spaces after the colon (see #887).
+                self._output.write(f"* `{name_str}`:")
 
                 # Add description with proper indentation for nested content
                 desc = extract_text(entry.description, console, preserve_markup=True)
@@ -166,7 +169,7 @@ class MarkdownFormatter:
 
                     # Split into lines and indent continuation lines to nest under the bullet
                     lines = desc.split("\n")
-                    self._output.write(lines[0])  # First line on same line as bullet
+                    self._output.write(" " + lines[0])  # First line on same line as bullet
 
                     # Track what type of list context we're in for proper nesting
                     in_numbered_list = False
@@ -222,11 +225,11 @@ class MarkdownFormatter:
 
                 # Write required in bold and separate brackets first
                 if is_required:
-                    self._output.write("  **[required]**")
+                    self._output.write(" **[required]**")
 
                 # Write each metadata item in its own brackets with italics
                 for item in metadata:
-                    self._output.write(f"  *[{item}]*")
+                    self._output.write(f" *[{item}]*")
 
                 self._output.write("\n")
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_admin_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_admin_commands_markdown.md
@@ -2,10 +2,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin status
 
@@ -18,8 +18,8 @@ Show system status.
 **Parameters**:
 
 * `SERVICES, --services`: Specific services to check (all if not specified).
-* `--watch, -w`: Continuously watch status.  *[default: False]*
-* `--interval`: Refresh interval in seconds when watching.  *[default: 5]*
+* `--watch, -w`: Continuously watch status. *[default: False]*
+* `--interval`: Refresh interval in seconds when watching. *[default: 5]*
 
 ### complex-cli admin config-cmd
 
@@ -31,12 +31,12 @@ Configure database settings.
 
 **Parameters**:
 
-* `--host`: Database server hostname.  *[default: localhost]*
-* `--port`: Database server port number.  *[default: 5432]*
-* `--username`: Authentication username.  *[default: admin]*
+* `--host`: Database server hostname. *[default: localhost]*
+* `--port`: Database server port number. *[default: 5432]*
+* `--username`: Authentication username. *[default: admin]*
 * `--password`: Authentication password (optional).
-* `--ssl-mode`: SSL connection mode.  *[choices: disable, prefer, require, verify-full]*  *[default: prefer]*
-* `--pool-size`: Connection pool size.  *[default: 10]*
+* `--ssl-mode`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
+* `--pool-size`: Connection pool size. *[default: 10]*
 
 ### complex-cli admin users
 
@@ -59,10 +59,10 @@ List all users.
 
 **Parameters**:
 
-* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users.  *[default: False]*
-* `ROLE, --role`: Filter by user role.  *[choices: admin, user, guest]*
-* `LIMIT, --limit`: Maximum number of users to display.  *[default: 100]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users. *[default: False]*
+* `ROLE, --role`: Filter by user role. *[choices: admin, user, guest]*
+* `LIMIT, --limit`: Maximum number of users to display. *[default: 100]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 #### complex-cli admin users create
 
@@ -74,18 +74,18 @@ Create a new user.
 
 **Arguments**:
 
-* `USERNAME`: Unique username for the new user.  **[required]**
-* `EMAIL`: Email address for the new user.  **[required]**
+* `USERNAME`: Unique username for the new user. **[required]**
+* `EMAIL`: Email address for the new user. **[required]**
 
 **Parameters**:
 
-* `--role`: User role assignment.  *[choices: admin, user, guest]*  *[default: user]*
-* `--permissions.none, --permissions.no-none`: Initial permission flags.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Initial permission flags.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Initial permission flags.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Initial permission flags.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Initial permission flags.  *[default: False]*
-* `--send-welcome, --no-send-welcome`: Send welcome email after creation.  *[default: True]*
+* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Initial permission flags. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Initial permission flags. *[default: False]*
+* `--send-welcome, --no-send-welcome`: Send welcome email after creation. *[default: True]*
 
 #### complex-cli admin users delete
 
@@ -97,12 +97,12 @@ Delete a user.
 
 **Arguments**:
 
-* `USERNAME`: Username to delete.  **[required]**
+* `USERNAME`: Username to delete. **[required]**
 
 **Parameters**:
 
-* `--force, --no-force, -f`: Skip confirmation prompt.  *[default: False]*
-* `--backup, --no-backup`: Create backup before deletion.  *[default: True]*
+* `--force, --no-force, -f`: Skip confirmation prompt. *[default: False]*
+* `--backup, --no-backup`: Create backup before deletion. *[default: True]*
 
 #### complex-cli admin users permissions
 
@@ -118,8 +118,8 @@ Grant permissions to a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to grant.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to grant. **[required]** *[choices: none, read, write, execute, admin]*
 
 **Parameters**:
 
@@ -136,8 +136,8 @@ Revoke permissions from a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to revoke.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to revoke. **[required]** *[choices: none, read, write, execute, admin]*
 
 ##### complex-cli admin users permissions audit
 
@@ -150,8 +150,8 @@ Audit permission changes.
 **Parameters**:
 
 * `USERNAME, --username`: Filter by username (all users if not specified).
-* `DAYS, --days`: Number of days to look back.  *[default: 30]*
-* `FORMAT, --format`: Output format for audit report.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DAYS, --days`: Number of days to look back. *[default: 30]*
+* `FORMAT, --format`: Output format for audit report. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ##### complex-cli admin users permissions roles
 
@@ -172,7 +172,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ###### complex-cli admin users permissions roles create-role
 
@@ -184,13 +184,13 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_data_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_data_commands_markdown.md
@@ -2,10 +2,10 @@ Data processing commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli data process
 
@@ -20,19 +20,19 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 
 **Arguments**:
 
-* `INPUT_FILES`: Input files to process  **[required]**
+* `INPUT_FILES`: Input files to process **[required]**
 
 **Parameters**:
 
-* `--batch-size`: Number of items to process per batch.  *[default: 32]*
-* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `--quality-level`: Processing quality level. Higher values mean better quality but slower.  *[choices: high, medium, low]*  *[default: high]*
-* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index.  *[choices: cuda, cpu, auto]*  *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `--input-dir`: Input data directory.  *[default: data/input]*
-* `--output-dir`: Output results directory.  *[default: data/output]*
+* `--batch-size`: Number of items to process per batch. *[default: 32]*
+* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--input-dir`: Input data directory. *[default: data/input]*
+* `--output-dir`: Output results directory. *[default: data/output]*
 * `--cache-dir`: Cache directory for intermediate files.
-* `--log-dir`: Directory for log files.  *[default: logs]*
+* `--log-dir`: Directory for log files. *[default: logs]*
 
 ### complex-cli data pipeline
 
@@ -47,17 +47,17 @@ PathConfig and ProcessingConfig).
 
 **Parameters**:
 
-* `--name`: Pipeline name for identification.  *[default: default-pipeline]*
-* `--input-dir`: Input data directory.  *[default: data/input]*
-* `--output-dir`: Output results directory.  *[default: data/output]*
+* `--name`: Pipeline name for identification. *[default: default-pipeline]*
+* `--input-dir`: Input data directory. *[default: data/input]*
+* `--output-dir`: Output results directory. *[default: data/output]*
 * `--cache-dir`: Cache directory for intermediate files.
-* `--log-dir`: Directory for log files.  *[default: logs]*
-* `--batch-size`: Number of items to process per batch.  *[default: 32]*
-* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `--quality-level`: Processing quality level. Higher values mean better quality but slower.  *[choices: high, medium, low]*  *[default: high]*
-* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index.  *[choices: cuda, cpu, auto]*  *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `--dry-run, --no-dry-run`: If True, simulate execution without making changes.  *[default: False]*
+* `--log-dir`: Directory for log files. *[default: logs]*
+* `--batch-size`: Number of items to process per batch. *[default: 32]*
+* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
 
@@ -69,10 +69,10 @@ Validate data files against schema.
 
 **Arguments**:
 
-* `INPUT_PATH`: Path to validate.  **[required]**
+* `INPUT_PATH`: Path to validate. **[required]**
 
 **Parameters**:
 
-* `--strict, --no-strict`: Enable strict validation mode.  *[default: False]*
+* `--strict, --no-strict`: Enable strict validation mode. *[default: False]*
 * `--schema-file`: Custom schema file (must exist).
 * `--ignore-patterns, --empty-ignore-patterns`: Patterns to ignore during validation.

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_exclude_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_exclude_commands_markdown.md
@@ -2,10 +2,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin status
 
@@ -18,8 +18,8 @@ Show system status.
 **Parameters**:
 
 * `SERVICES, --services`: Specific services to check (all if not specified).
-* `--watch, -w`: Continuously watch status.  *[default: False]*
-* `--interval`: Refresh interval in seconds when watching.  *[default: 5]*
+* `--watch, -w`: Continuously watch status. *[default: False]*
+* `--interval`: Refresh interval in seconds when watching. *[default: 5]*
 
 ### complex-cli admin config-cmd
 
@@ -31,12 +31,12 @@ Configure database settings.
 
 **Parameters**:
 
-* `--host`: Database server hostname.  *[default: localhost]*
-* `--port`: Database server port number.  *[default: 5432]*
-* `--username`: Authentication username.  *[default: admin]*
+* `--host`: Database server hostname. *[default: localhost]*
+* `--port`: Database server port number. *[default: 5432]*
+* `--username`: Authentication username. *[default: admin]*
 * `--password`: Authentication password (optional).
-* `--ssl-mode`: SSL connection mode.  *[choices: disable, prefer, require, verify-full]*  *[default: prefer]*
-* `--pool-size`: Connection pool size.  *[default: 10]*
+* `--ssl-mode`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
+* `--pool-size`: Connection pool size. *[default: 10]*
 
 ### complex-cli admin users
 
@@ -59,10 +59,10 @@ List all users.
 
 **Parameters**:
 
-* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users.  *[default: False]*
-* `ROLE, --role`: Filter by user role.  *[choices: admin, user, guest]*
-* `LIMIT, --limit`: Maximum number of users to display.  *[default: 100]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users. *[default: False]*
+* `ROLE, --role`: Filter by user role. *[choices: admin, user, guest]*
+* `LIMIT, --limit`: Maximum number of users to display. *[default: 100]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 #### complex-cli admin users create
 
@@ -74,18 +74,18 @@ Create a new user.
 
 **Arguments**:
 
-* `USERNAME`: Unique username for the new user.  **[required]**
-* `EMAIL`: Email address for the new user.  **[required]**
+* `USERNAME`: Unique username for the new user. **[required]**
+* `EMAIL`: Email address for the new user. **[required]**
 
 **Parameters**:
 
-* `--role`: User role assignment.  *[choices: admin, user, guest]*  *[default: user]*
-* `--permissions.none, --permissions.no-none`: Initial permission flags.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Initial permission flags.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Initial permission flags.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Initial permission flags.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Initial permission flags.  *[default: False]*
-* `--send-welcome, --no-send-welcome`: Send welcome email after creation.  *[default: True]*
+* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Initial permission flags. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Initial permission flags. *[default: False]*
+* `--send-welcome, --no-send-welcome`: Send welcome email after creation. *[default: True]*
 
 #### complex-cli admin users delete
 
@@ -97,12 +97,12 @@ Delete a user.
 
 **Arguments**:
 
-* `USERNAME`: Username to delete.  **[required]**
+* `USERNAME`: Username to delete. **[required]**
 
 **Parameters**:
 
-* `--force, --no-force, -f`: Skip confirmation prompt.  *[default: False]*
-* `--backup, --no-backup`: Create backup before deletion.  *[default: True]*
+* `--force, --no-force, -f`: Skip confirmation prompt. *[default: False]*
+* `--backup, --no-backup`: Create backup before deletion. *[default: True]*
 
 #### complex-cli admin users permissions
 
@@ -118,8 +118,8 @@ Grant permissions to a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to grant.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to grant. **[required]** *[choices: none, read, write, execute, admin]*
 
 **Parameters**:
 
@@ -136,8 +136,8 @@ Revoke permissions from a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to revoke.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to revoke. **[required]** *[choices: none, read, write, execute, admin]*
 
 ##### complex-cli admin users permissions audit
 
@@ -150,8 +150,8 @@ Audit permission changes.
 **Parameters**:
 
 * `USERNAME, --username`: Filter by username (all users if not specified).
-* `DAYS, --days`: Number of days to look back.  *[default: 30]*
-* `FORMAT, --format`: Output format for audit report.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DAYS, --days`: Number of days to look back. *[default: 30]*
+* `FORMAT, --format`: Output format for audit report. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ##### complex-cli admin users permissions roles
 
@@ -172,7 +172,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ###### complex-cli admin users permissions roles create-role
 
@@ -184,13 +184,13 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_flattened_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_flattened_commands_markdown.md
@@ -4,10 +4,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli admin users
 
@@ -30,10 +30,10 @@ List all users.
 
 **Parameters**:
 
-* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users.  *[default: False]*
-* `ROLE, --role`: Filter by user role.  *[choices: admin, user, guest]*
-* `LIMIT, --limit`: Maximum number of users to display.  *[default: 100]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users. *[default: False]*
+* `ROLE, --role`: Filter by user role. *[choices: admin, user, guest]*
+* `LIMIT, --limit`: Maximum number of users to display. *[default: 100]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ## complex-cli admin users create
 
@@ -45,18 +45,18 @@ Create a new user.
 
 **Arguments**:
 
-* `USERNAME`: Unique username for the new user.  **[required]**
-* `EMAIL`: Email address for the new user.  **[required]**
+* `USERNAME`: Unique username for the new user. **[required]**
+* `EMAIL`: Email address for the new user. **[required]**
 
 **Parameters**:
 
-* `--role`: User role assignment.  *[choices: admin, user, guest]*  *[default: user]*
-* `--permissions.none, --permissions.no-none`: Initial permission flags.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Initial permission flags.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Initial permission flags.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Initial permission flags.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Initial permission flags.  *[default: False]*
-* `--send-welcome, --no-send-welcome`: Send welcome email after creation.  *[default: True]*
+* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Initial permission flags. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Initial permission flags. *[default: False]*
+* `--send-welcome, --no-send-welcome`: Send welcome email after creation. *[default: True]*
 
 ## complex-cli admin users delete
 
@@ -68,12 +68,12 @@ Delete a user.
 
 **Arguments**:
 
-* `USERNAME`: Username to delete.  **[required]**
+* `USERNAME`: Username to delete. **[required]**
 
 **Parameters**:
 
-* `--force, --no-force, -f`: Skip confirmation prompt.  *[default: False]*
-* `--backup, --no-backup`: Create backup before deletion.  *[default: True]*
+* `--force, --no-force, -f`: Skip confirmation prompt. *[default: False]*
+* `--backup, --no-backup`: Create backup before deletion. *[default: True]*
 
 ## complex-cli admin users permissions
 
@@ -89,8 +89,8 @@ Grant permissions to a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to grant.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to grant. **[required]** *[choices: none, read, write, execute, admin]*
 
 **Parameters**:
 
@@ -107,8 +107,8 @@ Revoke permissions from a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to revoke.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to revoke. **[required]** *[choices: none, read, write, execute, admin]*
 
 ## complex-cli admin users permissions audit
 
@@ -121,8 +121,8 @@ Audit permission changes.
 **Parameters**:
 
 * `USERNAME, --username`: Filter by username (all users if not specified).
-* `DAYS, --days`: Number of days to look back.  *[default: 30]*
-* `FORMAT, --format`: Output format for audit report.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DAYS, --days`: Number of days to look back. *[default: 30]*
+* `FORMAT, --format`: Output format for audit report. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ## complex-cli admin users permissions roles
 
@@ -143,7 +143,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ## complex-cli admin users permissions roles create-role
 
@@ -155,13 +155,13 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
@@ -44,10 +44,10 @@ Complex CLI application for comprehensive documentation testing.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Subcommands**:
 
@@ -77,10 +77,10 @@ Displays the application version and system information.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli info
 
@@ -92,15 +92,15 @@ Show application information.
 
 **Parameters**:
 
-* `DETAILED, --detailed, --no-detailed`: Show detailed information including dependencies.  *[default: False]*
-* `FORMAT, --format`: Output format for the information.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DETAILED, --detailed, --no-detailed`: Show detailed information including dependencies. *[default: False]*
+* `FORMAT, --format`: Output format for the information. *[choices: json, yaml, table, csv]* *[default: table]*
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli admin
 
@@ -108,10 +108,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin status
 
@@ -124,8 +124,8 @@ Show system status.
 **Parameters**:
 
 * `SERVICES, --services`: Specific services to check (all if not specified).
-* `--watch, -w`: Continuously watch status.  *[default: False]*
-* `--interval`: Refresh interval in seconds when watching.  *[default: 5]*
+* `--watch, -w`: Continuously watch status. *[default: False]*
+* `--interval`: Refresh interval in seconds when watching. *[default: 5]*
 
 ### complex-cli admin config-cmd
 
@@ -137,12 +137,12 @@ Configure database settings.
 
 **Parameters**:
 
-* `--host`: Database server hostname.  *[default: localhost]*
-* `--port`: Database server port number.  *[default: 5432]*
-* `--username`: Authentication username.  *[default: admin]*
+* `--host`: Database server hostname. *[default: localhost]*
+* `--port`: Database server port number. *[default: 5432]*
+* `--username`: Authentication username. *[default: admin]*
 * `--password`: Authentication password (optional).
-* `--ssl-mode`: SSL connection mode.  *[choices: disable, prefer, require, verify-full]*  *[default: prefer]*
-* `--pool-size`: Connection pool size.  *[default: 10]*
+* `--ssl-mode`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
+* `--pool-size`: Connection pool size. *[default: 10]*
 
 ### complex-cli admin users
 
@@ -165,10 +165,10 @@ List all users.
 
 **Parameters**:
 
-* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users.  *[default: False]*
-* `ROLE, --role`: Filter by user role.  *[choices: admin, user, guest]*
-* `LIMIT, --limit`: Maximum number of users to display.  *[default: 100]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users. *[default: False]*
+* `ROLE, --role`: Filter by user role. *[choices: admin, user, guest]*
+* `LIMIT, --limit`: Maximum number of users to display. *[default: 100]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 #### complex-cli admin users create
 
@@ -180,18 +180,18 @@ Create a new user.
 
 **Arguments**:
 
-* `USERNAME`: Unique username for the new user.  **[required]**
-* `EMAIL`: Email address for the new user.  **[required]**
+* `USERNAME`: Unique username for the new user. **[required]**
+* `EMAIL`: Email address for the new user. **[required]**
 
 **Parameters**:
 
-* `--role`: User role assignment.  *[choices: admin, user, guest]*  *[default: user]*
-* `--permissions.none, --permissions.no-none`: Initial permission flags.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Initial permission flags.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Initial permission flags.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Initial permission flags.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Initial permission flags.  *[default: False]*
-* `--send-welcome, --no-send-welcome`: Send welcome email after creation.  *[default: True]*
+* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Initial permission flags. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Initial permission flags. *[default: False]*
+* `--send-welcome, --no-send-welcome`: Send welcome email after creation. *[default: True]*
 
 #### complex-cli admin users delete
 
@@ -203,12 +203,12 @@ Delete a user.
 
 **Arguments**:
 
-* `USERNAME`: Username to delete.  **[required]**
+* `USERNAME`: Username to delete. **[required]**
 
 **Parameters**:
 
-* `--force, --no-force, -f`: Skip confirmation prompt.  *[default: False]*
-* `--backup, --no-backup`: Create backup before deletion.  *[default: True]*
+* `--force, --no-force, -f`: Skip confirmation prompt. *[default: False]*
+* `--backup, --no-backup`: Create backup before deletion. *[default: True]*
 
 #### complex-cli admin users permissions
 
@@ -224,8 +224,8 @@ Grant permissions to a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to grant.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to grant. **[required]** *[choices: none, read, write, execute, admin]*
 
 **Parameters**:
 
@@ -242,8 +242,8 @@ Revoke permissions from a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to revoke.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to revoke. **[required]** *[choices: none, read, write, execute, admin]*
 
 ##### complex-cli admin users permissions audit
 
@@ -256,8 +256,8 @@ Audit permission changes.
 **Parameters**:
 
 * `USERNAME, --username`: Filter by username (all users if not specified).
-* `DAYS, --days`: Number of days to look back.  *[default: 30]*
-* `FORMAT, --format`: Output format for audit report.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DAYS, --days`: Number of days to look back. *[default: 30]*
+* `FORMAT, --format`: Output format for audit report. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ##### complex-cli admin users permissions roles
 
@@ -278,7 +278,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ###### complex-cli admin users permissions roles create-role
 
@@ -290,16 +290,16 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*
 
 ## complex-cli data
 
@@ -307,10 +307,10 @@ Data processing commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli data process
 
@@ -325,19 +325,19 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 
 **Arguments**:
 
-* `INPUT_FILES`: Input files to process  **[required]**
+* `INPUT_FILES`: Input files to process **[required]**
 
 **Parameters**:
 
-* `--batch-size`: Number of items to process per batch.  *[default: 32]*
-* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `--quality-level`: Processing quality level. Higher values mean better quality but slower.  *[choices: high, medium, low]*  *[default: high]*
-* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index.  *[choices: cuda, cpu, auto]*  *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `--input-dir`: Input data directory.  *[default: data/input]*
-* `--output-dir`: Output results directory.  *[default: data/output]*
+* `--batch-size`: Number of items to process per batch. *[default: 32]*
+* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--input-dir`: Input data directory. *[default: data/input]*
+* `--output-dir`: Output results directory. *[default: data/output]*
 * `--cache-dir`: Cache directory for intermediate files.
-* `--log-dir`: Directory for log files.  *[default: logs]*
+* `--log-dir`: Directory for log files. *[default: logs]*
 
 ### complex-cli data pipeline
 
@@ -352,17 +352,17 @@ PathConfig and ProcessingConfig).
 
 **Parameters**:
 
-* `--name`: Pipeline name for identification.  *[default: default-pipeline]*
-* `--input-dir`: Input data directory.  *[default: data/input]*
-* `--output-dir`: Output results directory.  *[default: data/output]*
+* `--name`: Pipeline name for identification. *[default: default-pipeline]*
+* `--input-dir`: Input data directory. *[default: data/input]*
+* `--output-dir`: Output results directory. *[default: data/output]*
 * `--cache-dir`: Cache directory for intermediate files.
-* `--log-dir`: Directory for log files.  *[default: logs]*
-* `--batch-size`: Number of items to process per batch.  *[default: 32]*
-* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `--quality-level`: Processing quality level. Higher values mean better quality but slower.  *[choices: high, medium, low]*  *[default: high]*
-* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index.  *[choices: cuda, cpu, auto]*  *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `--dry-run, --no-dry-run`: If True, simulate execution without making changes.  *[default: False]*
+* `--log-dir`: Directory for log files. *[default: logs]*
+* `--batch-size`: Number of items to process per batch. *[default: 32]*
+* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
 
@@ -374,11 +374,11 @@ Validate data files against schema.
 
 **Arguments**:
 
-* `INPUT_PATH`: Path to validate.  **[required]**
+* `INPUT_PATH`: Path to validate. **[required]**
 
 **Parameters**:
 
-* `--strict, --no-strict`: Enable strict validation mode.  *[default: False]*
+* `--strict, --no-strict`: Enable strict validation mode. *[default: False]*
 * `--schema-file`: Custom schema file (must exist).
 * `--ignore-patterns, --empty-ignore-patterns`: Patterns to ignore during validation.
 
@@ -388,10 +388,10 @@ Server management commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli server start
 
@@ -405,15 +405,15 @@ Demonstrates Pydantic model support for CLI parameters.
 
 **Parameters**:
 
-* `--server.host`: Server bind address.  *[default: 0.0.0.0]*
-* `--server.port`: Server port number.  *[default: 8000]*
-* `--server.workers`: Number of worker processes.  *[default: 4]*
-* `--server.timeout`: Request timeout in seconds.  *[default: 30.0]*
-* `--server.debug, --server.no-debug`: Enable debug mode.  *[default: False]*
-* `--auth.provider`: Authentication provider type.  *[choices: oauth2, jwt, basic, none]*  *[default: jwt]*
-* `--auth.token-expiry`: Token expiration time in seconds.  *[default: 3600]*
-* `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh.  *[default: True]*
-* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.  *[default: ['*']]*
+* `--server.host`: Server bind address. *[default: 0.0.0.0]*
+* `--server.port`: Server port number. *[default: 8000]*
+* `--server.workers`: Number of worker processes. *[default: 4]*
+* `--server.timeout`: Request timeout in seconds. *[default: 30.0]*
+* `--server.debug, --server.no-debug`: Enable debug mode. *[default: False]*
+* `--auth.provider`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
+* `--auth.token-expiry`: Token expiration time in seconds. *[default: 3600]*
+* `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
+* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
 
 ### complex-cli server stop
 
@@ -425,9 +425,9 @@ Stop the server.
 
 **Parameters**:
 
-* `--graceful, --no-graceful`: Perform graceful shutdown.  *[default: True]*
-* `--timeout`: Shutdown timeout in seconds.  *[default: 30]*
-* `--force, --no-force, -f`: Force immediate shutdown.  *[default: False]*
+* `--graceful, --no-graceful`: Perform graceful shutdown. *[default: True]*
+* `--timeout`: Shutdown timeout in seconds. *[default: 30]*
+* `--force, --no-force, -f`: Force immediate shutdown. *[default: False]*
 
 ### complex-cli server restart
 
@@ -439,8 +439,8 @@ Restart the server.
 
 **Parameters**:
 
-* `ROLLING, --rolling, --no-rolling`: Perform rolling restart (zero downtime).  *[default: False]*
-* `DELAY, --delay`: Delay between worker restarts in seconds.  *[default: 5]*
+* `ROLLING, --rolling, --no-rolling`: Perform rolling restart (zero downtime). *[default: False]*
+* `DELAY, --delay`: Delay between worker restarts in seconds. *[default: 5]*
 
 ## complex-cli cache
 
@@ -448,10 +448,10 @@ Cache management commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli cache configure
 
@@ -465,10 +465,10 @@ Demonstrates attrs class support for CLI parameters.
 
 **Parameters**:
 
-* `--config.backend`: Cache backend type.  *[choices: memory, redis, memcached, disk]*  *[default: memory]*
-* `--config.ttl`: Time-to-live in seconds.  *[default: 300]*
-* `--config.max-size`: Maximum cache size in MB.  *[default: 1024]*
-* `--config.compression, --config.no-compression`: Enable compression.  *[default: False]*
+* `--config.backend`: Cache backend type. *[choices: memory, redis, memcached, disk]* *[default: memory]*
+* `--config.ttl`: Time-to-live in seconds. *[default: 300]*
+* `--config.max-size`: Maximum cache size in MB. *[default: 1024]*
+* `--config.compression, --config.no-compression`: Enable compression. *[default: False]*
 
 ### complex-cli cache clear
 
@@ -480,8 +480,8 @@ Clear cache entries.
 
 **Parameters**:
 
-* `PATTERN, --pattern`: Pattern to match cache keys.  *[default: *]*
-* `DRY-RUN, --dry-run, --no-dry-run`: Show what would be cleared without actually clearing.  *[default: False]*
+* `PATTERN, --pattern`: Pattern to match cache keys. *[default: *]*
+* `DRY-RUN, --dry-run, --no-dry-run`: Show what would be cleared without actually clearing. *[default: False]*
 
 ### complex-cli cache stats
 
@@ -493,8 +493,8 @@ Show cache statistics.
 
 **Parameters**:
 
-* `DETAILED, --detailed, --no-detailed`: Show detailed statistics.  *[default: False]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DETAILED, --detailed, --no-detailed`: Show detailed statistics. *[default: False]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ## complex-cli complex-types
 
@@ -509,19 +509,19 @@ documentation system needs to handle correctly.
 
 **Parameters**:
 
-* `WORKER-COUNT, --worker-count`: Number of workers or "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `QUALITY, --quality`: Quality preset or "custom" for manual configuration.  *[choices: low, medium, high, custom]*  *[default: medium]*
+* `WORKER-COUNT, --worker-count`: Number of workers or "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `QUALITY, --quality`: Quality preset or "custom" for manual configuration. *[choices: low, medium, high, custom]* *[default: medium]*
 * `TAGS, --tags, --empty-tags`: Optional list of tags.
-* `FORMATS, --formats, --empty-formats`: List of output formats.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `THRESHOLDS, --thresholds, --empty-thresholds`: Threshold values or "default" for defaults.  *[choices: default]*  *[default: default]*
+* `FORMATS, --formats, --empty-formats`: List of output formats. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `THRESHOLDS, --thresholds, --empty-thresholds`: Threshold values or "default" for defaults. *[choices: default]* *[default: default]*
 * `CONFIG-PATH, --config-path`: Optional config file path (must exist if provided).
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli numpy-style
 
@@ -536,15 +536,15 @@ default for cyclopts.
 
 **Parameters**:
 
-* `NAME, --name`: The name parameter.  **[required]**
-* `COUNT, --count`: The count parameter, by default 1.  *[default: 1]*
+* `NAME, --name`: The name parameter. **[required]**
+* `COUNT, --count`: The count parameter, by default 1. *[default: 1]*
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli google-style
 
@@ -558,15 +558,15 @@ This command demonstrates Google docstring format.
 
 **Parameters**:
 
-* `NAME, --name`: The name parameter.  **[required]**
-* `COUNT, --count`: The count parameter. Defaults to 1.  *[default: 1]*
+* `NAME, --name`: The name parameter. **[required]**
+* `COUNT, --count`: The count parameter. Defaults to 1. *[default: 1]*
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli sphinx-style
 
@@ -580,15 +580,15 @@ This command demonstrates Sphinx/reST docstring format.
 
 **Parameters**:
 
-* `NAME, --name`: The name parameter.  **[required]**
-* `COUNT, --count`: The count parameter.  *[default: 1]*
+* `NAME, --name`: The name parameter. **[required]**
+* `COUNT, --count`: The count parameter. *[default: 1]*
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli secret-feature
 
@@ -602,11 +602,11 @@ This command has a hidden parameter.
 
 **Parameters**:
 
-* `ENABLE, --enable, --no-enable`: Enable the secret feature.  *[default: False]*
+* `ENABLE, --enable, --no-enable`: Enable the secret feature. *[default: False]*
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_hidden_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_hidden_commands_markdown.md
@@ -8,10 +8,10 @@ Complex CLI application for comprehensive documentation testing.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Subcommands**:
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_nested_permissions_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_nested_permissions_markdown.md
@@ -4,10 +4,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 #### complex-cli admin users
 
@@ -31,8 +31,8 @@ Grant permissions to a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to grant.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to grant. **[required]** *[choices: none, read, write, execute, admin]*
 
 **Parameters**:
 
@@ -49,8 +49,8 @@ Revoke permissions from a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to revoke.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to revoke. **[required]** *[choices: none, read, write, execute, admin]*
 
 ###### complex-cli admin users permissions audit
 
@@ -63,8 +63,8 @@ Audit permission changes.
 **Parameters**:
 
 * `USERNAME, --username`: Filter by username (all users if not specified).
-* `DAYS, --days`: Number of days to look back.  *[default: 30]*
-* `FORMAT, --format`: Output format for audit report.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DAYS, --days`: Number of days to look back. *[default: 30]*
+* `FORMAT, --format`: Output format for audit report. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ###### complex-cli admin users permissions roles
 
@@ -85,7 +85,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ###### complex-cli admin users permissions roles create-role
 
@@ -97,13 +97,13 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
@@ -2,10 +2,10 @@ Server management commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli server start
 
@@ -19,15 +19,15 @@ Demonstrates Pydantic model support for CLI parameters.
 
 **Parameters**:
 
-* `--server.host`: Server bind address.  *[default: 0.0.0.0]*
-* `--server.port`: Server port number.  *[default: 8000]*
-* `--server.workers`: Number of worker processes.  *[default: 4]*
-* `--server.timeout`: Request timeout in seconds.  *[default: 30.0]*
-* `--server.debug, --server.no-debug`: Enable debug mode.  *[default: False]*
-* `--auth.provider`: Authentication provider type.  *[choices: oauth2, jwt, basic, none]*  *[default: jwt]*
-* `--auth.token-expiry`: Token expiration time in seconds.  *[default: 3600]*
-* `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh.  *[default: True]*
-* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.  *[default: ['*']]*
+* `--server.host`: Server bind address. *[default: 0.0.0.0]*
+* `--server.port`: Server port number. *[default: 8000]*
+* `--server.workers`: Number of worker processes. *[default: 4]*
+* `--server.timeout`: Request timeout in seconds. *[default: 30.0]*
+* `--server.debug, --server.no-debug`: Enable debug mode. *[default: False]*
+* `--auth.provider`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
+* `--auth.token-expiry`: Token expiration time in seconds. *[default: 3600]*
+* `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
+* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
 
 ### complex-cli server stop
 
@@ -39,9 +39,9 @@ Stop the server.
 
 **Parameters**:
 
-* `--graceful, --no-graceful`: Perform graceful shutdown.  *[default: True]*
-* `--timeout`: Shutdown timeout in seconds.  *[default: 30]*
-* `--force, --no-force, -f`: Force immediate shutdown.  *[default: False]*
+* `--graceful, --no-graceful`: Perform graceful shutdown. *[default: True]*
+* `--timeout`: Shutdown timeout in seconds. *[default: 30]*
+* `--force, --no-force, -f`: Force immediate shutdown. *[default: False]*
 
 ### complex-cli server restart
 
@@ -53,5 +53,5 @@ Restart the server.
 
 **Parameters**:
 
-* `ROLLING, --rolling, --no-rolling`: Perform rolling restart (zero downtime).  *[default: False]*
-* `DELAY, --delay`: Delay between worker restarts in seconds.  *[default: 5]*
+* `ROLLING, --rolling, --no-rolling`: Perform rolling restart (zero downtime). *[default: False]*
+* `DELAY, --delay`: Delay between worker restarts in seconds. *[default: 5]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_utilities_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_utilities_markdown.md
@@ -8,10 +8,10 @@ Complex CLI application for comprehensive documentation testing.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Utilities**:
 
@@ -32,10 +32,10 @@ Displays the application version and system information.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli info
 
@@ -47,15 +47,15 @@ Show application information.
 
 **Parameters**:
 
-* `DETAILED, --detailed, --no-detailed`: Show detailed information including dependencies.  *[default: False]*
-* `FORMAT, --format`: Output format for the information.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DETAILED, --detailed, --no-detailed`: Show detailed information including dependencies. *[default: False]*
+* `FORMAT, --format`: Output format for the information. *[choices: json, yaml, table, csv]* *[default: table]*
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli cache
 
@@ -63,10 +63,10 @@ Cache management commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 #### complex-cli cache configure
 
@@ -80,10 +80,10 @@ Demonstrates attrs class support for CLI parameters.
 
 **Parameters**:
 
-* `--config.backend`: Cache backend type.  *[choices: memory, redis, memcached, disk]*  *[default: memory]*
-* `--config.ttl`: Time-to-live in seconds.  *[default: 300]*
-* `--config.max-size`: Maximum cache size in MB.  *[default: 1024]*
-* `--config.compression, --config.no-compression`: Enable compression.  *[default: False]*
+* `--config.backend`: Cache backend type. *[choices: memory, redis, memcached, disk]* *[default: memory]*
+* `--config.ttl`: Time-to-live in seconds. *[default: 300]*
+* `--config.max-size`: Maximum cache size in MB. *[default: 1024]*
+* `--config.compression, --config.no-compression`: Enable compression. *[default: False]*
 
 #### complex-cli cache clear
 
@@ -95,8 +95,8 @@ Clear cache entries.
 
 **Parameters**:
 
-* `PATTERN, --pattern`: Pattern to match cache keys.  *[default: *]*
-* `DRY-RUN, --dry-run, --no-dry-run`: Show what would be cleared without actually clearing.  *[default: False]*
+* `PATTERN, --pattern`: Pattern to match cache keys. *[default: *]*
+* `DRY-RUN, --dry-run, --no-dry-run`: Show what would be cleared without actually clearing. *[default: False]*
 
 #### complex-cli cache stats
 
@@ -108,8 +108,8 @@ Show cache statistics.
 
 **Parameters**:
 
-* `DETAILED, --detailed, --no-detailed`: Show detailed statistics.  *[default: False]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DETAILED, --detailed, --no-detailed`: Show detailed statistics. *[default: False]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ### complex-cli complex-types
 
@@ -124,16 +124,16 @@ documentation system needs to handle correctly.
 
 **Parameters**:
 
-* `WORKER-COUNT, --worker-count`: Number of workers or "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `QUALITY, --quality`: Quality preset or "custom" for manual configuration.  *[choices: low, medium, high, custom]*  *[default: medium]*
+* `WORKER-COUNT, --worker-count`: Number of workers or "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `QUALITY, --quality`: Quality preset or "custom" for manual configuration. *[choices: low, medium, high, custom]* *[default: medium]*
 * `TAGS, --tags, --empty-tags`: Optional list of tags.
-* `FORMATS, --formats, --empty-formats`: List of output formats.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `THRESHOLDS, --thresholds, --empty-thresholds`: Threshold values or "default" for defaults.  *[choices: default]*  *[default: default]*
+* `FORMATS, --formats, --empty-formats`: List of output formats. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `THRESHOLDS, --thresholds, --empty-thresholds`: Threshold values or "default" for defaults. *[choices: default]* *[default: default]*
 * `CONFIG-PATH, --config-path`: Optional config file path (must exist if provided).
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_filtered_directive_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_filtered_directive_output.md
@@ -6,10 +6,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin users
 
@@ -32,10 +32,10 @@ List all users.
 
 **Parameters**:
 
-* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users.  *[default: False]*
-* `ROLE, --role`: Filter by user role.  *[choices: admin, user, guest]*
-* `LIMIT, --limit`: Maximum number of users to display.  *[default: 100]*
-* `FORMAT, --format`: Output format.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `ACTIVE-ONLY, --active-only, --no-active-only`: Show only active users. *[default: False]*
+* `ROLE, --role`: Filter by user role. *[choices: admin, user, guest]*
+* `LIMIT, --limit`: Maximum number of users to display. *[default: 100]*
+* `FORMAT, --format`: Output format. *[choices: json, yaml, table, csv]* *[default: table]*
 
 #### complex-cli admin users create
 
@@ -47,18 +47,18 @@ Create a new user.
 
 **Arguments**:
 
-* `USERNAME`: Unique username for the new user.  **[required]**
-* `EMAIL`: Email address for the new user.  **[required]**
+* `USERNAME`: Unique username for the new user. **[required]**
+* `EMAIL`: Email address for the new user. **[required]**
 
 **Parameters**:
 
-* `--role`: User role assignment.  *[choices: admin, user, guest]*  *[default: user]*
-* `--permissions.none, --permissions.no-none`: Initial permission flags.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Initial permission flags.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Initial permission flags.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Initial permission flags.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Initial permission flags.  *[default: False]*
-* `--send-welcome, --no-send-welcome`: Send welcome email after creation.  *[default: True]*
+* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Initial permission flags. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Initial permission flags. *[default: False]*
+* `--send-welcome, --no-send-welcome`: Send welcome email after creation. *[default: True]*
 
 #### complex-cli admin users delete
 
@@ -70,12 +70,12 @@ Delete a user.
 
 **Arguments**:
 
-* `USERNAME`: Username to delete.  **[required]**
+* `USERNAME`: Username to delete. **[required]**
 
 **Parameters**:
 
-* `--force, --no-force, -f`: Skip confirmation prompt.  *[default: False]*
-* `--backup, --no-backup`: Create backup before deletion.  *[default: True]*
+* `--force, --no-force, -f`: Skip confirmation prompt. *[default: False]*
+* `--backup, --no-backup`: Create backup before deletion. *[default: True]*
 
 #### complex-cli admin users permissions
 
@@ -91,8 +91,8 @@ Grant permissions to a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to grant.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to grant. **[required]** *[choices: none, read, write, execute, admin]*
 
 **Parameters**:
 
@@ -109,8 +109,8 @@ Revoke permissions from a user.
 
 **Arguments**:
 
-* `USERNAME`: Target username.  **[required]**
-* `PERMISSION`: Permission flags to revoke.  **[required]**  *[choices: none, read, write, execute, admin]*
+* `USERNAME`: Target username. **[required]**
+* `PERMISSION`: Permission flags to revoke. **[required]** *[choices: none, read, write, execute, admin]*
 
 ##### complex-cli admin users permissions audit
 
@@ -123,8 +123,8 @@ Audit permission changes.
 **Parameters**:
 
 * `USERNAME, --username`: Filter by username (all users if not specified).
-* `DAYS, --days`: Number of days to look back.  *[default: 30]*
-* `FORMAT, --format`: Output format for audit report.  *[choices: json, yaml, table, csv]*  *[default: table]*
+* `DAYS, --days`: Number of days to look back. *[default: 30]*
+* `FORMAT, --format`: Output format for audit report. *[choices: json, yaml, table, csv]* *[default: table]*
 
 ##### complex-cli admin users permissions roles
 
@@ -145,7 +145,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ###### complex-cli admin users permissions roles create-role
 
@@ -157,13 +157,13 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
@@ -6,10 +6,10 @@ Data processing commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli data process
 
@@ -24,19 +24,19 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 
 **Arguments**:
 
-* `INPUT_FILES`: Input files to process  **[required]**
+* `INPUT_FILES`: Input files to process **[required]**
 
 **Parameters**:
 
-* `--batch-size`: Number of items to process per batch.  *[default: 32]*
-* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `--quality-level`: Processing quality level. Higher values mean better quality but slower.  *[choices: high, medium, low]*  *[default: high]*
-* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index.  *[choices: cuda, cpu, auto]*  *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `--input-dir`: Input data directory.  *[default: data/input]*
-* `--output-dir`: Output results directory.  *[default: data/output]*
+* `--batch-size`: Number of items to process per batch. *[default: 32]*
+* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--input-dir`: Input data directory. *[default: data/input]*
+* `--output-dir`: Output results directory. *[default: data/output]*
 * `--cache-dir`: Cache directory for intermediate files.
-* `--log-dir`: Directory for log files.  *[default: logs]*
+* `--log-dir`: Directory for log files. *[default: logs]*
 
 ### complex-cli data pipeline
 
@@ -51,17 +51,17 @@ PathConfig and ProcessingConfig).
 
 **Parameters**:
 
-* `--name`: Pipeline name for identification.  *[default: default-pipeline]*
-* `--input-dir`: Input data directory.  *[default: data/input]*
-* `--output-dir`: Output results directory.  *[default: data/output]*
+* `--name`: Pipeline name for identification. *[default: default-pipeline]*
+* `--input-dir`: Input data directory. *[default: data/input]*
+* `--output-dir`: Output results directory. *[default: data/output]*
 * `--cache-dir`: Cache directory for intermediate files.
-* `--log-dir`: Directory for log files.  *[default: logs]*
-* `--batch-size`: Number of items to process per batch.  *[default: 32]*
-* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection.  *[choices: auto]*  *[default: auto]*
-* `--quality-level`: Processing quality level. Higher values mean better quality but slower.  *[choices: high, medium, low]*  *[default: high]*
-* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index.  *[choices: cuda, cpu, auto]*  *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate.  *[choices: json, yaml, table, csv]*  *[default: [json]]*
-* `--dry-run, --no-dry-run`: If True, simulate execution without making changes.  *[default: False]*
+* `--log-dir`: Directory for log files. *[default: logs]*
+* `--batch-size`: Number of items to process per batch. *[default: 32]*
+* `--num-workers`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
 
@@ -73,11 +73,11 @@ Validate data files against schema.
 
 **Arguments**:
 
-* `INPUT_PATH`: Path to validate.  **[required]**
+* `INPUT_PATH`: Path to validate. **[required]**
 
 **Parameters**:
 
-* `--strict, --no-strict`: Enable strict validation mode.  *[default: False]*
+* `--strict, --no-strict`: Enable strict validation mode. *[default: False]*
 * `--schema-file`: Custom schema file (must exist).
 * `--ignore-patterns, --empty-ignore-patterns`: Patterns to ignore during validation.
 
@@ -87,10 +87,10 @@ Server management commands.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli server start
 
@@ -104,15 +104,15 @@ Demonstrates Pydantic model support for CLI parameters.
 
 **Parameters**:
 
-* `--server.host`: Server bind address.  *[default: 0.0.0.0]*
-* `--server.port`: Server port number.  *[default: 8000]*
-* `--server.workers`: Number of worker processes.  *[default: 4]*
-* `--server.timeout`: Request timeout in seconds.  *[default: 30.0]*
-* `--server.debug, --server.no-debug`: Enable debug mode.  *[default: False]*
-* `--auth.provider`: Authentication provider type.  *[choices: oauth2, jwt, basic, none]*  *[default: jwt]*
-* `--auth.token-expiry`: Token expiration time in seconds.  *[default: 3600]*
-* `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh.  *[default: True]*
-* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins.  *[default: ['*']]*
+* `--server.host`: Server bind address. *[default: 0.0.0.0]*
+* `--server.port`: Server port number. *[default: 8000]*
+* `--server.workers`: Number of worker processes. *[default: 4]*
+* `--server.timeout`: Request timeout in seconds. *[default: 30.0]*
+* `--server.debug, --server.no-debug`: Enable debug mode. *[default: False]*
+* `--auth.provider`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
+* `--auth.token-expiry`: Token expiration time in seconds. *[default: 3600]*
+* `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
+* `--auth.allowed-origins, --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
 
 ### complex-cli server stop
 
@@ -124,9 +124,9 @@ Stop the server.
 
 **Parameters**:
 
-* `--graceful, --no-graceful`: Perform graceful shutdown.  *[default: True]*
-* `--timeout`: Shutdown timeout in seconds.  *[default: 30]*
-* `--force, --no-force, -f`: Force immediate shutdown.  *[default: False]*
+* `--graceful, --no-graceful`: Perform graceful shutdown. *[default: True]*
+* `--timeout`: Shutdown timeout in seconds. *[default: 30]*
+* `--force, --no-force, -f`: Force immediate shutdown. *[default: False]*
 
 ### complex-cli server restart
 
@@ -138,5 +138,5 @@ Restart the server.
 
 **Parameters**:
 
-* `ROLLING, --rolling, --no-rolling`: Perform rolling restart (zero downtime).  *[default: False]*
-* `DELAY, --delay`: Delay between worker restarts in seconds.  *[default: 5]*
+* `ROLLING, --rolling, --no-rolling`: Perform rolling restart (zero downtime). *[default: False]*
+* `DELAY, --delay`: Delay between worker restarts in seconds. *[default: 5]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_nested_directive_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_nested_directive_output.md
@@ -6,10 +6,10 @@ Administrative commands for system management.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 #### complex-cli admin users
 
@@ -42,7 +42,7 @@ List all role templates.
 
 **Parameters**:
 
-* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles.  *[default: False]*
+* `INCLUDE-SYSTEM, --include-system, --no-include-system`: Include built-in system roles. *[default: False]*
 
 ###### complex-cli admin users permissions roles create-role
 
@@ -54,13 +54,13 @@ Create a new role template.
 
 **Arguments**:
 
-* `NAME`: Role name.  **[required]**
+* `NAME`: Role name. **[required]**
 
 **Parameters**:
 
-* `--permissions.none, --permissions.no-none`: Default permissions for this role.  *[default: False]*
-* `--permissions.read, --permissions.no-read`: Default permissions for this role.  *[default: False]*
-* `--permissions.write, --permissions.no-write`: Default permissions for this role.  *[default: False]*
-* `--permissions.execute, --permissions.no-execute`: Default permissions for this role.  *[default: False]*
-* `--permissions.admin, --permissions.no-admin`: Default permissions for this role.  *[default: False]*
-* `--description`: Role description.  *[default: ""]*
+* `--permissions.none, --permissions.no-none`: Default permissions for this role. *[default: False]*
+* `--permissions.read, --permissions.no-read`: Default permissions for this role. *[default: False]*
+* `--permissions.write, --permissions.no-write`: Default permissions for this role. *[default: False]*
+* `--permissions.execute, --permissions.no-execute`: Default permissions for this role. *[default: False]*
+* `--permissions.admin, --permissions.no-admin`: Default permissions for this role. *[default: False]*
+* `--description`: Role description. *[default: ""]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_simple_directive_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_simple_directive_output.md
@@ -8,10 +8,10 @@ Complex CLI application for comprehensive documentation testing.
 
 **Global Options**:
 
-* `--verbose, -v`: Verbosity level (-v, -vv, -vvv).  *[default: 0]*
-* `--quiet, --no-quiet, -q`: Suppress non-essential output.  *[default: False]*
-* `--log-level`: Logging level.  *[choices: debug, info, warning, error, critical]*  *[default: info]*
-* `--no-color, --no-no-color`: Disable colored output  *[default: False]*
+* `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
+* `--quiet, --no-quiet, -q`: Suppress non-essential output. *[default: False]*
+* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Subcommands**:
 

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -41,8 +41,8 @@ def test_generate_docs_simple_app():
 
         **Parameters**:
 
-        * `NAME, --name`: Your name.  **[required]**
-        * `VERBOSE, --verbose, --no-verbose`: Enable verbose output.  *[default: False]*
+        * `NAME, --name`: Your name. **[required]**
+        * `VERBOSE, --verbose, --no-verbose`: Enable verbose output. *[default: False]*
         """
     )
 
@@ -93,12 +93,12 @@ def test_generate_docs_with_commands():
     assert "## myapp serve" in actual
     assert "Start the server." in actual
     assert "**Parameters**:" in actual
-    assert "* `PORT, --port`: Port number.  *[default: 8000]*" in actual
+    assert "* `PORT, --port`: Port number. *[default: 8000]*" in actual
 
     # Build command details (now shows full path)
     assert "## myapp build" in actual
     assert "Build the project." in actual
-    assert "* `OUTPUT, --output`: Output directory.  *[default: ./dist]*" in actual
+    assert "* `OUTPUT, --output`: Output directory. *[default: ./dist]*" in actual
 
 
 def test_generate_docs_recursive():
@@ -271,8 +271,8 @@ def test_generate_docs_with_required_parameters():
 
         **Parameters**:
 
-        * `REQUIRED, --required`: Required parameter  **[required]**
-        * `OPTIONAL, --optional`:   *[default: default]*
+        * `REQUIRED, --required`: Required parameter **[required]**
+        * `OPTIONAL, --optional`: *[default: default]*
         """
     )
 
@@ -625,8 +625,8 @@ def test_generate_docs_with_meta_app():
 
         **Parameters**:
 
-        * `INPUT-FILE, --input-file`: Input file path.  **[required]**
-        * `VERBOSE, --verbose, --no-verbose`: Enable verbose output.  *[default: False]*
+        * `INPUT-FILE, --input-file`: Input file path. **[required]**
+        * `VERBOSE, --verbose, --no-verbose`: Enable verbose output. *[default: False]*
         * `CONFIG, --config`: Config file
         """
     )

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -279,6 +279,41 @@ def test_generate_docs_with_required_parameters():
     assert actual == expected
 
 
+def test_generate_docs_consistent_whitespace_after_param_colon():
+    """Regression test for #887.
+
+    ``generate_docs()`` should emit exactly one space after the parameter
+    colon when there is following text (help and/or metadata), and no
+    trailing whitespace when there is nothing after the colon.
+    """
+    app = App(name="something")
+
+    @app.command
+    def do_something(
+        *,
+        has_help: str | None = None,
+        has_metadata: str,
+        has_no_help: str | None = None,
+        is_last: str | None = None,
+    ):
+        """Do something.
+
+        Args:
+            has_help: Some help text.
+        """
+
+    actual = app.generate_docs()
+
+    assert "* `--has-help`: Some help text.\n" in actual
+    assert "* `--has-metadata`: **[required]**\n" in actual
+    assert "* `--has-no-help`:\n" in actual
+    assert "* `--is-last`:\n" in actual
+
+    # No line should have trailing whitespace.
+    for line in actual.splitlines():
+        assert line == line.rstrip(), f"Line has trailing whitespace: {line!r}"
+
+
 def test_generate_docs_with_choices():
     """Test documentation with parameter choices."""
     from enum import Enum

--- a/tests/test_markdown_formatter.py
+++ b/tests/test_markdown_formatter.py
@@ -99,8 +99,8 @@ def test_markdown_formatter_parameter_panel_table():
     expected = dedent("""\
         ## Parameters
 
-        * `--port, -p`: Port number  **[required]**  *[default: 8080]*
-        * `--verbose, -v`: Enable verbose mode  *[choices: true, false]*
+        * `--port, -p`: Port number **[required]** *[default: 8080]*
+        * `--verbose, -v`: Enable verbose mode *[choices: true, false]*
 
         """)
 
@@ -136,8 +136,8 @@ def test_markdown_formatter_parameter_panel_list():
     expected = dedent("""\
         ## Parameters
 
-        * `--port, -p`: Port number  **[required]**  *[default: 8080]*
-        * `--verbose`: Enable verbose mode  *[env: VERBOSE]*
+        * `--port, -p`: Port number **[required]** *[default: 8080]*
+        * `--verbose`: Enable verbose mode *[env: VERBOSE]*
 
         """)
 
@@ -297,7 +297,7 @@ def test_parameter_table_with_all_metadata():
     expected = dedent("""\
         ## Parameters
 
-        * `--config, -c`: Configuration file path  **[required]**  *[choices: /etc/app.conf, ~/.app.conf, ./app.conf]*  *[env: APP_CONFIG, CONFIG_PATH]*  *[default: /etc/app.conf]*
+        * `--config, -c`: Configuration file path **[required]** *[choices: /etc/app.conf, ~/.app.conf, ./app.conf]* *[env: APP_CONFIG, CONFIG_PATH]* *[default: /etc/app.conf]*
 
         """)
 
@@ -331,7 +331,7 @@ def test_parameter_table_no_required_column():
     expected = dedent("""\
         ## Options
 
-        * `--debug`: Enable debug mode  *[default: False]*
+        * `--debug`: Enable debug mode *[default: False]*
         * `--quiet, -q`: Suppress output
 
         """)
@@ -360,7 +360,7 @@ def test_parameter_with_no_description():
     expected = dedent("""\
         ## Parameters
 
-        * `--flag`:   *[default: True]*
+        * `--flag`: *[default: True]*
 
         """)
 


### PR DESCRIPTION
Fixes #887.

## Problem

`generate_docs()` produced varying amounts of whitespace (0–3 spaces) after a parameter's colon in the **markdown** output, depending on whether the parameter had help text, metadata, or was in the trailing position:

```markdown
* `--has-help`: Some help text.
* `--has-metadata`:   **[required]**
* `--has-no-help`: 
* `--is-last`:
```

The trailing space on parameters with no following text also breaks pre-commit's [`trailing-whitespace`](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace) hook when docs are autogenerated and checked in.

## Fix

In `cyclopts/help/formatters/markdown.py`, write a bare colon and let each following piece (description, `**[required]**`, and each `*[…]*` metadata item) supply its own single leading space. There is now always exactly one space when text follows the colon, and no trailing whitespace otherwise:

```markdown
* `--has-help`: Some help text.
* `--has-metadata`: **[required]**
* `--has-no-help`:
* `--is-last`:
```

Scope is markdown-only — RST (definition-list layout) and HTML (metadata spans) never exhibited the issue.

## Tests

- Added `test_generate_docs_consistent_whitespace_after_param_colon` reproducing the issue, including a blanket assertion that no rendered line has trailing whitespace.
- Updated existing hardcoded expectations in `test_generate_docs.py` and `test_markdown_formatter.py`, and regenerated the syrupy markdown snapshots. The snapshot diff is whitespace-only (verified: every changed line is identical after collapsing spaces).
- Full suite: 2636 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)