### PR TITLE
Add structured command/parameter deprecation with runtime warning hook

### DIFF
--- a/cyclopts/_deprecation.py
+++ b/cyclopts/_deprecation.py
@@ -1,0 +1,27 @@
+import warnings
+from collections.abc import Callable
+
+DeprecatedHandler = Callable[[str, str, "str | None", "str | None"], None]
+"""Signature for a ``deprecated_handler``: ``(kind, name, version, message) -> None``.
+
+``kind`` is ``"command"`` or ``"parameter"``; ``name`` is the command/parameter's
+primary CLI name; ``version`` and ``message`` come from the ``deprecated`` field
+(see :func:`cyclopts.utils.normalize_deprecated`).
+"""
+
+
+def default_deprecated_handler(kind: str, name: str, version: str | None, message: str | None) -> None:
+    """Default ``deprecated_handler``: emits a :class:`DeprecationWarning`.
+
+    Note that Python ignores :class:`DeprecationWarning` by default unless the
+    triggering code runs as ``__main__``; configure warning filters (e.g. ``-W
+    default::DeprecationWarning``) or ``logging.captureWarnings(True)`` to see
+    it reliably, or supply a custom ``deprecated_handler`` (e.g. one that calls
+    your own logger) to bypass the warnings-filter system entirely.
+    """
+    text = f"{kind} {name!r} is deprecated"
+    if version:
+        text += f" since v{version}"
+    if message:
+        text += f": {message}"
+    warnings.warn(text, DeprecationWarning, stacklevel=2)

--- a/cyclopts/command_spec.py
+++ b/cyclopts/command_spec.py
@@ -27,6 +27,8 @@ class CommandSpec:
         CLI command name. If None, will be derived from the attribute name via name_transform.
         For function imports: used as the name of the wrapper App.
         For App imports: must match the App's internal name, or ValueError is raised at resolution.
+    deprecated : str | tuple[str, str] | None
+        Optional deprecation message or tuple of (version, message) to indicate when the command was deprecated.
     app_kwargs : dict
         Keyword arguments to pass to App() if wrapping a function.
         Raises ValueError if used with App imports (Apps should be configured in their own definition).
@@ -43,6 +45,7 @@ class CommandSpec:
     import_path: str
     name: str | tuple[str, ...] | None = None
     app_kwargs: dict[str, Any] = Factory(dict)
+    deprecated: str | tuple[str, str] | None = None
     help: str | None = None
     sort_key: Any = None
     group: "Group | str | tuple[Group | str, ...] | None" = None
@@ -156,6 +159,8 @@ class CommandSpec:
             self._resolved.sort_key = self.sort_key
         if self.group is not None:
             self._resolved.group = self.group
+        if self.deprecated is not None:
+            self._resolved.deprecated = self.deprecated
         if self._show is not None:
             self._resolved.show = self._show
         if self._resolved._name_transform is None:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -25,6 +25,7 @@ from typing import (
 
 from attrs import Factory, define, field
 
+from cyclopts._deprecation import DeprecatedHandler, default_deprecated_handler
 from cyclopts.annotations import resolve_annotated
 from cyclopts.app_stack import AppStack
 from cyclopts.argument import ArgumentCollection
@@ -51,6 +52,7 @@ from cyclopts.utils import (
     create_error_console_from_console,
     default_name_transform,
     help_formatter_converter,
+    normalize_deprecated,
     optional_to_tuple_converter,
     sort_key_converter,
     to_list_converter,
@@ -371,6 +373,10 @@ class App:
     )
 
     show: bool = field(default=True, kw_only=True)
+
+    deprecated: str | tuple[str, str] | None = field(default=None, kw_only=True)
+
+    deprecated_handler: DeprecatedHandler | None = field(default=None, kw_only=True)
 
     _console: Optional["Console"] = field(default=None, kw_only=True, alias="console")
 
@@ -1396,6 +1402,7 @@ class App:
                 sort_key=kwargs.pop("sort_key", None),
                 group=kwargs.pop("group", None),  # type: ignore[arg-type]
                 show=kwargs.pop("show", None),  # type: ignore[arg-type]
+                deprecated=kwargs.pop("deprecated", None),  # type: ignore[arg-type]
                 app_kwargs=kwargs,
             )
 
@@ -1646,6 +1653,7 @@ class App:
                 command_chain = command_chain[:-1]
 
         command_app = execution_apps[-1]
+        command_chain_apps = execution_apps  # Used only for deprecation warnings below.
         del execution_apps  # Always use AppStack from here-on.
 
         ignored: dict[str, Any] = {}
@@ -1717,6 +1725,7 @@ class App:
                                 group=command_group,  # pyright: ignore
                             ) from e
 
+                        _emit_deprecation_warnings(command_chain_apps, argument_collection, command_app)
                     else:
                         if unused_tokens:
                             raise UnknownCommandError(unused_tokens=unused_tokens)
@@ -2796,6 +2805,33 @@ class App:
 
         signature = ", ".join(f"{k}={v!r}" for k, v in non_defaults.items())
         return f"{type(self).__name__}({signature})"
+
+
+def _emit_deprecation_warnings(
+    command_chain_apps: Sequence["App"],
+    argument_collection: ArgumentCollection,
+    command_app: "App",
+) -> None:
+    """Fire ``deprecated_handler`` for deprecated commands/parameters actually used.
+
+    Only fires for commands actually invoked and parameters actually supplied on the
+    CLI (not merely declared). Must run only once parsing/validation has fully
+    succeeded, so a failed parse never warns about deprecations that were never reached.
+    """
+    for app in command_chain_apps:
+        if app.deprecated is not None:
+            handler = app.app_stack.resolve("deprecated_handler", fallback=default_deprecated_handler)
+            version, message = normalize_deprecated(app.deprecated)
+            handler("command", app.name[0], version, message)
+
+    for argument in argument_collection:
+        if argument.parameter.deprecated is not None and argument.has_tokens:
+            handler = (
+                argument.parameter.deprecated_handler
+                or command_app.app_stack.resolve("deprecated_handler", fallback=default_deprecated_handler)
+            )
+            version, message = normalize_deprecated(argument.parameter.deprecated)
+            handler("parameter", argument.name, version, message)
 
 
 def _get_help_flag_index(tokens, help_flags, end_of_options_delimiter) -> int | None:

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -25,7 +25,14 @@ from cyclopts.field_info import get_field_infos
 from cyclopts.group import Group
 from cyclopts.help.inline_text import InlineText
 from cyclopts.help.silent import SILENT, SilentRich
-from cyclopts.utils import SortHelper, frozen, is_class_and_subclass, resolve_callables, slice_to_str
+from cyclopts.utils import (
+    SortHelper,
+    frozen,
+    is_class_and_subclass,
+    normalize_deprecated,
+    resolve_callables,
+    slice_to_str,
+)
 
 if TYPE_CHECKING:
     from rich.console import RenderableType
@@ -371,10 +378,26 @@ def format_deprecated_tag(version: str | None, content: str | None) -> str:
     return f"{tag} {content}" if content else tag
 
 
+def _resolve_deprecation(
+    explicit: str | tuple[str, str] | None,
+    parsed_deprecation,
+) -> tuple[str | None, str | None] | None:
+    """Resolve the deprecation metadata to render, if any.
+
+    An explicit ``deprecated`` field (set directly on an :class:`App`/:class:`Parameter`)
+    takes priority over a docstring's ``.. deprecated::`` directive.
+    """
+    if explicit is not None:
+        return normalize_deprecated(explicit)
+    if parsed_deprecation is not None:
+        return parsed_deprecation.version, parsed_deprecation.description
+    return None
+
+
 def format_doc(app: "App", format: str) -> InlineText | SilentRich:
     raw_doc_string = app.help
 
-    if not raw_doc_string:
+    if not raw_doc_string and app.deprecated is None:
         return SILENT
 
     parsed = docstring_parse(raw_doc_string, format)
@@ -386,15 +409,19 @@ def format_doc(app: "App", format: str) -> InlineText | SilentRich:
     # docstring_parser extracts a top-level ``.. deprecated::`` directive into
     # ``parsed.deprecation`` metadata, so it never reaches the renderer as text;
     # reconstruct it here for every help format.
-    if parsed.deprecation:
+    deprecation = _resolve_deprecation(app.deprecated, parsed.deprecation)
+    if deprecation is not None:
         if components:
             components.append("\n")
-        components.append(format_deprecated_tag(parsed.deprecation.version, parsed.deprecation.description) + "\n")
+        components.append(format_deprecated_tag(*deprecation) + "\n")
 
     if parsed.long_description:
         if components:
             components.append("\n")
         components.append(parsed.long_description + "\n")
+
+    if not components:
+        return SILENT
 
     return InlineText.from_format(_smart_join(components), format=format, force_empty_end=True)
 
@@ -515,7 +542,11 @@ def _make_help_entry(argument: "Argument", format: str) -> HelpEntry:
     negative_names = [o for o in options if o in negatives and not is_short_flag(o)]
     negative_shorts = [o for o in options if o in negatives and is_short_flag(o)]
 
-    help_description = InlineText.from_format(argument.parameter.help, format=format)
+    help_text = argument.parameter.help
+    if argument.parameter.deprecated is not None:
+        tag = format_deprecated_tag(*normalize_deprecated(argument.parameter.deprecated))
+        help_text = f"{tag} {help_text}" if help_text else tag
+    help_description = InlineText.from_format(help_text, format=format)
 
     choices = argument.get_choices()
 
@@ -635,9 +666,10 @@ def format_command_entries(apps_with_names: Iterable, format: str) -> list[HelpE
 
         parsed = docstring_parse(app.help, format)
         description = parsed.short_description
-        if parsed.deprecation:
+        deprecation = _resolve_deprecation(app.deprecated, parsed.deprecation)
+        if deprecation is not None:
             # Tag-only in the command list; the full deprecation message shows on the command's own help page.
-            tag = format_deprecated_tag(parsed.deprecation.version, None)
+            tag = format_deprecated_tag(deprecation[0], None)
             description = f"{tag} {description}" if description else tag
 
         entry = HelpEntry(

--- a/cyclopts/parameter.py
+++ b/cyclopts/parameter.py
@@ -23,6 +23,7 @@ else:
 
 import cyclopts._env_var
 from cyclopts._convert import _abstract_to_concrete_type_mapping
+from cyclopts._deprecation import DeprecatedHandler
 from cyclopts.annotations import (
     ITERABLE_TYPES,
     NoneType,
@@ -293,6 +294,10 @@ class Parameter:
     )
 
     help: str | None = field(default=None, kw_only=True)
+
+    deprecated: str | tuple[str, str] | None = field(default=None, kw_only=True)
+
+    deprecated_handler: DeprecatedHandler | None = field(default=None, kw_only=True)
 
     show_env_var: bool = field(
         default=None,

--- a/cyclopts/utils.py
+++ b/cyclopts/utils.py
@@ -299,6 +299,18 @@ def slice_to_str(value: slice, /) -> str:
     return ":".join(parts)
 
 
+def normalize_deprecated(value: str | tuple[str, str]) -> tuple[str | None, str | None]:
+    """Normalize a ``deprecated`` field value into ``(version, message)``.
+
+    A plain string is treated as the message with no version; a ``(version, message)``
+    tuple is passed through, with an empty version normalized to :obj:`None`.
+    """
+    if isinstance(value, str):
+        return None, value
+    version, message = value
+    return (version or None), message
+
+
 def is_builtin(obj: Any) -> bool:
     return getattr(obj, "__module__", "").split(".")[0] in stdlib_module_names
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -132,6 +132,47 @@ API
          │ --version  Display application version.                               │
          ╰───────────────────────────────────────────────────────────────────────╯
 
+   .. attribute:: deprecated
+      :type: Union[None, str, Tuple[str, str]]
+      :value: None
+
+      Mark this command as deprecated.
+      A plain string is used as the deprecation message; a ``(version, message)`` tuple additionally
+      records the version the command was deprecated in.
+      Renders a ``[⚠ Deprecated]`` tag on the command's help page and in its parent's command list,
+      taking priority over any ``.. deprecated::`` directive found in the docstring.
+      Also triggers :attr:`deprecated_handler` at runtime whenever this command is actually invoked.
+
+   .. attribute:: deprecated_handler
+      :type: Optional[Callable[[str, str, Optional[str], Optional[str]], None]]
+      :value: None
+
+      Callback invoked as ``(kind, name, version, message)`` whenever a deprecated command is
+      invoked or a deprecated parameter is explicitly supplied on the CLI (not merely declared).
+      ``kind`` is ``"command"`` or ``"parameter"``, ``name`` is its primary CLI name, and
+      ``version``/``message`` come from the :attr:`deprecated` field.
+
+      If unset, inherits from the closest ancestor App that sets one; if none do, falls back to
+      emitting a standard :class:`DeprecationWarning` via the :mod:`warnings` module. Set this to
+      route deprecation notices through your own logger instead:
+
+      .. code-block:: python
+
+         import logging
+         from cyclopts import App
+
+         logger = logging.getLogger(__name__)
+
+
+         def log_deprecation(kind, name, version, message):
+             logger.warning("%s %r is deprecated%s: %s", kind, name, f" (v{version})" if version else "", message)
+
+
+         app = App(deprecated_handler=log_deprecation)
+
+      A :class:`~cyclopts.Parameter`'s own :attr:`~cyclopts.Parameter.deprecated_handler`, if set,
+      takes priority over the App's for that specific parameter.
+
    .. attribute:: help_flags
       :type: Union[str, Iterable[str]]
       :value: ("--help", "-h")
@@ -1376,6 +1417,26 @@ API
 
       Help string to be displayed on the help page.
       If not specified, defaults to the docstring.
+
+   .. attribute:: deprecated
+      :type: Union[None, str, Tuple[str, str]]
+      :value: None
+
+      Mark this parameter as deprecated.
+      A plain string is used as the deprecation message; a ``(version, message)`` tuple additionally
+      records the version the parameter was deprecated in.
+      Renders a ``[⚠ Deprecated]`` tag alongside the parameter's help entry.
+      Also triggers :attr:`deprecated_handler` at runtime whenever this parameter is explicitly
+      supplied on the CLI (not merely declared).
+
+   .. attribute:: deprecated_handler
+      :type: Optional[Callable[[str, str, Optional[str], Optional[str]], None]]
+      :value: None
+
+      Callback invoked as ``(kind, name, version, message)`` when this parameter is deprecated
+      and explicitly supplied. Overrides the owning :class:`~cyclopts.App`'s
+      :attr:`~cyclopts.App.deprecated_handler` for this parameter only; see there for details
+      and an example.
 
    .. attribute:: show_env_var
       :type: Optional[bool]

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -349,6 +349,78 @@ There are a few ways to add a help string to a command:
       │ --version  Display application version.                               │
       ╰───────────────────────────────────────────────────────────────────────╯
 
+.. _Deprecating a Command:
+
+---------------------
+Deprecating a Command
+---------------------
+Mark a command as deprecated via the :attr:`deprecated <cyclopts.App.deprecated>` field, either on
+:meth:`@app.command <cyclopts.App.command>` or directly on a sub-app.
+It accepts either a plain message, or a ``(version, message)`` tuple:
+
+.. code-block:: python
+
+   from cyclopts import App
+
+   app = App(name="my-script")
+
+   @app.command
+   def foo():
+       """Help string for foo."""
+
+   @app.command(deprecated="Use foo instead.")
+   def bar():
+       """Help string for bar."""
+
+   app()
+
+.. code-block:: console
+
+   $ my-script --help
+   Usage: my-script COMMAND
+
+   ╭─ Commands ───────────────────────────────────────────────────────────────────╮
+   │ bar          [⚠ Deprecated] Help string for bar.                             │
+   │ foo          Help string for foo.                                            │
+   │ --help (-h)  Display this message and exit.                                  │
+   │ --version    Display application version.                                    │
+   ╰──────────────────────────────────────────────────────────────────────────────╯
+
+   $ my-script bar --help
+   Usage: my-script bar
+
+   Help string for bar.
+
+   [⚠ Deprecated] Use foo instead.
+
+This only changes what's *displayed*; ``bar`` still runs normally when invoked.
+To also get notified at runtime whenever ``bar`` is actually invoked (e.g. to log a warning),
+set :attr:`App.deprecated_handler <cyclopts.App.deprecated_handler>`.
+It's called as ``(kind, name, version, message)``, where ``kind`` is ``"command"`` or ``"parameter"``:
+
+.. code-block:: python
+
+   import logging
+   from cyclopts import App
+
+   logger = logging.getLogger(__name__)
+
+
+   def log_deprecation(kind, name, version, message):
+       logger.warning("%s %r is deprecated: %s", kind, name, message)
+
+
+   app = App(name="my-script", deprecated_handler=log_deprecation)
+
+   @app.command(deprecated="Use foo instead.")
+   def bar():
+       pass
+
+Set on the root :class:`.App`, ``deprecated_handler`` is inherited by every sub-app unless overridden.
+If left unset entirely, Cyclopts falls back to emitting a standard :class:`DeprecationWarning`.
+The same mechanism applies to :attr:`Parameter.deprecated <cyclopts.Parameter.deprecated>`, firing
+only when that specific parameter is explicitly supplied on the CLI -- see :ref:`Parameters`.
+
 -----
 Async
 -----

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -1,3 +1,5 @@
+.. _Parameters:
+
 ==========
 Parameters
 ==========
@@ -249,6 +251,39 @@ It is recommended to use docstrings for your parameter help, but if necessary, y
    ╭─ Parameters ──────────────────────────────────────────────────╮
    │ *  VALUE,--value  THIS IS USED. [required]                    │
    ╰───────────────────────────────────────────────────────────────╯
+
+-----------------------
+Deprecating a Parameter
+-----------------------
+Mark an individual parameter as deprecated via :attr:`Parameter.deprecated <cyclopts.Parameter.deprecated>`,
+either a plain message or a ``(version, message)`` tuple:
+
+.. code-block:: python
+
+   @app.command
+   def foo(
+       *,
+       new_parameter: int = 0,
+       old_parameter: Annotated[int, Parameter(deprecated="Use --new-parameter instead.")] = 0,
+   ):
+       pass
+
+.. code-block:: console
+
+   $ my-script foo --help
+   Usage: my-script foo [OPTIONS]
+
+   ╭─ Parameters ─────────────────────────────────────────────────────────────────╮
+   │ --new-parameter  [default: 0]                                                │
+   │ --old-parameter  [⚠ Deprecated] Use --new-parameter instead. [default: 0]    │
+   ╰──────────────────────────────────────────────────────────────────────────────╯
+
+This only changes what's *displayed*. To also get notified at runtime whenever ``old_parameter`` is
+actually supplied on the CLI (unused defaults never trigger it), set
+:attr:`Parameter.deprecated_handler <cyclopts.Parameter.deprecated_handler>`, or set
+:attr:`App.deprecated_handler <cyclopts.App.deprecated_handler>` once to cover every deprecated
+command and parameter in the application -- see :ref:`Deprecating a Command` for details
+and a logging example.
 
 .. _Converters:
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,174 @@
+"""Tests for runtime deprecation warnings (App.deprecated_handler / Parameter.deprecated_handler).
+
+These are distinct from the help-rendering deprecation tests in test_help.py: this file
+covers the runtime callback fired when a deprecated command/parameter is actually used.
+"""
+
+from typing import Annotated
+
+import pytest
+
+from cyclopts import App, Parameter
+from cyclopts.exceptions import ValidationError
+
+
+@pytest.fixture
+def calls():
+    """A list that a fake ``deprecated_handler`` appends ``(kind, name, version, message)`` to."""
+    return []
+
+
+@pytest.fixture
+def handler(calls):
+    def _handler(kind, name, version, message):
+        calls.append((kind, name, version, message))
+
+    return _handler
+
+
+def test_deprecated_command_fires_handler_on_invocation(app, handler, calls):
+    app.deprecated_handler = handler
+
+    @app.command(deprecated=("2.0", "Use new-cmd instead."))
+    def old_cmd():
+        return "ran"
+
+    result = app(["old-cmd"])
+
+    assert result == "ran"
+    assert calls == [("command", "old-cmd", "2.0", "Use new-cmd instead.")]
+
+
+def test_non_deprecated_command_does_not_fire_handler(app, handler, calls):
+    app.deprecated_handler = handler
+
+    @app.command
+    def fine_cmd():
+        return "ran"
+
+    app(["fine-cmd"])
+
+    assert calls == []
+
+
+def test_deprecated_parameter_fires_only_when_explicitly_supplied(app, handler, calls):
+    app.deprecated_handler = handler
+
+    @app.default
+    def main(x: Annotated[int, Parameter(deprecated="use --y instead")] = 0, y: int = 0):
+        return x, y
+
+    app(["--y", "5"])
+    assert calls == []  # x used its default; never supplied.
+
+    app(["--x", "5"])
+    assert calls == [("parameter", "--x", None, "use --y instead")]
+
+
+def test_deprecated_parameter_with_version(app, handler, calls):
+    app.deprecated_handler = handler
+
+    @app.default
+    def main(x: Annotated[int, Parameter(deprecated=("1.5", "Use --y."))] = 0):
+        return x
+
+    app(["--x", "1"])
+
+    assert calls == [("parameter", "--x", "1.5", "Use --y.")]
+
+
+def test_parameter_deprecated_handler_overrides_app_handler(app, calls):
+    app_calls = []
+    param_calls = []
+    app.deprecated_handler = lambda kind, name, version, message: app_calls.append((kind, name, version, message))
+
+    @app.default
+    def main(
+        x: Annotated[
+            int,
+            Parameter(
+                deprecated="p",
+                deprecated_handler=lambda kind, name, version, message: param_calls.append(
+                    (kind, name, version, message)
+                ),
+            ),
+        ] = 0,
+    ):
+        return x
+
+    app(["--x", "1"])
+
+    assert app_calls == []
+    assert param_calls == [("parameter", "--x", None, "p")]
+
+
+def test_subapp_inherits_root_deprecated_handler(app, handler, calls):
+    app.deprecated_handler = handler
+
+    sub = App(name="sub", deprecated="deprecated subapp")
+    app.command(sub)
+
+    @sub.default
+    def sub_main():
+        return "ran"
+
+    app(["sub"])
+
+    assert calls == [("command", "sub", None, "deprecated subapp")]
+
+
+def test_deprecated_intermediate_group_and_leaf_both_fire(app, handler, calls):
+    app.deprecated_handler = handler
+
+    group = App(name="group", deprecated="whole group is old")
+    app.command(group)
+
+    @group.command(deprecated="leaf itself is also old")
+    def leaf():
+        return "ran"
+
+    app(["group", "leaf"])
+
+    assert ("command", "group", None, "whole group is old") in calls
+    assert ("command", "leaf", None, "leaf itself is also old") in calls
+    assert len(calls) == 2
+
+
+def test_no_deprecation_no_warning(app, handler, calls):
+    app.deprecated_handler = handler
+
+    @app.default
+    def main(x: int = 0):
+        return x
+
+    app(["--x", "1"])
+
+    assert calls == []
+
+
+def test_deprecated_handler_not_fired_on_failed_validation(app, handler, calls):
+    """A validator rejecting the arguments must prevent the deprecated_handler from firing."""
+    app.deprecated_handler = handler
+
+    def reject(x):
+        raise ValueError("nope")
+
+    @app.default(validator=reject)
+    def main(x: Annotated[int, Parameter(deprecated="old param")] = 0):
+        return x
+
+    with pytest.raises(ValidationError):
+        app(["--x", "1"], print_error=False, exit_on_error=False)
+
+    assert calls == []
+
+
+def test_default_deprecated_handler_emits_deprecation_warning(app):
+    """Without a custom handler, the built-in default emits a stdlib DeprecationWarning."""
+
+    @app.command(deprecated=("3.0", "Use other instead."))
+    def old_cmd():
+        return "ran"
+
+    with pytest.warns(DeprecationWarning, match="old-cmd.*deprecated.*v3.0.*Use other instead."):
+        app(["old-cmd"])

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -2176,6 +2176,121 @@ def test_help_docstring_deprecated_metadata(console, normalize_trailing_whitespa
     assert normalize_trailing_whitespace(capture.get()) == expected
 
 
+def test_help_app_deprecated_field(console, normalize_trailing_whitespace):
+    """Explicit ``App.deprecated`` renders like the docstring directive, without needing one."""
+    app = App(name="test_help", help="Main summary.")
+
+    @app.command(deprecated=("2.0", "Use other-tool instead."))
+    def sub():
+        """Subcommand summary."""
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    expected = dedent(
+        """\
+        Usage: test_help COMMAND
+
+        Main summary.
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ sub          [⚠ Deprecated in v2.0] Subcommand summary.            │
+        │ --help (-h)  Display this message and exit.                        │
+        │ --version    Display application version.                          │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+
+    assert normalize_trailing_whitespace(capture.get()) == expected
+
+    with console.capture() as capture:
+        app.help_print(["sub"], console=console)
+
+    expected = dedent(
+        """\
+        Usage: test_help sub
+
+        Subcommand summary.
+
+        [⚠ Deprecated in v2.0] Use other-tool instead.
+
+        """
+    )
+
+    assert normalize_trailing_whitespace(capture.get()) == expected
+
+
+def test_help_app_deprecated_field_no_version_no_help(console, normalize_trailing_whitespace):
+    """A plain string ``deprecated`` value is the message; no help text is required for the tag to render."""
+    app = App(name="test_help")
+
+    @app.command(deprecated="Will be removed.")
+    def sub():
+        pass
+
+    with console.capture() as capture:
+        app.help_print(["sub"], console=console)
+
+    expected = dedent(
+        """\
+        Usage: test_help sub
+
+        [⚠ Deprecated] Will be removed.
+
+        """
+    )
+
+    assert normalize_trailing_whitespace(capture.get()) == expected
+
+
+def test_help_app_deprecated_field_overrides_docstring(console, normalize_trailing_whitespace):
+    """The explicit ``deprecated`` field takes priority over a docstring ``.. deprecated::`` directive."""
+    app = App(name="test_help")
+
+    @app.command(deprecated="Explicit message wins.")
+    def sub():
+        """Summary.
+
+        .. deprecated:: 1.0
+            Docstring message should not be shown.
+        """
+
+    with console.capture() as capture:
+        app.help_print(["sub"], console=console)
+
+    expected = dedent(
+        """\
+        Usage: test_help sub
+
+        Summary.
+
+        [⚠ Deprecated] Explicit message wins.
+
+        """
+    )
+
+    assert normalize_trailing_whitespace(capture.get()) == expected
+
+
+def test_help_parameter_deprecated_field(app, console, normalize_trailing_whitespace):
+    """Explicit ``Parameter.deprecated`` renders a tag alongside the parameter's help entry."""
+
+    @app.default
+    def main(
+        x: Annotated[int, Parameter(deprecated=("1.5", "Use --y instead."), help="An int.")] = 0,
+        y: Annotated[int, Parameter(deprecated="No version given.")] = 0,
+    ):
+        pass
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    actual = normalize_trailing_whitespace(capture.get())
+
+    assert "[⚠ Deprecated in v1.5] Use --y instead. An int." in actual
+    assert "[⚠ Deprecated] No version given." in actual
+
+
 def test_help_rich(app, console, normalize_trailing_whitespace):
     """Newlines actually get interpreted with rich."""
     description = dedent(

--- a/tests/test_lazy_commands.py
+++ b/tests/test_lazy_commands.py
@@ -1077,3 +1077,54 @@ def test_iterate_commands_resolve_lazy(lazy_module):
 
     # Lazy command should now be resolved
     assert app._commands["lazy"].is_resolved
+
+
+def test_command_spec_deprecated_applied_on_resolve(app):
+    """CommandSpec.deprecated is copied onto the resolved App."""
+    spec = CommandSpec(import_path="os.path:join", name="join", deprecated=("3.0", "Use pathlib instead."))
+
+    # Not applied until resolved.
+    assert spec.deprecated == ("3.0", "Use pathlib instead.")
+
+    resolved = spec.resolve(app)
+
+    assert resolved.deprecated == ("3.0", "Use pathlib instead.")
+
+
+def test_command_spec_deprecated_unset_leaves_resolved_app_alone(app, lazy_module):
+    """When CommandSpec.deprecated is unset, the resolved App keeps its own default (None)."""
+    test_module = lazy_module()
+
+    def cmd():
+        pass
+
+    test_module.cmd = cmd  # type: ignore[attr-defined]
+
+    spec = CommandSpec(import_path="test_lazy_module:cmd", name="cmd")
+    resolved = spec.resolve(app)
+
+    assert resolved.deprecated is None
+
+
+def test_lazy_command_deprecated_via_app_command(console, lazy_module, normalize_trailing_whitespace):
+    """app.command(..., deprecated=...) on an import-path string reaches the resolved App and renders."""
+    test_module = lazy_module()
+
+    def old_cmd():
+        """Old command."""
+        pass
+
+    test_module.old_cmd = old_cmd  # type: ignore[attr-defined]
+
+    app = App(name="myapp")
+    app.command("test_lazy_module:old_cmd", name="old", deprecated=("1.0", "Use new instead."))
+
+    # Stored on the CommandSpec pre-resolution.
+    spec = app._commands["old"]
+    assert isinstance(spec, CommandSpec)
+    assert spec.deprecated == ("1.0", "Use new instead.")
+
+    with console.capture() as capture:
+        app.help_print([], console=console)
+
+    assert "[⚠ Deprecated in v1.0]" in normalize_trailing_whitespace(capture.get())


### PR DESCRIPTION
Command/Parameter previously only supported deprecation via docstring `.. deprecated::` directives. Adds an explicit `deprecated` field (message or (version, message) tuple) that takes priority over the docstring, plus a `deprecated_handler` callable fired at actual point-of-use (command invocation, parameter explicitly supplied) so callers can route notices through their own logger instead of relying on Python's warnings filter. CommandSpec.deprecated is now wired through to the resolved App.