### PR TITLE
Honor n_tokens on container element converters through public convert()

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -627,8 +627,10 @@ def _convert(
                     # Call with just tokens - cls/self already bound
                     return resolved_converter((value,))
                 else:
-                    # Regular function - pass type and tokens
-                    return resolved_converter(t_, (value,))
+                    # Regular function - pass type and tokens.
+                    # ``value`` may be a single Token or a sequence of Tokens (n_tokens > 1).
+                    tokens_ = tuple(value) if isinstance(value, (list, tuple)) else (value,)
+                    return resolved_converter(t_, tokens_)
 
             converter = converter_with_token
 
@@ -735,24 +737,28 @@ def _convert(
         # This is common for many types, such as libraries that try to mimic pathlib.Path interface.
         # TODO: This doesn't respect the type-annotation of ``*args``.
         if is_builtin(type_) or not field_infos:
-            assert isinstance(token, Token)
             try:
-                if token.implicit_value is not UNSET:
-                    out = token.implicit_value
-                elif converter is None:
-                    out = _converters.get(type_, type_)(token.value)  # pyright: ignore[reportOptionalCall]
-                elif converter_needs_token:
-                    out = converter(type_, token)  # pyright: ignore[reportArgumentType]
+                if converter_needs_token and not isinstance(token, Token):
+                    # Multi-token converter (n_tokens > 1) receives the full token sequence.
+                    out = converter(type_, token)  # pyright: ignore[reportOptionalCall, reportArgumentType]
                 else:
-                    out = converter(type_, token.value)
+                    assert isinstance(token, Token)
+                    if token.implicit_value is not UNSET:
+                        out = token.implicit_value
+                    elif converter is None:
+                        out = _converters.get(type_, type_)(token.value)  # pyright: ignore[reportOptionalCall]
+                    elif converter_needs_token:
+                        out = converter(type_, token)  # pyright: ignore[reportArgumentType]
+                    else:
+                        out = converter(type_, token.value)
             except CoercionError as e:
                 if e.target_type is None:
                     e.target_type = type_
-                if e.token is None:
+                if e.token is None and isinstance(token, Token):
                     e.token = token
                 raise
             except ValueError:
-                raise CoercionError(token=token, target_type=type_) from None
+                raise CoercionError(token=token if isinstance(token, Token) else None, target_type=type_) from None
         else:
             # Convert it into a user-supplied class.
             # First check if we have a single token that's a JSON string
@@ -915,8 +921,8 @@ def convert(
         # enum.Flag object.
         return convert_enum_flag(maybe_origin_type, tokens, name_transform)
     else:
-        tokens_per_element, consume_all = token_count(type_)
         annotated_type_ = Annotated[(type_, *annotations_)] if annotations_ else type_
+        tokens_per_element, consume_all = token_count(annotated_type_)
         if consume_all:
             return convert_priv(annotated_type_, tokens)  # pyright: ignore
         elif len(tokens) == 1:

--- a/tests/test_bind_dict.py
+++ b/tests/test_bind_dict.py
@@ -84,6 +84,30 @@ def test_bind_dict_value_type_converter(app):
     assert app("foo --d.a=xyz", exit_on_error=False, result_action="return_value") == {"a": "XYZ"}
 
 
+def test_bind_dict_value_type_multi_token_converter(app):
+    """A ``dict`` value type's converter that consumes ``n_tokens > 1`` receives all its tokens.
+
+    Regression: ``token_count`` was computed on the metadata-stripped value type, so each
+    value was split token-by-token and the converter was invoked per-token instead of once
+    per ``n_tokens``-sized group.
+    """
+    from typing import Annotated
+
+    from cyclopts import Parameter
+
+    def combine_xy(type_, tokens):
+        return f"{tokens[0].value},{tokens[1].value}"
+
+    @app.command
+    def foo(points: dict[str, Annotated[str, Parameter(n_tokens=2, converter=combine_xy)]]):
+        return points
+
+    assert app("foo --points.a 1 2 --points.b 3 4", exit_on_error=False, result_action="return_value") == {
+        "a": "1,2",
+        "b": "3,4",
+    }
+
+
 def test_bind_dict_value_type_validator_nested_in_dataclass(app):
     from dataclasses import dataclass
 


### PR DESCRIPTION
## Summary

Follow-up to #890, addressing Copilot review feedback (https://github.com/BrianPugh/cyclopts/pull/890#discussion_r3813420997).

The public `convert()` computed `token_count` on the resolved, **metadata-stripped** value type, so a container element carrying `Parameter(n_tokens=N)` was split token-by-token and its converter was invoked once per token instead of once per `N`-sized group. `#890` re-attaches element metadata for the *conversion* call but not for the *token-count/split* decision, so the two disagreed.

## Realistic trigger

```python
def combine_xy(type_, tokens):
    return f"{tokens[0].value},{tokens[1].value}"

@app.default
def main(points: dict[str, Annotated[str, Parameter(n_tokens=2, converter=combine_xy)]]):
    ...
#  --points.a 1 2 --points.b 3 4   ->  want {'a': '1,2', 'b': '3,4'}
```

Before this change that raised `IndexError` (the converter received a single token). Fixing only the token-count line surfaced a second layer (`_convert`'s converter path is single-token), so three coordinated changes are needed.

## Changes (all in `cyclopts/_convert.py`)

- `convert()` computes `token_count` on the re-attached annotated type, so the split decision reflects the element's own metadata.
- `converter_with_token` passes a token *sequence* through as-is instead of always wrapping a single value.
- The builtin / no-`field_infos` scalar branch routes a multi-token converter to the full token sequence (with the error handlers guarding the widened token type).

## Scope / risk

The common cases are unaffected: `n_tokens=1` element converters/validators (the #890 scope), and custom types whose *natural* token count already matches (e.g. `dict[str, Server]` where `Server(host, port)` naturally takes 2 tokens) already worked. This only changes the exotic case where an element's `n_tokens` differs from the base type's natural count. It does touch the hot conversion path, so it warrants a careful review.

## Testing

Adds `test_bind_dict_value_type_multi_token_converter`. Full suite green (2640 passed).
