### PR TITLE
Skip var-keyword parameters in shell completion generation

### DIFF
--- a/cyclopts/completion/_base.py
+++ b/cyclopts/completion/_base.py
@@ -15,6 +15,7 @@ from attrs import field
 from cyclopts.annotations import ITERABLE_TYPES, is_annotated, is_union
 from cyclopts.argument import ArgumentCollection
 from cyclopts.exceptions import CycloptsError
+from cyclopts.field_info import VAR_KEYWORD
 from cyclopts.group_extractors import RegisteredCommand, groups_from_app
 from cyclopts.utils import frozen, is_class_and_subclass
 
@@ -105,6 +106,13 @@ def extract_completion_data(app: "App") -> dict[tuple[str, ...], CompletionData]
         own_arguments = ArgumentCollection()
         with app.app_stack(execution_path):
             for subapp, app_arguments in _iter_resolution_argument_collections(execution_path, parse_docstring=True):
+                # ``**kwargs`` accepts arbitrary option names, so no per-option spec can
+                # represent it; its ``--[KEYWORD]`` placeholder name is invalid shell
+                # syntax (zsh's ``_arguments`` aborts on it, breaking completion for the
+                # entire command).
+                app_arguments = ArgumentCollection(
+                    argument for argument in app_arguments if argument.field_info.kind is not VAR_KEYWORD
+                )
                 arguments.extend(app_arguments)
                 if not any(subapp is a for a in current):
                     continue  # inherited (ancestor meta launcher)

--- a/tests/completion/apps.py
+++ b/tests/completion/apps.py
@@ -283,3 +283,23 @@ def collect(
         Optional tags.
     """
     pass
+
+
+# ``**kwargs`` accepts arbitrary option names; its ``--[KEYWORD]`` placeholder
+# must not leak into completion scripts (zsh's ``_arguments`` rejects it and
+# breaks completion for the whole command).
+app_var_keyword = App(name="varkw")
+
+
+@app_var_keyword.command
+def create(*, verbose: bool = False, **overrides: str):
+    """Create a thing.
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output.
+    overrides : str
+        Arbitrary overrides.
+    """
+    pass

--- a/tests/completion/test_bash.py
+++ b/tests/completion/test_bash.py
@@ -20,6 +20,7 @@ from .apps import (
     app_path,
     app_positional_literal,
     app_positional_path,
+    app_var_keyword,
 )
 
 
@@ -1123,3 +1124,10 @@ def test_bash_path_completion_reflects_caller_cwd(bash_tester):
     assert "myfile.txt" in completions, (
         f"expected 'myfile.txt' from caller cwd, got {completions!r} (driver likely overrode cwd to its own tmpdir)"
     )
+
+
+def test_var_keyword_skipped(bash_tester):
+    """``**kwargs`` emits no spec; siblings still complete."""
+    tester = bash_tester(app_var_keyword, "varkw")
+    assert "KEYWORD" not in tester.completion_script
+    assert "--verbose" in tester.completion_script

--- a/tests/completion/test_fish.py
+++ b/tests/completion/test_fish.py
@@ -17,6 +17,7 @@ from .apps import (
     app_nested,
     app_path,
     app_rst,
+    app_var_keyword,
 )
 
 
@@ -618,3 +619,10 @@ def test_fish_path_completion_reflects_caller_cwd(fish_tester):
     assert any("myfile.txt" in c for c in completions), (
         f"expected 'myfile.txt' from caller cwd, got {completions!r} (driver likely overrode cwd to its own tmpdir)"
     )
+
+
+def test_var_keyword_skipped(fish_tester):
+    """``**kwargs`` emits no spec; siblings still complete."""
+    tester = fish_tester(app_var_keyword, "varkw")
+    assert "KEYWORD" not in tester.completion_script
+    assert "-l verbose" in tester.completion_script

--- a/tests/completion/test_zsh.py
+++ b/tests/completion/test_zsh.py
@@ -18,6 +18,7 @@ from .apps import (
     app_nested,
     app_path,
     app_rst,
+    app_var_keyword,
 )
 
 
@@ -1480,3 +1481,11 @@ def test_naked_tab_at_no_arg_subcommand_offers_help(zsh_tester):
     completions = tester.get_completions("probe noarg ")
     assert "--help" in completions
     assert "--version" in completions
+
+
+def test_var_keyword_skipped(zsh_tester):
+    """``**kwargs`` emits no spec; siblings still complete and the script stays valid."""
+    tester = zsh_tester(app_var_keyword, "varkw")
+    assert "KEYWORD" not in tester.completion_script
+    assert "--verbose" in tester.completion_script
+    assert tester.validate_script_syntax()


### PR DESCRIPTION
## Skip var-keyword parameters in shell completion generation

Bare `**kwargs` parameters carry the `--[KEYWORD]` placeholder name, which leaked into the generated completion scripts for all three shells. zsh's `_arguments` rejects `[` in an option name and aborts with `invalid option definition`, breaking tab completion for the *entire* command — including its ordinary options.

- Since `**kwargs` accepts arbitrary `--<anything>` names, no per-option spec can represent it; var-keyword arguments are now filtered once in `extract_completion_data`, fixing zsh, bash, and fish together.
- This also drops the same invalid sentinel that `Unpack[TypedDict]` kwargs emitted. Their promoted fields were never offered by completion before either, so no regression — field-level completion for PEP 692 kwargs remains unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
