### PR TITLE
Report an un-parsable Union as a clean error instead of a traceback

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -27,6 +27,7 @@ else:
 from cyclopts.annotations import (
     ITERABLE_TYPES,
     get_annotated_discriminator,
+    get_hint_name,
     is_annotated,
     is_enum_flag,
     is_nonetype,
@@ -986,8 +987,12 @@ def token_count(type_: Any, skip_converter_params: bool = False) -> tuple[int, b
         for sub_type_ in sub_args[1:]:
             this = token_count(sub_type_)
             if this != token_count_target:
+                # Callers that reach this while binding CLI tokens (``Argument.token_count``)
+                # translate this into a ``CycloptsError`` so the end user gets a formatted
+                # message instead of a traceback.
                 raise ValueError(
-                    f"Cannot Union types that consume different numbers of tokens: {sub_args[0]} {sub_type_}"
+                    f"Cannot Union types that consume different numbers of tokens: "
+                    f"{get_hint_name(sub_args[0])} and {get_hint_name(sub_type_)}."
                 )
         return token_count_target
     elif is_builtin(type_):

--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -1054,7 +1054,7 @@ class Argument:
 
                 # Recursively call token_count to get the consume_all behavior
                 # We ignore the token count from the recursive call and use our explicit n_tokens
-                _, consume_all_from_type = token_count(hint)
+                _, consume_all_from_type = self._token_count(hint)
                 return self.parameter.n_tokens, consume_all_from_type
 
         if len(keys) > 1:
@@ -1065,8 +1065,23 @@ class Argument:
             hint = self.hint
             if self._enum_flag_type and not keys:
                 return 1, True
-        tokens_per_element, consume_all = token_count(hint)
+        tokens_per_element, consume_all = self._token_count(hint)
         return tokens_per_element, consume_all
+
+    def _token_count(self, hint) -> tuple[int, bool]:
+        """``token_count`` with un-parsable type hints reported as a ``CycloptsError``.
+
+        ``token_count`` raises a plain :class:`ValueError` for an annotation it cannot
+        make sense of (e.g. ``Union[list[int], int]``, whose members consume differing
+        numbers of tokens). That happens during token binding, so without this the end
+        user gets a raw traceback and ``exit_on_error`` is bypassed.
+        """
+        try:
+            return token_count(hint)
+        except CycloptsError:
+            raise
+        except ValueError as e:
+            raise CycloptsError(msg=e.args[0] if e.args else None, argument=self) from e
 
     @property
     def _negatives_hint(self):

--- a/tests/test_bind_union.py
+++ b/tests/test_bind_union.py
@@ -6,7 +6,7 @@ from typing import Annotated, Union
 import pytest
 
 from cyclopts import Parameter
-from cyclopts.exceptions import CoercionError, MissingArgumentError
+from cyclopts.exceptions import CoercionError, CycloptsError, MissingArgumentError
 
 
 @pytest.mark.parametrize(
@@ -202,3 +202,39 @@ def test_union_of_dataclasses_ambiguous_fields_error(app):
             print_error=False,
             exit_on_error=False,
         )
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        Union[bool, str],
+        Union[bool, int],
+        Union[list[int], int],
+        Union[tuple[int, int], int],
+    ],
+)
+def test_union_differing_token_counts_raises_cyclopts_error(app, annotation):
+    """A Union whose members consume differing token counts reports cleanly.
+
+    Previously a bare ``ValueError`` escaped from ``token_count`` outside of
+    Cyclopts's error handling, so end users got a raw traceback and
+    ``exit_on_error`` was ignored.
+    """
+
+    @app.command
+    def cli(x: annotation):  # pyright: ignore
+        pass
+
+    with pytest.raises(CycloptsError):
+        app.parse_args("cli --x 1", print_error=False, exit_on_error=False)
+
+
+def test_union_differing_token_counts_honors_exit_on_error(app):
+    """The error is routed through Cyclopts's handler rather than escaping as a traceback."""
+
+    @app.command
+    def cli(x: Union[list[int], int]):
+        pass
+
+    with pytest.raises(SystemExit):
+        app(["cli", "--x", "1"], print_error=False, exit_on_error=True)


### PR DESCRIPTION
## Summary

`token_count` raises a plain `ValueError` when a Union's members consume differing numbers of tokens. It is called from `Argument.token_count` during token binding, which is outside Cyclopts's error handling, so annotations like `Union[list[int], int]` and `Union[bool, str]` gave the end user a raw Python traceback and silently bypassed `exit_on_error`.

Nothing surfaces at registration or in `--help`, so the app looks healthy right up until someone actually passes the option.

## Fix

`Argument.token_count` now translates that `ValueError` into a `CycloptsError` carrying the offending argument, so it is formatted like any other CLI error and honors `exit_on_error`. `token_count` itself still raises `ValueError` as before, keeping its contract (and existing test) intact; its message now names the types readably rather than printing raw `repr`s.

## Testing

Adds `tests/test_bind_union.py` cases asserting a `CycloptsError` (not a raw traceback) and that `exit_on_error` is honored. The 5 new tests fail on `main` before this change and pass after.
