### PR TITLE
Handle a config file whose document root is empty or not a mapping

### DIFF
--- a/cyclopts/config/_common.py
+++ b/cyclopts/config/_common.py
@@ -47,26 +47,41 @@ class ConfigBase(ABC):
         """Return a string identifying the configuration source for error messages."""
         raise NotImplementedError
 
+    def _ensure_mapping(self, node: Any, traversed: list[str]) -> None:
+        """Raise a :class:`CycloptsError` if a visited configuration node is not a mapping.
+
+        Parameters
+        ----------
+        node: Any
+            The configuration node reached so far.
+        traversed: list[str]
+            Keys descended through to reach ``node``; empty for the document root.
+        """
+        if isinstance(node, dict):
+            return
+        keyword = "".join(f"[{k}]" for k in traversed)
+        location = f"key {keyword} " if keyword else ""
+        raise CycloptsError(
+            msg=f'Configuration {location}in "{self.source}" must be a mapping, but got {type(node).__name__}.'
+        )
+
     def __call__(
         self,
         app: "App",
         commands: tuple[str, ...],
         arguments: ArgumentCollection,
     ):
-        config: dict[str, Any] = self.config.copy()
         traversed: list[str] = []
+        root = self.config
+        self._ensure_mapping(root, traversed)
+        config: dict[str, Any] = root.copy()
         for key in chain(self.root_keys, commands if self.use_commands_as_keys else ()):
             try:
                 config = config[key]
             except KeyError:
                 return
             traversed.append(key)
-            if not isinstance(config, dict):
-                keyword = "".join(f"[{k}]" for k in traversed)
-                raise CycloptsError(
-                    msg=f'Configuration key {keyword} in "{self.source}" must be a mapping, '
-                    f"but got {type(config).__name__}."
-                )
+            self._ensure_mapping(config, traversed)
 
         # Hierarchical config uses current app; flat config uses root app to filter sibling commands
         if self.use_commands_as_keys:
@@ -167,7 +182,7 @@ class ConfigFromFile(ConfigBase):
                             msg += ": "
                         msg += exception_msg
                     raise CycloptsError(msg=msg) from e
-                return self._config
+                return self._config or {}
             if not self.search_parents:
                 # Only look at the specified path; do not walk parent directories.
                 break

--- a/tests/config/test_common.py
+++ b/tests/config/test_common.py
@@ -309,3 +309,18 @@ def test_config_exception_during_load_config_msg(tmp_path):
     with pytest.raises(CycloptsError) as e:
         _ = dummy_error_config.config
     assert str(e.value) == "ValueError: My exception's message."
+
+
+class DummyEmptyDocument(ConfigFromFile):
+    def _load_config(self, path: Path) -> dict[str, Any]:
+        return None  # pyright: ignore[reportReturnType]
+
+
+def test_config_common_empty_document_is_empty_mapping(tmp_path):
+    """A file whose document is empty loads as an empty config, on every access."""
+    path = tmp_path / "config"
+    path.touch()
+    config = DummyEmptyDocument(path)
+
+    assert config.config == {}  # freshly loaded
+    assert config.config == {}  # served from the cache

--- a/tests/config/test_dict.py
+++ b/tests/config/test_dict.py
@@ -1048,3 +1048,35 @@ def test_config_dict_with_negative_numbers():
 
     result = app([])
     assert result == "offset=-10, temperature=-5.5"
+
+
+def test_config_dict_root_non_mapping_node():
+    """A non-mapping document root raises a clean CycloptsError, not AttributeError."""
+    from cyclopts import CycloptsError
+
+    app = App(config=Dict([1, 2], source="dict"), result_action="return_value")  # pyright: ignore[reportArgumentType]
+
+    @app.default
+    def main(x: int = 0):
+        return x
+
+    with pytest.raises(CycloptsError) as e:
+        app([], exit_on_error=False)
+
+    assert str(e.value) == 'Configuration in "dict" must be a mapping, but got list.'
+
+
+def test_config_dict_root_non_mapping_node_with_root_keys():
+    """A non-mapping document root is reported before ``root_keys`` are descended."""
+    from cyclopts import CycloptsError
+
+    app = App(config=Dict(5, root_keys=("tool",), source="dict"), result_action="return_value")  # pyright: ignore[reportArgumentType]
+
+    @app.default
+    def main(x: int = 0):
+        return x
+
+    with pytest.raises(CycloptsError) as e:
+        app([], exit_on_error=False)
+
+    assert str(e.value) == 'Configuration in "dict" must be a mapping, but got int.'

--- a/tests/config/test_yaml.py
+++ b/tests/config/test_yaml.py
@@ -1,5 +1,8 @@
 from textwrap import dedent
 
+import pytest
+
+from cyclopts import App, CycloptsError
 from cyclopts.config._yaml import Yaml
 
 
@@ -29,3 +32,38 @@ def test_config_yaml(tmp_path):
             },
         }
     }
+
+
+@pytest.mark.parametrize("contents", ["", "# only a comment\n"])
+def test_config_yaml_empty_document(tmp_path, contents):
+    """An empty (or comments-only) YAML file is an empty config, not a crash."""
+    fn = tmp_path / "test.yaml"
+    fn.write_text(contents)
+
+    config = Yaml(fn)
+    assert config.config == {}
+
+    app = App(config=config, result_action="return_value")
+
+    @app.default
+    def main(x: int = 7):
+        return x
+
+    assert app([], exit_on_error=False) == 7
+
+
+def test_config_yaml_non_mapping_document(tmp_path):
+    """A YAML document that is not a mapping raises a clean CycloptsError."""
+    fn = tmp_path / "test.yaml"
+    fn.write_text("- a\n- b\n")
+
+    app = App(config=Yaml(fn, source="test.yaml"), result_action="return_value")
+
+    @app.default
+    def main(x: int = 7):
+        return x
+
+    with pytest.raises(CycloptsError) as e:
+        app([], exit_on_error=False)
+
+    assert str(e.value) == 'Configuration in "test.yaml" must be a mapping, but got list.'


### PR DESCRIPTION
A `config.yaml` that is empty, or has everything commented out, kills the CLI:

```
$ myapp --x 5
Traceback (most recent call last):
  File "cyclopts/config/_common.py", line 56, in __call__
    config: dict[str, Any] = self.config.copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```

`safe_load` returns `None` for those documents, as does `json.load` for a file holding `null`. `Toml` returns `{}` for its empty file and keeps working.

Behind it, `ConfigFromFile.config` is annotated `-> dict[str, Any]` but returns `None` on first access and `{}` on the second: the cache-hit branch at line 155 has `or {}`, the fresh-load branch at line 170 does not.

A scalar or list root gives the raw error that #873 removed for child nodes:

```
Yaml("list.yaml")   ->  AttributeError: 'list' object has no attribute 'items'
Yaml("scalar.yaml") ->  AttributeError: 'int' object has no attribute 'copy'
```

#873 put the mapping check inside the descent loop, and line 56 runs before the loop starts, so the root is the one node it never sees. Its three tests use `Dict({...})`, whose root is a dict by construction.

Both changes are in `_common.py`: line 170 becomes `return self._config or {}`, matching its sibling fifteen lines above, and the mapping check moves into `_ensure_mapping()` so it also runs on the root. The message for descended keys is unchanged, so #873's tests match it as written.

Deliberate: `or {}` maps a `[]` root to `{}` rather than to an error, which is what line 155 has done since 2025-01.

Tests cover empty and comments-only YAML, a non-mapping YAML root, a non-mapping `Dict` root with and without `root_keys`, and the first-versus-second read of `config`. Reverting only the guard fails 3 of the 6, reverting only `or {}` fails the other 3. Full suite 2613 passed, `pre-commit run --all-files` clean.

Written with Claude Code.
