### PR TITLE
Split JSON documents on newlines when rendering decode errors

### DIFF
--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -404,7 +404,11 @@ def json_decode_error_verbosifier(decode_error: "JSONDecodeError", context: int 
     context: int
         Number of surrounding-character context
     """
-    lines = decode_error.doc.splitlines()
+    # ``JSONDecodeError.lineno`` is derived from ``doc.count("\n", 0, pos) + 1``, so the document
+    # has to be split on ``"\n"`` to stay in step with it. ``str.splitlines()`` additionally breaks
+    # on ``\v``, ``\f``, ``\u2028`` and friends, which JSON allows raw inside strings, and it drops
+    # the empty final line, so it can select the wrong line or index past the end.
+    lines = decode_error.doc.split("\n")
     line = lines[decode_error.lineno - 1]
 
     error_index = decode_error.colno - 1  # colno is 1-indexed

--- a/tests/config/test_json.py
+++ b/tests/config/test_json.py
@@ -112,3 +112,24 @@ def test_config_invalid_json(tmp_path, console):
         """
     )
     assert actual == expected
+
+
+def test_config_empty_json(tmp_path, console):
+    """An empty config file reports the decode error rather than raising out of the error panel."""
+    Path("config.json").write_text("")
+
+    with pytest.raises(CycloptsError), console.capture() as capture:
+        app("create", error_console=console, exit_on_error=False)
+
+    actual = capture.get()
+    expected = dedent(
+        """\
+        ╭─ Error ────────────────────────────────────────────────────────────╮
+        │ JSONDecodeError:                                                   │
+        │                                                                    │
+        │     ^                                                              │
+        │ Expecting value: line 1 column 1 (char 0)                          │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,15 @@
+import json
+
 import pytest
 
-from cyclopts.utils import Sentinel, _pascal_to_snake, grouper, is_option_like, parse_version
+from cyclopts.utils import (
+    Sentinel,
+    _pascal_to_snake,
+    grouper,
+    is_option_like,
+    json_decode_error_verbosifier,
+    parse_version,
+)
 
 
 def test_grouper():
@@ -117,3 +126,35 @@ def test_pascal_to_snake(input_str, expected):
 )
 def test_parse_version(version_string, expected):
     assert parse_version(version_string) == expected
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        "",
+        "{\n",
+        '{\n  "a": 1,\n',
+    ],
+)
+def test_json_decode_error_verbosifier_error_at_end_of_document(doc):
+    """A document ending in a newline reports an error on a line ``str.splitlines`` discards."""
+    with pytest.raises(json.JSONDecodeError) as exc_info:
+        json.loads(doc)
+
+    assert json_decode_error_verbosifier(exc_info.value).split("\n")[:3] == ["JSONDecodeError:", "    ", "    ^"]
+
+
+def test_json_decode_error_verbosifier_line_separator_in_string():
+    r"""``\u2028`` is legal raw inside a JSON string, but ``str.splitlines`` breaks on it.
+
+    ``JSONDecodeError.lineno`` counts only ``\n``, so splitting any other way points the caret
+    at a different line than the one the error refers to.
+    """
+    with pytest.raises(json.JSONDecodeError) as exc_info:
+        json.loads('{"a": "x\u2028y",\n  bad}')
+
+    assert json_decode_error_verbosifier(exc_info.value).split("\n")[:3] == [
+        "JSONDecodeError:",
+        "      bad}",
+        "      ^",
+    ]


### PR DESCRIPTION
`json_decode_error_verbosifier` splits the document with `str.splitlines()` and indexes it with `JSONDecodeError.lineno`. The two disagree on what a line is. `lineno` comes from `doc.count("\n", 0, pos) + 1`, while `splitlines()` also breaks on `\v`, `\f`, `\x1c`-`\x1e`, `\x85`, `\u2028`, `\u2029`, and drops the empty final element.

`\u2028` and `\u2029` are accepted raw inside a JSON string by `json.loads`, so a document containing one yields more entries from `splitlines()` than `lineno` counts. The caret is then drawn under a line other than the failing one, no error raised.

When the failure sits at the end of a document ending in a newline, `lineno - 1 == len(lines)` and the lookup raises `IndexError`. An empty `config.json` reaches it. The `IndexError` escapes from `CoercionError.__rich__` while rich renders the error panel, so a rich-internal traceback replaces the message.

`split("\n")` is how `lineno` is derived, so the index is in range by construction: `len(doc.split("\n")) == doc.count("\n") + 1 >= lineno`. Bounds-checking `splitlines()` would stop the `IndexError` but leave the wrong-line case, so I did not take that route.

Unchanged: `colno` is a character offset, so with tabs or double-width characters the caret is off by the display width.

Five new assertions cover both failure modes, one through an empty config file end to end. Each fails on `main`. Suite goes 2614 to 2619 passed with no other change; `pre-commit run --all-files` is clean.
