### PR TITLE
Add "sys_exit_if_non_zero_else_return" result action and document result_action modes

### DIFF
--- a/cyclopts/_result_action.py
+++ b/cyclopts/_result_action.py
@@ -16,6 +16,7 @@ ResultActionSingle = (
         "return_int_as_exit_code_else_zero",
         "print_non_int_sys_exit",
         "sys_exit",
+        "sys_exit_if_non_zero_else_return",
         "return_none",
         "return_zero",
         "print_return_zero",
@@ -116,6 +117,16 @@ def handle_result_action(
                 sys.exit(result)
             else:
                 sys.exit(resolve_returncode(result))
+        case "sys_exit_if_non_zero_else_return":
+            if isinstance(result, bool):
+                returncode = 0 if result else 1
+            elif isinstance(result, int):
+                returncode = result
+            else:
+                returncode = resolve_returncode(result)
+            if returncode == 0:
+                return returncode
+            sys.exit(returncode)
         case "print_non_int_return_int_as_exit_code":
             if isinstance(result, bool):
                 return 0 if result else 1

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -32,3 +32,36 @@
 .py.property {
     display: block !important;
 }
+
+/* Tighten the result_action reference table (issue #896). The RTD theme wraps
+   each code sample in a bordered box with a large 24px bottom margin, which
+   pools whitespace at the bottom of every row. Drop the box and the extra
+   margins so the code sits flush with the rest of the row. Scoped to this one
+   table via :class: result-action-modes so other code blocks are unaffected. */
+.rst-content table.result-action-modes td,
+.rst-content table.result-action-modes th {
+    padding: 6px 10px;
+    vertical-align: top;
+}
+.rst-content table.result-action-modes td p {
+    margin-bottom: 0;
+}
+.rst-content table.result-action-modes div[class^="highlight"],
+.rst-content table.result-action-modes div[class^="highlight"] pre {
+    /* The theme sets overflow-x:auto here; leaving overflow-y unset makes the
+       browser force it to auto too (CSS spec), which fires a spurious vertical
+       scrollbar on single-line cells from subpixel line-height rounding. Pin
+       overflow-y:hidden on BOTH the wrapper div and the pre so only horizontal
+       scrolling (for the odd long line) remains. */
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+.rst-content table.result-action-modes div[class^="highlight"] {
+    margin: 0;
+    border: none;
+    background: transparent;
+}
+.rst-content table.result-action-modes div[class^="highlight"] pre {
+    padding: 0;
+    background: transparent;
+}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -615,184 +615,165 @@ API
          app(backend="trio")  # Override the app's backend for this call
 
    .. attribute:: result_action
-      :type: Literal["return_value", "call_if_callable", "print_non_int_return_int_as_exit_code", "print_str_return_int_as_exit_code", "print_str_return_zero", "print_non_none_return_int_as_exit_code", "print_non_none_return_zero", "return_int_as_exit_code_else_zero", "print_non_int_sys_exit", "sys_exit", "return_none", "return_zero", "print_return_zero", "sys_exit_zero", "print_sys_exit_zero"] | Callable[[Any], Any] | Iterable[Literal[...] | Callable[[Any], Any]] | None
+      :type: Literal["return_value", "call_if_callable", "print_non_int_return_int_as_exit_code", "print_str_return_int_as_exit_code", "print_str_return_zero", "print_non_none_return_int_as_exit_code", "print_non_none_return_zero", "return_int_as_exit_code_else_zero", "print_non_int_sys_exit", "sys_exit", "sys_exit_if_non_zero_else_return", "return_none", "return_zero", "print_return_zero", "sys_exit_zero", "print_sys_exit_zero"] | Callable[[Any], Any] | Iterable[Literal[...] | Callable[[Any], Any]] | None
       :value: None
 
       Controls how :meth:`.App.__call__` and :meth:`.App.run_async` handle command return values. By default (``"print_non_int_sys_exit"``), the app will call :func:`sys.exit` with an appropriate exit code. This default was chosen for consistent functionality between standalone scripts, and console entrypoints.
 
       Can be a predefined literal string, a custom callable that takes the result and returns a processed value, or a **sequence of actions** to be applied left-to-right in a pipeline.
 
-      Each predefined mode's exact behavior is shown below:
+      Every predefined mode is listed below with its exact behavior. See :ref:`Result Action` for a higher-level overview and common gotchas.
 
-      **"print_non_int_sys_exit"** (default)
+      .. list-table::
+         :header-rows: 1
+         :widths: 28 32 40
+         :class: result-action-modes
 
-         The default CLI mode. Prints non-int values to stdout, then calls :func:`sys.exit` with the appropriate exit code.
+         * - ``result_action``
+           - Effect
+           - Equivalent code
+         * - ``"return_value"``
+           - ``app()`` returns the command's value unchanged. Best for embedding or testing.
+           - .. code-block:: python
 
-         .. code-block:: python
+                return result
+         * - ``"call_if_callable"``
+           - Calls the result if it's callable, otherwise returns it unchanged. Compose with another action; see :ref:`Dataclass Commands`.
+           - .. code-block:: python
 
-            if isinstance(result, bool):
-                sys.exit(0 if result else 1)  # i.e. True is success
-            elif isinstance(result, int):
-                sys.exit(result)
-            elif result is not None:
+                return (
+                    result()
+                    if callable(result)
+                    else result
+                )
+         * - ``"print_non_int_sys_exit"`` (**default**)
+           - Prints non-int results, then :func:`sys.exit` with the exit code.
+           - .. code-block:: python
+
+                if isinstance(result, bool):
+                    sys.exit(0 if result else 1)
+                elif isinstance(result, int):
+                    sys.exit(result)
+                elif result is not None:
+                    print(result)
+                    sys.exit(resolve_returncode(result))
+                else:
+                    sys.exit(resolve_returncode(result))
+         * - ``"sys_exit"``
+           - Never prints; :func:`sys.exit` with the exit code.
+           - .. code-block:: python
+
+                if isinstance(result, bool):
+                    sys.exit(0 if result else 1)
+                elif isinstance(result, int):
+                    sys.exit(result)
+                else:
+                    sys.exit(resolve_returncode(result))
+         * - ``"sys_exit_if_non_zero_else_return"``
+           - Returns the exit code on success (``0``); only calls :func:`sys.exit` when the exit code is non-zero.
+           - .. code-block:: python
+
+                if isinstance(result, bool):
+                    returncode = 0 if result else 1
+                elif isinstance(result, int):
+                    returncode = result
+                else:
+                    returncode = resolve_returncode(result)
+                if returncode == 0:
+                    return returncode
+                sys.exit(returncode)
+         * - ``"return_int_as_exit_code_else_zero"``
+           - Never prints; returns int/bool as the exit code, else ``0``.
+           - .. code-block:: python
+
+                if isinstance(result, bool):
+                    return 0 if result else 1
+                elif isinstance(result, int):
+                    return result
+                else:
+                    return resolve_returncode(result)
+         * - ``"print_non_int_return_int_as_exit_code"``
+           - Prints non-int results; returns int/bool as the exit code, else ``0``.
+           - .. code-block:: python
+
+                if isinstance(result, bool):
+                    return 0 if result else 1
+                elif isinstance(result, int):
+                    return result
+                elif result is not None:
+                    print(result)
+                    return resolve_returncode(result)
+                else:
+                    return resolve_returncode(result)
+         * - ``"print_str_return_int_as_exit_code"``
+           - Prints only ``str`` results; returns int/bool as the exit code, else ``0``.
+           - .. code-block:: python
+
+                if isinstance(result, str):
+                    print(result)
+                    return resolve_returncode(result)
+                elif isinstance(result, bool):
+                    return 0 if result else 1
+                elif isinstance(result, int):
+                    return result
+                else:
+                    return resolve_returncode(result)
+         * - ``"print_non_none_return_int_as_exit_code"``
+           - Prints all non-``None`` results; returns int/bool as the exit code, else ``0``.
+           - .. code-block:: python
+
+                if result is not None:
+                    print(result)
+                if isinstance(result, bool):
+                    return 0 if result else 1
+                elif isinstance(result, int):
+                    return result
+                return resolve_returncode(result)
+         * - ``"print_str_return_zero"``
+           - Prints only ``str`` results; always returns ``0``.
+           - .. code-block:: python
+
+                if isinstance(result, str):
+                    print(result)
+                return resolve_returncode(result)
+         * - ``"print_non_none_return_zero"``
+           - Prints all non-``None`` results; always returns ``0``.
+           - .. code-block:: python
+
+                if result is not None:
+                    print(result)
+                return resolve_returncode(result)
+         * - ``"print_return_zero"``
+           - Prints the result (even ``None``); always returns ``0``.
+           - .. code-block:: python
+
+                print(result)
+                return resolve_returncode(result)
+         * - ``"return_zero"``
+           - Never prints; always returns ``0``.
+           - .. code-block:: python
+
+                return resolve_returncode(result)
+         * - ``"return_none"``
+           - Never prints; always returns ``None``.
+           - .. code-block:: python
+
+                return None
+         * - ``"sys_exit_zero"``
+           - Never prints; always :func:`sys.exit(0) <sys.exit>`.
+           - .. code-block:: python
+
+                sys.exit(resolve_returncode(result))
+         * - ``"print_sys_exit_zero"``
+           - Prints the result (even ``None``); always :func:`sys.exit(0) <sys.exit>`.
+           - .. code-block:: python
+
                 print(result)
                 sys.exit(resolve_returncode(result))
-            else:
-                sys.exit(resolve_returncode(result))
 
-         See :ref:`Custom Return Code Protocol <custom-return-code-protocol>` for :func:`~cyclopts.resolve_returncode`.
+      .. note::
 
-      **"return_value"**
-
-         Returns the command's value unchanged. Use for embedding Cyclopts in other Python code or testing.
-
-         .. code-block:: python
-
-            return result
-
-      **"call_if_callable"**
-
-         Calls the result if it's callable (with no arguments), otherwise returns it unchanged. Useful for the dataclass command pattern where commands return class instances with ``__call__`` methods. Intended to be used in composition with other result actions (e.g., ``["call_if_callable", "print_non_int_sys_exit"]``).
-
-         .. code-block:: python
-
-            return result() if callable(result) else result
-
-         See :ref:`Dataclass Commands` for usage examples.
-
-      **"sys_exit"**
-
-         Never prints output. Calls :func:`sys.exit` with the appropriate exit code. Useful for CLI apps that handle their own output and just need exit code handling.
-
-         .. code-block:: python
-
-            if isinstance(result, bool):
-                sys.exit(0 if result else 1)  # i.e. True is success
-            elif isinstance(result, int):
-                sys.exit(result)
-            else:
-                sys.exit(resolve_returncode(result))
-
-      **"print_non_int_return_int_as_exit_code"**
-
-         Prints non-int values, returns int/bool as exit codes. Useful for testing and embedding.
-
-         .. code-block:: python
-
-            if isinstance(result, bool):
-                return 0 if result else 1  # i.e. True is success
-            elif isinstance(result, int):
-                return result
-            elif result is not None:
-                print(result)
-                return resolve_returncode(result)
-            else:
-                return resolve_returncode(result)
-
-      **"print_str_return_int_as_exit_code"**
-
-         Only prints string return values. Returns int/bool as exit codes, silently returns 0 for other types.
-
-         .. code-block:: python
-
-            if isinstance(result, str):
-                print(result)
-                return resolve_returncode(result)
-            elif isinstance(result, bool):
-                return 0 if result else 1  # i.e. True is success
-            elif isinstance(result, int):
-                return result
-            else:
-                return resolve_returncode(result)
-
-      **"print_str_return_zero"**
-
-         Only prints string return values, always returns 0. Useful for simple output-only CLIs.
-
-         .. code-block:: python
-
-            if isinstance(result, str):
-                print(result)
-            return resolve_returncode(result)
-
-      **"print_non_none_return_int_as_exit_code"**
-
-         Prints all non-None values (including ints), returns int/bool as exit codes.
-
-         .. code-block:: python
-
-            if result is not None:
-                print(result)
-            if isinstance(result, bool):
-                return 0 if result else 1  # i.e. True is success
-            elif isinstance(result, int):
-                return result
-            return resolve_returncode(result)
-
-      **"print_non_none_return_zero"**
-
-         Prints all non-None values (including ints), always returns 0.
-
-         .. code-block:: python
-
-            if result is not None:
-                print(result)
-            return resolve_returncode(result)
-
-      **"return_int_as_exit_code_else_zero"**
-
-         Never prints output. Returns int/bool as exit codes, 0 for all other types. Useful for silent CLIs.
-
-         .. code-block:: python
-
-            if isinstance(result, bool):
-                return 0 if result else 1  # i.e. True is success
-            elif isinstance(result, int):
-                return result
-            else:
-                return resolve_returncode(result)
-
-      **"return_none"**
-
-         Always returns None, regardless of the command's return value.
-
-         .. code-block:: python
-
-            return None
-
-      **"return_zero"**
-
-         Always returns 0, regardless of the command's return value.
-
-         .. code-block:: python
-
-            return resolve_returncode(result)
-
-      **"print_return_zero"**
-
-         Always prints the result (even None), then always returns 0.
-
-         .. code-block:: python
-
-            print(result)
-            return resolve_returncode(result)
-
-      **"sys_exit_zero"**
-
-         Always calls :func:`sys.exit(0) <sys.exit>`, regardless of the command's return value.
-
-         .. code-block:: python
-
-            sys.exit(resolve_returncode(result))
-
-      **"print_sys_exit_zero"**
-
-         Always prints the result (even None), then calls :func:`sys.exit(0) <sys.exit>`.
-
-         .. code-block:: python
-
-            print(result)
-            sys.exit(resolve_returncode(result))
+         ``bool`` results are treated as exit codes: :obj:`True` → ``0`` (success), :obj:`False` → ``1``. Where the table above says "``0``", the value is actually :func:`~cyclopts.resolve_returncode` of the result, which is ``0`` unless the result defines a :ref:`__cyclopts_returncode__ <custom-return-code-protocol>` method.
 
       **Custom Callable**
 

--- a/docs/source/packaging.rst
+++ b/docs/source/packaging.rst
@@ -112,7 +112,39 @@ When using Cyclopts as a CLI application, command return values are automaticall
 - Boolean returns are converted: :obj:`True` → :func:`sys.exit(0) <sys.exit>`, :obj:`False` → :func:`sys.exit(1) <sys.exit>`
 - :obj:`None` returns call :func:`sys.exit(0) <sys.exit>`
 
-This default behavior makes Cyclopts applications work consistently whether run directly as scripts or installed via `console_scripts entry points <https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts>`_. The :attr:`~cyclopts.App.result_action` can be customized if different behavior is needed:
+This default behavior makes Cyclopts applications work consistently whether run directly as scripts or installed via `console_scripts entry points <https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts>`_.
+
+Broadly, each mode does two things with the command's return value: it optionally **prints** the value, and it either **returns** it from ``app()`` or passes it to :func:`sys.exit` as an exit code. The mode you pick decides which of those happen and when. Cyclopts ships a mode for many common combinations; see :attr:`.App.result_action` in the API reference.
+
+^^^^^^^^^^^^^^^
+Common Gotchas
+^^^^^^^^^^^^^^^
+
+**sys_exit modes raise SystemExit even on success.** If your ``result_action`` calls :func:`sys.exit` (including the default ``"print_non_int_sys_exit"``), then invoking ``app()`` raises :exc:`SystemExit` *even when the command succeeds*:
+
+.. code-block:: python
+
+   # Raises SystemExit even on success:
+   def test_my_app():
+       app("foo")  # <-- crashes with SystemExit
+
+Catch it with ``pytest.raises(SystemExit)``, or configure a non-exiting mode such as ``result_action="return_value"`` (see :meth:`.App.__call__` to override ``result_action`` per-invocation).
+
+**return\_ modes drop the exit code unless you pass it to sys.exit.** If your ``result_action`` is in the ``return_`` family, ``app()`` returns the exit code rather than exiting, so your entrypoint must forward it to :func:`sys.exit`. Otherwise the process always exits ``0`` regardless of what the command returned:
+
+.. code-block:: python
+
+   app = App(result_action="return_value")
+
+   # Loses the exit code -- process always exits 0:
+   if __name__ == "__main__":
+       app()
+
+   # Propagates the exit code:
+   if __name__ == "__main__":
+       sys.exit(app())
+
+If you'd rather not write ``sys.exit(app())`` but still want a failing exit code to propagate, use ``result_action="sys_exit_if_non_zero_else_return"`` instead.
 
 
 .. _custom-return-code-protocol:

--- a/tests/test_result_action.py
+++ b/tests/test_result_action.py
@@ -674,6 +674,131 @@ def test_result_action_sys_exit_with_none(monkeypatch):
 
 
 # ==============================================================================
+# sys_exit_if_non_zero_else_return tests
+# ==============================================================================
+
+
+def test_result_action_sys_exit_if_non_zero_else_return_with_zero():
+    """sys_exit_if_non_zero_else_return: returns 0 without exiting on success."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def succeed() -> int:
+        return 0
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["succeed"])
+
+    assert result == 0
+    assert buf.getvalue() == ""
+
+
+def test_result_action_sys_exit_if_non_zero_else_return_with_none():
+    """sys_exit_if_non_zero_else_return: None resolves to 0 and returns without exiting."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def do_nothing() -> None:
+        pass
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        result = app(["do-nothing"])
+
+    assert result == 0
+    assert buf.getvalue() == ""
+
+
+def test_result_action_sys_exit_if_non_zero_else_return_with_true():
+    """sys_exit_if_non_zero_else_return: True is success (0), returns without exiting."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def check() -> bool:
+        return True
+
+    result = app(["check"])
+    assert result == 0
+
+
+def test_result_action_sys_exit_if_non_zero_else_return_with_nonzero(monkeypatch):
+    """sys_exit_if_non_zero_else_return: non-zero int calls sys.exit."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def fail(code: int) -> int:
+        return code
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        app(["fail", "3"])
+
+    assert exit_code == 3
+    assert buf.getvalue() == ""
+
+
+def test_result_action_sys_exit_if_non_zero_else_return_with_false(monkeypatch):
+    """sys_exit_if_non_zero_else_return: False is failure (1), calls sys.exit(1)."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def check() -> bool:
+        return False
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    app(["check"])
+    assert exit_code == 1
+
+
+def test_cyclopts_returncode_sys_exit_if_non_zero_else_return(monkeypatch):
+    """sys_exit_if_non_zero_else_return honors __cyclopts_returncode__ for non-int results."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=7)
+
+    exit_code = None
+
+    def mock_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    monkeypatch.setattr("sys.exit", mock_exit)
+
+    app(["run"])
+    assert exit_code == 7
+
+
+def test_cyclopts_returncode_sys_exit_if_non_zero_else_return_zero():
+    """sys_exit_if_non_zero_else_return returns without exiting when resolved code is 0."""
+    app = App(result_action="sys_exit_if_non_zero_else_return")
+
+    @app.command
+    def run() -> _CustomResult:
+        return _CustomResult(returncode=0)
+
+    result = app(["run"])
+    assert result == 0
+
+
+# ==============================================================================
 # Default and inheritance tests
 # ==============================================================================
 


### PR DESCRIPTION
Addresses the discussion in #896.

Two things here:

**New `result_action` mode: `sys_exit_if_non_zero_else_return`.** Returns the exit code on success (`0`), so `app()` stays test-friendly and doesn't raise `SystemExit`, but calls `sys.exit()` when the code is non-zero so a failing exit code still propagates without wrapping the entrypoint in `sys.exit(app())`. This is the "best of both worlds" requested in the issue. Honors `__cyclopts_returncode__` for non-int results like the rest of the family.

**Docs.** The issue author couldn't find the exhaustive list of modes and got bitten by two `result_action` traps, so:

- `api.rst`: replaced the long per-mode prose breakdown with a single scannable table (`result_action` | Effect | equivalent code) covering every predefined mode, including the new one, plus a note on the bool/`resolve_returncode` nuance.
- `packaging.rst`: expanded the "Result Action" section into a higher-level overview that links to the API reference, and added a "Common Gotchas" subsection covering the two traps: `sys_exit` modes raise `SystemExit` even on success (unit testing), and `return_` modes drop the exit code unless forwarded to `sys.exit`.
- `custom.css`: small scoped CSS to tighten the new table (drops the theme's code-block border/margin and a spurious single-line scrollbar).

Added 7 tests for the new mode; the full `result_action` suite is green and the docs build clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
