### PR TITLE
Fix Literal types containing a None member

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -658,6 +658,9 @@ def _convert(
         # Try coercing the token into each allowed Literal value (left-to-right).
         last_coercion_error = None
         for choice in get_args(type_):
+            if choice is None:
+                # Like ``Optional``, a ``None`` member is only reachable via the default, not a token.
+                continue
             try:
                 res = convert(type(choice), token)
             except CoercionError as e:

--- a/cyclopts/argument/utils.py
+++ b/cyclopts/argument/utils.py
@@ -100,7 +100,8 @@ def get_choices_from_hint(type_: type, name_transform: Callable[[str], str]) -> 
             if x:
                 choices.extend(x)
     elif _origin is Literal:
-        choices.extend(str(x) for x in get_args(type_))
+        # A ``None`` member is only reachable via the default, not a token (like ``Optional``).
+        choices.extend(str(x) for x in get_args(type_) if x is not None)
     elif _origin in ITERABLE_TYPES:
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -360,7 +360,7 @@ class CoercionError(CycloptsError):
         choice_strs: list[str] | None = None
         plain_choices: list[str] | None = None
         if get_origin(self.target_type) is Literal:
-            args = get_args(self.target_type)
+            args = [x for x in get_args(self.target_type) if x is not None]  # ``None`` cannot be entered as a token.
             choice_strs = [f'"{x}"' if isinstance(x, str) else repr(x) for x in args]
             plain_choices = [x for x in args if isinstance(x, str)]
         elif isinstance(self.target_type, type) and issubclass(self.target_type, Enum):

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -340,6 +340,13 @@ def test_coerce_literal():
     assert 3 == convert(Literal["foo", "bar", 3], ["3"])
 
 
+def test_coerce_literal_none_member():
+    """A ``None`` Literal member is only reachable via the default, like ``Optional``; issue: valid tokens after it must still match."""
+    assert "foo" == convert(Literal[None, "foo"], ["foo"])
+    assert "foo" == convert(Literal["foo", None], ["foo"])
+    assert 3 == convert(Literal[None, "foo", 3], ["3"])
+
+
 def assert_convert_coercion_error(*args, msg, name_transform=None, **kwargs):
     if name_transform is None:
         name_transform = default_name_transform
@@ -386,6 +393,15 @@ def test_coerce_literal_invalid_choice_keyword_non_cli_token():
         Literal["foo", "bar", 3],
         [Token(keyword="--MY-KEYWORD", value="invalid-choice", source="TEST")],
         msg='Invalid value "invalid-choice" for --MY-KEYWORD from TEST. Choose from: "foo", "bar", 3.',
+    )
+
+
+def test_coerce_literal_none_member_invalid_choice():
+    """``None`` cannot be entered as a CLI token, so it is omitted from the choices list."""
+    assert_convert_coercion_error(
+        Literal["foo", None],
+        ["invalid-choice"],
+        msg='Invalid value "invalid-choice" for MOCKED_ARGUMENT_NAME. Choose from: "foo".',
     )
 
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -922,6 +922,25 @@ def test_help_format_group_parameters_choices_literal_no_show(capture_format_gro
     assert actual == expected
 
 
+def test_help_format_group_parameters_choices_literal_none_member(capture_format_group_parameters):
+    """A ``None`` Literal member cannot be entered as a token, so it is not a displayed choice (like ``Optional``)."""
+
+    def cmd(
+        foo: Annotated[Literal[None, "fizz", "buzz"], Parameter(help="Docstring for foo.")] = None,
+    ):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO --foo  Docstring for foo. [choices: fizz, buzz]                │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
 def test_help_format_group_parameters_choices_literal_union(capture_format_group_parameters):
     def cmd(
         foo: Annotated[int | Literal["fizz", "buzz"] | Literal["bar"], Parameter(help="Docstring for foo.")] = "fizz",


### PR DESCRIPTION
## Summary

`Literal[None, "a", "b"]` fails whenever the `None` choice is reached during conversion. On `main`, passing the **valid** value `b` is rejected with `CoercionError: NoneType takes no arguments`, because conversion tries the `None` member and crashes before reaching the real choice. Invalid input surfaces the same internal `NoneType takes no arguments` text.

## Fix

Skip `None` members during token conversion. Like `Optional`, `None` is only reachable via the default, never via a token. Also omit `None` from "Choose from:" error messages, help-panel choices, and shell-completion choices, matching the equivalent `Optional[Literal[...]]` spelling.

## Testing

Adds coercion and help-panel coverage for `None`-containing `Literal`s. New tests fail on `main` before this change and pass after.
