### PR TITLE
Render flattened subapp commands in generated docs

### DIFF
--- a/cyclopts/docs/base.py
+++ b/cyclopts/docs/base.py
@@ -503,12 +503,16 @@ def iterate_commands(app: "App", include_hidden: bool = False, resolve_lazy: boo
     Tuple[str, App]
         (command_name, resolved_subapp) for each valid command.
     """
-    if not app._commands:
-        return
+    commands: dict[str, App | CommandSpec] = dict(app._commands)
+    # Merge commands from flattened subapps (registered via name="*"); parent commands take precedence.
+    for flattened in app._flattened_subapps:
+        for cmd_name in flattened:
+            if cmd_name not in commands and not _is_builtin_flag(flattened, cmd_name):
+                commands[cmd_name] = flattened._get_item(cmd_name, recurse_meta=False)
 
     seen: set[int] = set()
 
-    for name, app_or_spec in app._commands.items():
+    for name, app_or_spec in commands.items():
         if _is_builtin_flag(app, name):
             continue
 

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -1073,3 +1073,43 @@ def test_generate_docs_usage_name_empty_string_is_inserted_verbatim():
     first_line = next(line for line in subcommand_usage.splitlines() if line.strip())
     assert not first_line.startswith("cli ")
     assert first_line.startswith("serve")
+
+
+@pytest.mark.parametrize("fmt", ["markdown", "rst", "html"])
+def test_generate_docs_flattened_subapp_commands(fmt):
+    """Commands flattened via app.command(subapp, name="*") get their own doc sections."""
+    app = App(name="app")
+    sub_app = App(name="sub")
+
+    @sub_app.command
+    def star(bar: int):
+        """Star command."""
+        pass
+
+    app.command(sub_app, name="*")
+
+    actual = app.generate_docs(output_format=fmt)
+    assert "app star" in actual
+    assert "bar" in actual.lower()
+
+
+def test_generate_docs_flattened_subapp_parent_precedence():
+    """On a name collision, the parent's command is documented, not the flattened subapp's."""
+    app = App(name="app")
+    sub_app = App(name="sub")
+
+    @app.command
+    def run():
+        """Parent run."""
+        pass
+
+    @sub_app.command(name="run")
+    def sub_run():
+        """Subapp run."""
+        pass
+
+    app.command(sub_app, name="*")
+
+    actual = app.generate_docs()
+    assert "Parent run" in actual
+    assert "Subapp run" not in actual


### PR DESCRIPTION
## Render flattened subapp commands in generated docs

Commands flattened into a parent via `app.command(subapp, name="*")` showed up in the help-derived **Commands** panel but got no doc section or TOC entry (and a dead anchor link). Root cause: every docs format builds its command list through `iterate_commands()` in `cyclopts/docs/base.py`, which only walked `app._commands` and never `app._flattened_subapps`.

- `iterate_commands()` now merges flattened subapp commands using the same semantics as `_combined_meta_command_mapping()`/`resolved_commands()`: parent commands take precedence on name collision, and the subapp's own builtin `--help`/`--version` entries are skipped.
- Since markdown, RST, HTML, and the recursive doc walk all go through this one helper, the fix covers all formats, including nested flattening.

Fixes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
