### PR TITLE
Add type hints to help copy methods

### DIFF
--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -13,6 +13,11 @@ from typing import (
 
 from attrs import define, evolve, field
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 from cyclopts.annotations import resolve_annotated
 from cyclopts.argument.utils import is_short_flag
 from cyclopts.core import _get_root_module_name, _iter_resolution_argument_collections
@@ -124,7 +129,7 @@ class HelpEntry:
     default: str | None = None
     """Default value for this parameter to display. None means no default to show."""
 
-    def copy(self, **kwargs):
+    def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)
 
 
@@ -150,7 +155,7 @@ class HelpPanel:
     entries: list[HelpEntry] = field(factory=list)
     """List of help entries to display (in order) in the panel."""
 
-    def copy(self, **kwargs):
+    def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)
 
     def _remove_duplicates(self):

--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -1,10 +1,16 @@
 import math
+import sys
 import textwrap
 from collections.abc import Iterable
 from operator import attrgetter
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from attrs import evolve
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from cyclopts.utils import frozen
 
@@ -394,7 +400,7 @@ class ColumnSpec:
             value = None
         return "" if value is None else value
 
-    def copy(self, **kwargs):
+    def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)
 
 
@@ -698,7 +704,7 @@ class TableSpec:
 
         return table
 
-    def copy(self, **kwargs):
+    def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)
 
 
@@ -830,5 +836,5 @@ class PanelSpec:
 
         return Panel(renderable, **opts)
 
-    def copy(self, **kwargs):
+    def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)


### PR DESCRIPTION
Hello.

I realized these helper methods were untyped when trying to customize the `HelpEntry` which forced me to add `# type: ignore[no-untyped-call]` to the `.copy()`.