### PR TITLE
Fix deprecated not being rendered

### DIFF
--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -363,10 +363,18 @@ def format_doc(app: "App", format: str) -> InlineText | SilentRich:
     if parsed.short_description:
         components.append(parsed.short_description + "\n")
 
+    if parsed.deprecation and format in ("restructuredtext", "rst"):
+        from cyclopts.help.rst_preprocessor import format_deprecated_tag
+
+        if components:
+            components.append("\n")
+        components.append(format_deprecated_tag(parsed.deprecation.version, parsed.deprecation.description) + "\n")
+
     if parsed.long_description:
-        if parsed.short_description:
+        if components:
             components.append("\n")
         components.append(parsed.long_description + "\n")
+
     return InlineText.from_format(_smart_join(components), format=format, force_empty_end=True)
 
 
@@ -604,10 +612,18 @@ def format_command_entries(apps_with_names: Iterable, format: str) -> list[HelpE
 
         sort_key = resolve_callables(app.sort_key, app)
 
+        parsed = docstring_parse(app.help, format)
+        description_text = parsed.short_description or ""
+        if parsed.deprecation and format in ("restructuredtext", "rst"):
+            from cyclopts.help.rst_preprocessor import format_deprecated_tag
+
+            tag = format_deprecated_tag(parsed.deprecation.version, parsed.deprecation.description)
+            description_text = f"{tag} {description_text}" if description_text else tag
+
         entry = HelpEntry(
             positive_names=tuple(long_names),
             positive_shorts=tuple(short_names),
-            description=InlineText.from_format(docstring_parse(app.help, format).short_description, format=format),
+            description=InlineText.from_format(description_text, format=format),
             sort_key=sort_key,
         )
         if entry not in entries:

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -351,6 +351,26 @@ def _smart_join(strings: Sequence[str]) -> str:
     return "".join(result)
 
 
+def format_deprecated_tag(version: str | None, content: str | None) -> str:
+    """Format a "Deprecated" tag, shared by the ``.. deprecated::`` directive and ``DocstringDeprecated`` metadata.
+
+    Parameters
+    ----------
+    version : str | None
+        Version the deprecation applies to, if any.
+    content : str | None
+        Optional explanatory content (e.g. "Use something else instead").
+
+    Returns
+    -------
+    str
+        Formatted tag, e.g. ``"[⚠ Deprecated in v1.0] Use something else instead"``.
+    """
+    tag = f"[⚠ Deprecated in v{version}]" if version else "[⚠ Deprecated]"
+    content = (content or "").strip()
+    return f"{tag} {content}" if content else tag
+
+
 def format_doc(app: "App", format: str) -> InlineText | SilentRich:
     raw_doc_string = app.help
 
@@ -363,9 +383,10 @@ def format_doc(app: "App", format: str) -> InlineText | SilentRich:
     if parsed.short_description:
         components.append(parsed.short_description + "\n")
 
-    if parsed.deprecation and format in ("restructuredtext", "rst"):
-        from cyclopts.help.rst_preprocessor import format_deprecated_tag
-
+    # docstring_parser extracts a top-level ``.. deprecated::`` directive into
+    # ``parsed.deprecation`` metadata, so it never reaches the renderer as text;
+    # reconstruct it here for every help format.
+    if parsed.deprecation:
         if components:
             components.append("\n")
         components.append(format_deprecated_tag(parsed.deprecation.version, parsed.deprecation.description) + "\n")
@@ -613,17 +634,16 @@ def format_command_entries(apps_with_names: Iterable, format: str) -> list[HelpE
         sort_key = resolve_callables(app.sort_key, app)
 
         parsed = docstring_parse(app.help, format)
-        description_text = parsed.short_description or ""
-        if parsed.deprecation and format in ("restructuredtext", "rst"):
-            from cyclopts.help.rst_preprocessor import format_deprecated_tag
-
-            tag = format_deprecated_tag(parsed.deprecation.version, parsed.deprecation.description)
-            description_text = f"{tag} {description_text}" if description_text else tag
+        description = parsed.short_description
+        if parsed.deprecation:
+            # Tag-only in the command list; the full deprecation message shows on the command's own help page.
+            tag = format_deprecated_tag(parsed.deprecation.version, None)
+            description = f"{tag} {description}" if description else tag
 
         entry = HelpEntry(
             positive_names=tuple(long_names),
             positive_shorts=tuple(short_names),
-            description=InlineText.from_format(description_text, format=format),
+            description=InlineText.from_format(description, format=format),
             sort_key=sort_key,
         )
         if entry not in entries:

--- a/cyclopts/help/rst_preprocessor.py
+++ b/cyclopts/help/rst_preprocessor.py
@@ -187,6 +187,26 @@ def _handle_version_directive(
     return tag, start_index + 1
 
 
+def format_deprecated_tag(version: str | None, content: str | None) -> str:
+    """Format a "Deprecated" tag, shared by the ``.. deprecated::`` directive and ``DocstringDeprecated`` metadata.
+
+    Parameters
+    ----------
+    version : str | None
+        Version the deprecation applies to, if any.
+    content : str | None
+        Optional explanatory content (e.g. "Use something else instead").
+
+    Returns
+    -------
+    str
+        Formatted tag, e.g. ``"[⚠ Deprecated in v1.0] Use something else instead"``.
+    """
+    tag = f"[⚠ Deprecated in v{version}]" if version else "[⚠ Deprecated]"
+    content = (content or "").strip()
+    return f"{tag} {content}" if content else tag
+
+
 def _handle_deprecated_directive(
     directive_name: str, directive_arg: str, lines: list[str], start_index: int, current_indent: int
 ) -> tuple[str, int]:
@@ -214,8 +234,7 @@ def _handle_deprecated_directive(
     """
     paragraphs, next_i = _gather_indented_block(lines, start_index + 1, current_indent)
     content = "\n\n".join(paragraphs).strip()
-    tag = f"[⚠ Deprecated in v{directive_arg}]"
-    return f"{tag} {content}" if content else tag, next_i
+    return format_deprecated_tag(directive_arg, content), next_i
 
 
 def _handle_admonition_directive(

--- a/cyclopts/help/rst_preprocessor.py
+++ b/cyclopts/help/rst_preprocessor.py
@@ -187,26 +187,6 @@ def _handle_version_directive(
     return tag, start_index + 1
 
 
-def format_deprecated_tag(version: str | None, content: str | None) -> str:
-    """Format a "Deprecated" tag, shared by the ``.. deprecated::`` directive and ``DocstringDeprecated`` metadata.
-
-    Parameters
-    ----------
-    version : str | None
-        Version the deprecation applies to, if any.
-    content : str | None
-        Optional explanatory content (e.g. "Use something else instead").
-
-    Returns
-    -------
-    str
-        Formatted tag, e.g. ``"[⚠ Deprecated in v1.0] Use something else instead"``.
-    """
-    tag = f"[⚠ Deprecated in v{version}]" if version else "[⚠ Deprecated]"
-    content = (content or "").strip()
-    return f"{tag} {content}" if content else tag
-
-
 def _handle_deprecated_directive(
     directive_name: str, directive_arg: str, lines: list[str], start_index: int, current_indent: int
 ) -> tuple[str, int]:
@@ -232,6 +212,8 @@ def _handle_deprecated_directive(
     next_index : int
         Next line index to process.
     """
+    from cyclopts.help.help import format_deprecated_tag
+
     paragraphs, next_i = _gather_indented_block(lines, start_index + 1, current_indent)
     content = "\n\n".join(paragraphs).strip()
     return format_deprecated_tag(directive_arg, content), next_i

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -2130,6 +2130,52 @@ def test_help_markdown(app, console, normalize_trailing_whitespace):
     assert normalize_trailing_whitespace(actual) == expected
 
 
+@pytest.mark.parametrize("help_format", ["markdown", "rst"])
+def test_help_docstring_deprecated_metadata(console, normalize_trailing_whitespace, help_format):
+    """A top-level ``.. deprecated::`` is extracted into metadata by docstring_parser and must be re-rendered."""
+    description = dedent(
+        """\
+        Main summary.
+
+        .. deprecated:: 2.0
+            Use ``other-tool`` instead.
+
+        Long description.
+        """
+    )
+    app = App(help=description, help_format=help_format)
+
+    @app.command
+    def sub():
+        """Subcommand summary.
+
+        .. deprecated::
+        """
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    expected = dedent(
+        """\
+        Usage: test_help COMMAND
+
+        Main summary.
+
+        [⚠ Deprecated in v2.0] Use other-tool instead.
+
+        Long description.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ sub          [⚠ Deprecated] Subcommand summary.                    │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+
+    assert normalize_trailing_whitespace(capture.get()) == expected
+
+
 def test_help_rich(app, console, normalize_trailing_whitespace):
     """Newlines actually get interpreted with rich."""
     description = dedent(


### PR DESCRIPTION
The deprecated directive is not being rendered. The reason is that it is split out by docstring as its own metaclass. Also retrieve this when formatting the doc and add to the components.

Also pull out the formatting, and allow empty deprecation version.