### PR TITLE
Honor a dict value type's Parameter annotation

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -11,6 +11,7 @@ from enum import Enum, Flag
 from functools import partial, reduce
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Literal,
     TypeVar,
@@ -850,6 +851,11 @@ def convert(
 
     convert_priv = partial(_convert, converter=converter, name_transform=name_transform)
     convert_tuple = partial(_convert_tuple, converter=converter, name_transform=name_transform)
+    # ``_convert`` applies a type's own ``Parameter`` metadata (converter/validator), but
+    # ``resolve`` discards it. Stash the metadata so it can be re-attached to the
+    # *normalized* type for the scalar dispatch below; this is what lets a container's
+    # value type carry its own ``Parameter``, e.g. ``dict[str, PositiveInt]``.
+    annotations_ = get_args(type_)[1:] if is_annotated(type_) else ()
     type_ = resolve(type_)
 
     if type_ is Any:
@@ -892,14 +898,15 @@ def convert(
         return convert_enum_flag(maybe_origin_type, tokens, name_transform)
     else:
         tokens_per_element, consume_all = token_count(type_)
+        annotated_type_ = Annotated[(type_, *annotations_)] if annotations_ else type_
         if consume_all:
-            return convert_priv(type_, tokens)  # pyright: ignore
+            return convert_priv(annotated_type_, tokens)  # pyright: ignore
         elif len(tokens) == 1:
-            return convert_priv(type_, tokens[0])  # pyright: ignore
+            return convert_priv(annotated_type_, tokens[0])  # pyright: ignore
         elif tokens_per_element == 1:
-            return [convert_priv(type_, item) for item in tokens]  # pyright: ignore
+            return [convert_priv(annotated_type_, item) for item in tokens]  # pyright: ignore
         elif len(tokens) == tokens_per_element:
-            return convert_priv(type_, tokens)  # pyright: ignore
+            return convert_priv(annotated_type_, tokens)  # pyright: ignore
         else:
             raise NotImplementedError("Unreachable?")
 

--- a/tests/test_bind_dict.py
+++ b/tests/test_bind_dict.py
@@ -47,3 +47,56 @@ def test_bind_dict_with_mixed_keys_and_regular_params(app, assert_parse_args):
         config={"key1": 7, "key2": 42},
         count=3,
     )
+
+
+def test_bind_dict_value_type_validator(app):
+    """A ``dict`` value type's ``Parameter`` validator is honored.
+
+    Every other container honors element-level ``Parameter`` metadata; ``dict``
+    used to silently discard it.
+    """
+    from cyclopts.exceptions import ValidationError
+    from cyclopts.types import PositiveInt
+
+    @app.command
+    def foo(d: dict[str, PositiveInt]):
+        return d
+
+    assert app("foo --d.a=5", exit_on_error=False, result_action="return_value") == {"a": 5}
+
+    with pytest.raises(ValidationError):
+        app("foo --d.a=-5", exit_on_error=False, result_action="return_value")
+
+
+def test_bind_dict_value_type_converter(app):
+    """A ``dict`` value type's ``Parameter`` converter is honored."""
+    from typing import Annotated
+
+    from cyclopts import Parameter
+
+    def upper_converter(type_, tokens):
+        return tokens[0].value.upper()
+
+    @app.command
+    def foo(d: dict[str, Annotated[str, Parameter(converter=upper_converter)]]):
+        return d
+
+    assert app("foo --d.a=xyz", exit_on_error=False, result_action="return_value") == {"a": "XYZ"}
+
+
+def test_bind_dict_value_type_validator_nested_in_dataclass(app):
+    from dataclasses import dataclass
+
+    from cyclopts.exceptions import ValidationError
+    from cyclopts.types import PositiveInt
+
+    @dataclass
+    class Config:
+        d: dict[str, PositiveInt]
+
+    @app.command
+    def foo(config: Config):
+        return config
+
+    with pytest.raises(ValidationError):
+        app("foo --config.d.a=-5", exit_on_error=False, result_action="return_value")


### PR DESCRIPTION
## Summary

Every container propagated element-level `Parameter` metadata except `dict`. `dict[str, PositiveInt]` accepted `-5` and `dict[str, ExistingFile]` accepted a nonexistent path, while the `list`/`tuple`/`set` equivalents all rejected them. Custom converters were dropped the same way.

## Root cause

`_convert` is what applies a type's own `Parameter` metadata, and it is reached for container elements because the container branches recurse internally. The `dict` branch instead recursed through the public `convert`, which calls `resolve` and discards `Annotated` metadata before dispatching, so a scalar value type lost its converter and validator.

## Fix

`convert` now stashes the annotation metadata and re-attaches it to the normalized type in the scalar dispatch, so `_convert` sees it. The metadata is re-attached after normalization (`Any` -> `str`, abstract -> concrete) rather than by passing the original hint through, which would bypass those steps. Verified that no shape double-validates: scalar, `**kwargs`, `dict`, `list`, and `*args` each invoke an element validator exactly once.

## Testing

Adds `tests/test_bind_dict.py` coverage for value-type validators, converters, and nested-in-dataclass cases. All three new tests fail on `main` before this change and pass after.
