### PR TITLE
Fix Number, Path, and Slice validators silently skipping set, frozenset, and dict elements

### DIFF
--- a/cyclopts/validators/_number.py
+++ b/cyclopts/validators/_number.py
@@ -1,12 +1,16 @@
-from collections.abc import Sequence
 from typing import Any
 
 from cyclopts.utils import frozen
+from cyclopts.validators._utils import iter_container_elements
 
 
 @frozen(kw_only=True)
 class Number:
     """Limit input number to a value range.
+
+    If the annotated parameter is a container (``list``, ``tuple``, ``set``,
+    ``frozenset``, or ``dict``), each element is validated individually.
+    For a ``dict``, the **values** are validated; keys are not.
 
     Example Usage:
 
@@ -57,10 +61,9 @@ class Number:
     """Input value must be a multiple of this value."""
 
     def __call__(self, type_: Any, value: Any):
-        if isinstance(value, Sequence):
-            if isinstance(value, str):
-                raise TypeError
-            for v in value:
+        elements = iter_container_elements(value)
+        if elements is not None:
+            for v in elements:
                 self(type_, v)
         else:
             if not isinstance(value, int | float):

--- a/cyclopts/validators/_path.py
+++ b/cyclopts/validators/_path.py
@@ -5,6 +5,7 @@ from typing import Any
 from attrs import field
 
 from cyclopts.utils import frozen, to_tuple_converter
+from cyclopts.validators._utils import iter_container_elements
 
 
 def ext_converter(value: str | Iterable[str] | None) -> tuple[str, ...]:
@@ -14,6 +15,10 @@ def ext_converter(value: str | Iterable[str] | None) -> tuple[str, ...]:
 @frozen(kw_only=True)
 class Path:
     """Assertions on properties of :class:`pathlib.Path`.
+
+    If the annotated parameter is a container (``list``, ``tuple``, ``set``,
+    ``frozenset``, or ``dict``), each element is validated individually.
+    For a ``dict``, the **values** are validated; keys are not.
 
     Example Usage:
 
@@ -89,11 +94,9 @@ class Path:
             raise ValueError("(exists=True, file_okay=False, dir_okay=False) is an invalid configuration.")
 
     def __call__(self, type_: Any, path: Any):
-        if isinstance(path, Sequence):
-            if isinstance(path, str):
-                raise TypeError
-
-            for p in path:
+        elements = iter_container_elements(path)
+        if elements is not None:
+            for p in elements:
                 self(type_, p)
         else:
             if not isinstance(path, pathlib.Path):

--- a/cyclopts/validators/_slice.py
+++ b/cyclopts/validators/_slice.py
@@ -1,7 +1,7 @@
-from collections.abc import Sequence
 from typing import Any
 
 from cyclopts.utils import frozen
+from cyclopts.validators._utils import iter_container_elements
 
 
 def _selects_nothing(s: slice) -> bool:
@@ -39,6 +39,10 @@ def _selects_nothing(s: slice) -> bool:
 class Slice:
     """Assertions on properties of a :class:`slice`.
 
+    If the annotated parameter is a container (``list``, ``tuple``, ``set``,
+    ``frozenset``, or ``dict``), each element is validated individually.
+    For a ``dict``, the **values** are validated; keys are not.
+
     Example Usage:
 
     .. code-block:: python
@@ -72,10 +76,9 @@ class Slice:
     """If :obj:`False`, the slice **must** select a non-empty range. Defaults to :obj:`True`."""
 
     def __call__(self, type_: Any, value: Any):
-        if isinstance(value, Sequence):
-            if isinstance(value, str):
-                raise TypeError
-            for v in value:
+        elements = iter_container_elements(value)
+        if elements is not None:
+            for v in elements:
                 self(type_, v)
         else:
             if not isinstance(value, slice):

--- a/cyclopts/validators/_utils.py
+++ b/cyclopts/validators/_utils.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Set as AbstractSet
+from typing import Any
+
+
+def iter_container_elements(value: Any) -> Iterator[Any] | None:
+    """Yield the elements a per-element validator should recurse into.
+
+    Cyclopts converts container-annotated parameters into concrete ``list``,
+    ``tuple``, ``set``, ``frozenset``, and ``dict`` objects, and hands the
+    **whole** container to the parameter's validator. Validators use this helper
+    so every container kind recurses uniformly.
+
+    Mappings yield their **values**; a mapping's keys are not validated. This
+    matches how ``**kwargs`` parameters are validated elsewhere in Cyclopts.
+
+    Returns
+    -------
+    Iterator | None
+        An iterator over the elements to validate, or :obj:`None` if ``value``
+        is not a container (i.e. it should be validated as a scalar).
+
+    Raises
+    ------
+    TypeError
+        If ``value`` is a :class:`str`, which is a :class:`~collections.abc.Sequence`
+        but never a valid container of values to validate.
+    """
+    if isinstance(value, Mapping):
+        return iter(value.values())
+    if isinstance(value, Sequence | AbstractSet):
+        if isinstance(value, str):
+            raise TypeError
+        return iter(value)
+    return None

--- a/tests/py312/test_validator_slice_set.py
+++ b/tests/py312/test_validator_slice_set.py
@@ -1,0 +1,20 @@
+"""Slice validator over ``set`` elements.
+
+Lives under ``tests/py312`` because ``slice`` objects only became hashable in
+Python 3.12; on earlier versions ``{slice(...)}`` cannot even be constructed
+(and pyright flags it as unhashable). The ``dict`` mapping case, which does not
+require hashable slices, stays in ``tests/validators/test_validator_slice.py``.
+"""
+
+import pytest
+
+from cyclopts.validators import Slice
+
+
+def test_validator_slice_set():
+    """Sets are validated element-wise, just like sequences."""
+    validator = Slice(allow_empty=False)
+    validator(set[slice], {slice(0, 3)})
+
+    with pytest.raises(ValueError):
+        validator(set[slice], {slice(3, 1)})

--- a/tests/validators/test_validator_number.py
+++ b/tests/validators/test_validator_number.py
@@ -79,3 +79,36 @@ def test_validator_number_typeerror():
     validator = Number(gte=5)
     with pytest.raises(TypeError):
         validator(str, "foo")  # pyright: ignore[reportArgumentType]
+
+
+def test_validator_number_set():
+    """Sets are validated element-wise, just like sequences."""
+    validator = Number(lt=5)
+    validator(set[int], {0, 1, 2})
+    validator(frozenset[int], frozenset({0, 1, 2}))
+
+    with pytest.raises(ValueError):
+        validator(set[int], {0, 6})
+
+    with pytest.raises(ValueError):
+        validator(frozenset[int], frozenset({0, 6}))
+
+
+def test_validator_number_mapping():
+    """Mapping **values** are validated element-wise."""
+    validator = Number(lt=5)
+    validator(dict[str, int], {"a": 0, "b": 1})
+
+    with pytest.raises(ValueError):
+        validator(dict[str, int], {"a": 0, "b": 6})
+
+
+def test_validator_number_nested_containers():
+    validator = Number(lt=5)
+    validator(dict[str, list[int]], {"a": [0, 1]})
+
+    with pytest.raises(ValueError):
+        validator(dict[str, list[int]], {"a": [0, 6]})
+
+    with pytest.raises(ValueError):
+        validator(list[set[int]], [{0}, {6}])

--- a/tests/validators/test_validator_path.py
+++ b/tests/validators/test_validator_path.py
@@ -103,3 +103,33 @@ def test_path_extension_not_match_multi(ext):
     with pytest.raises(ValueError) as e:
         validator(Path, Path("foo.mp4"))
     assert str(e.value) == '"foo.mp4" does not match one of supported extensions {"png", "jpg"}.'
+
+
+def test_path_exists_set(tmp_path):
+    """Sets are validated element-wise, just like sequences."""
+    validator = validators.Path(exists=True)
+    validator(set[Path], {tmp_path})
+    validator(frozenset[Path], frozenset({tmp_path}))
+
+    with pytest.raises(ValueError):
+        validator(set[Path], {tmp_path / "foo"})
+
+    with pytest.raises(ValueError):
+        validator(frozenset[Path], frozenset({tmp_path / "foo"}))
+
+
+def test_path_exists_mapping(tmp_path):
+    """Mapping **values** are validated element-wise."""
+    validator = validators.Path(exists=True)
+    validator(dict[str, Path], {"a": tmp_path})
+
+    with pytest.raises(ValueError):
+        validator(dict[str, Path], {"a": tmp_path / "foo"})
+
+
+def test_path_ext_set(tmp_path):
+    validator = validators.Path(ext="txt")
+    validator(set[Path], {tmp_path / "foo.txt"})
+
+    with pytest.raises(ValueError):
+        validator(set[Path], {tmp_path / "foo.bin"})

--- a/tests/validators/test_validator_slice.py
+++ b/tests/validators/test_validator_slice.py
@@ -70,15 +70,6 @@ def test_validator_slice_ignores_non_slice():
     validator(slice, 5)  # Not a slice; silently ignored.
 
 
-def test_validator_slice_set():
-    """Sets are validated element-wise, just like sequences."""
-    validator = Slice(allow_empty=False)
-    validator(set[slice], {slice(0, 3)})
-
-    with pytest.raises(ValueError):
-        validator(set[slice], {slice(3, 1)})
-
-
 def test_validator_slice_mapping():
     """Mapping **values** are validated element-wise."""
     validator = Slice(allow_empty=False)

--- a/tests/validators/test_validator_slice.py
+++ b/tests/validators/test_validator_slice.py
@@ -68,3 +68,21 @@ def test_validator_slice_sequence_type():
 def test_validator_slice_ignores_non_slice():
     validator = Slice(allow_empty=False)
     validator(slice, 5)  # Not a slice; silently ignored.
+
+
+def test_validator_slice_set():
+    """Sets are validated element-wise, just like sequences."""
+    validator = Slice(allow_empty=False)
+    validator(set[slice], {slice(0, 3)})
+
+    with pytest.raises(ValueError):
+        validator(set[slice], {slice(3, 1)})
+
+
+def test_validator_slice_mapping():
+    """Mapping **values** are validated element-wise."""
+    validator = Slice(allow_empty=False)
+    validator(dict[str, slice], {"a": slice(0, 3)})
+
+    with pytest.raises(ValueError):
+        validator(dict[str, slice], {"a": slice(3, 1)})


### PR DESCRIPTION
## Summary

The built-in `Number`, `Path`, and `Slice` validators recursed into a container's elements only when the value was a `Sequence`. Cyclopts hands the whole converted container to a parameter's validator, so `set`, `frozenset`, and `dict` values fell through to the scalar branch, failed the scalar `isinstance` check, and returned without validating anything.

The result was a silent bypass: `set[Path]` with `Path(exists=True)` accepted a nonexistent path, and `dict[str, int]` with `Number(lte=10)` accepted `999`. `list` and `tuple` were unaffected.

## Fix

Recursion now goes through a shared `iter_container_elements` helper so all three validators treat container kinds uniformly. Mappings validate their values, matching how `**kwargs` parameters are already validated in `Argument.convert_and_validate`. Non-container iterables keep their previous behavior.

## Testing

Adds `set`/`frozenset`/`dict`/nested-container cases to the number, path, and slice validator suites. The 8 new element-validation tests fail on `main` before this change and pass after.
