### PR TITLE
Raise a clean AmbiguousCommandError instead of a raw ValueError traceback

### DIFF
--- a/cyclopts/__init__.py
+++ b/cyclopts/__init__.py
@@ -7,6 +7,7 @@ except ImportError:
 
 __all__ = [
     "__version__",
+    "AmbiguousCommandError",
     "App",
     "Argument",
     "ArgumentCollection",
@@ -54,6 +55,7 @@ from cyclopts._run import run
 from cyclopts.argument import Argument, ArgumentCollection
 from cyclopts.core import App
 from cyclopts.exceptions import (
+    AmbiguousCommandError,
     ArgumentOrderError,
     CoercionError,
     CombinedShortOptionError,

--- a/cyclopts/app_stack.py
+++ b/cyclopts/app_stack.py
@@ -37,7 +37,11 @@ class AppStack:
         # Convert strings to Apps if needed
         if isinstance(apps[0], str):
             str_apps = cast(Sequence[str], apps)
-            _, apps_tuple, _ = self.stack[0][0].parse_commands(str_apps, include_parent_meta=True)
+            # ``raise_on_ambiguous=False``: this resolution only feeds override propagation;
+            # an ambiguous command raises properly inside ``parse_args``'s error handling.
+            _, apps_tuple, _ = self.stack[0][0].parse_commands(
+                str_apps, include_parent_meta=True, raise_on_ambiguous=False
+            )
             resolved_apps: list[App] = list(apps_tuple)
         else:
             resolved_apps = cast(list["App"], list(apps))

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -33,6 +33,7 @@ from cyclopts.bind import create_bound_arguments, is_option_like, normalize_toke
 from cyclopts.command_spec import CommandSpec
 from cyclopts.config._env import Env
 from cyclopts.exceptions import (
+    AmbiguousCommandError,
     CommandCollisionError,
     CycloptsError,
     UnknownCommandError,
@@ -1035,6 +1036,7 @@ class App:
         tokens: None | str | Iterable[str] = None,
         *,
         include_parent_meta=True,
+        raise_on_ambiguous: bool = True,
     ) -> tuple[tuple[str, ...], tuple["App", ...], list[str]]:
         """Extract out the command tokens from a command.
 
@@ -1045,6 +1047,12 @@ class App:
         tokens: None | str | Iterable[str]
             Either a string, or a list of strings to launch a command.
             Defaults to ``sys.argv[1:]``
+        raise_on_ambiguous: bool
+            When True (default), raise :class:`.AmbiguousCommandError` if a token
+            fuzzy-matches multiple commands. When False, treat the ambiguous token
+            as a non-command (ending the command chain).
+
+            This parameter is primarily for internal use.
         include_parent_meta: bool
             Controls whether parent meta apps are included in the execution path.
 
@@ -1120,9 +1128,9 @@ class App:
                 if len(matches) == 1:
                     # Single fuzzy match found
                     app_or_spec = command_mapping[matches[0]]
-                elif len(matches) > 1:
+                elif len(matches) > 1 and raise_on_ambiguous:
                     # Ambiguous match - multiple commands match after normalization
-                    raise ValueError(f"Ambiguous command '{token}'. Could match: {', '.join(sorted(matches))}.")
+                    raise AmbiguousCommandError(command_token=token, matches=sorted(matches))
 
             if app_or_spec is None:
                 # Token is not a command. Try to consume it as a meta app parameter.
@@ -1845,7 +1853,10 @@ class App:
 
                 e.verbose = verbose if verbose is not None else False
                 e.root_input_tokens = tokens
-                assert e.console is not None
+                if e.console is None:
+                    # e.g. errors raised during command resolution, before
+                    # ``_parse_known_args``'s error decoration.
+                    e.console = self.error_console
                 if help_on_error if help_on_error is not None else False:
                     self.help_print(tokens, console=e.console)
                 if print_error if print_error is not None else True:

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -35,6 +35,7 @@ STYLE_SOURCE = "dim"
 
 
 __all__ = [
+    "AmbiguousCommandError",
     "CoercionError",
     "CommandCollisionError",
     "CycloptsError",
@@ -507,6 +508,32 @@ class UnknownCommandError(CycloptsError):
                     yield ", ", ""
                 yield name, STYLE_VALID_CHOICE
             yield ".", ""
+
+
+@define(kw_only=True)
+class AmbiguousCommandError(CycloptsError, ValueError):
+    """A command token fuzzy-matched multiple registered command names.
+
+    Derives from :class:`ValueError` for backwards compatibility; this used to be raised as a plain ``ValueError``.
+    """
+
+    command_token: str = ""
+    """The offending CLI token."""
+
+    matches: Sequence[str] = ()
+    """Registered command names that the token could match."""
+
+    def _segments(self) -> "Iterator[tuple[str, str] | Text]":
+        yield from super()._segments()
+
+        yield "Ambiguous command '", ""
+        yield self.command_token, STYLE_OFFENDING_VALUE
+        yield "'. Could match: ", ""
+        for i, name in enumerate(self.matches):
+            if i:
+                yield ", ", ""
+            yield name, STYLE_VALID_CHOICE
+        yield ".", ""
 
 
 @define(kw_only=True)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2753,6 +2753,10 @@ Exceptions
    :show-inheritance:
    :members:
 
+.. autoexception:: cyclopts.AmbiguousCommandError
+   :show-inheritance:
+   :members:
+
 .. autoexception:: cyclopts.UnusedCliTokensError
    :show-inheritance:
    :members:

--- a/tests/test_fuzzy_command_matching.py
+++ b/tests/test_fuzzy_command_matching.py
@@ -6,7 +6,7 @@ Should probably be removed in v5.
 import pytest
 
 from cyclopts import App
-from cyclopts.exceptions import UnknownCommandError
+from cyclopts.exceptions import AmbiguousCommandError, UnknownCommandError
 
 
 @pytest.mark.parametrize(
@@ -91,6 +91,25 @@ def test_fuzzy_command_matching_ambiguous_error(app):
     # Both normalize to 'mycommand', so this is ambiguous
     with pytest.raises(ValueError, match="Ambiguous command 'my_command'.*my-command.*mycommand"):
         app.parse_args(["my_command"], exit_on_error=False)
+
+
+def test_fuzzy_command_matching_ambiguous_error_end_to_end(app, console):
+    """The ambiguity error is a CycloptsError: formatted panel + ``exit_on_error`` honored, not a raw traceback."""
+
+    @app.command(name="my-command")
+    def cmd1():
+        pass
+
+    @app.command(name="my_command")
+    def cmd2():
+        pass
+
+    with console.capture() as capture, pytest.raises(AmbiguousCommandError):
+        app(["mycommand"], error_console=console, exit_on_error=False, print_error=True)
+
+    actual = capture.get()
+    assert "Ambiguous command" in actual
+    assert "mycommand" in actual
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Two commands colliding under fuzzy name normalization (e.g. `my-command` and `my_command` with input `mycommand`) crashed `app()` with an unhandled `ValueError` traceback: the error was raised from command resolution inside `app_stack.__enter__`, before `parse_args`' `CycloptsError` handling, so it bypassed error formatting and ignored `exit_on_error`.

## Fix

The ambiguity now raises `AmbiguousCommandError` (a `CycloptsError`; still a `ValueError` subclass for backwards compatibility) through the normal error path: formatted panel, `exit_on_error`/`print_error` honored. The `app_stack` resolution pass uses the new `parse_commands(raise_on_ambiguous=False)` since it only feeds override propagation.

## Testing

Adds `tests/test_fuzzy_command_matching.py` coverage. Verified on `main` that `app(["mycommand"], exit_on_error=False)` currently escapes with a raw `ValueError`; after this change it raises a formatted `AmbiguousCommandError`. `AmbiguousCommandError` is exported and documented in `api.rst`.
