### PR TITLE
register field-name CLI options when `validate_by_name` is set

### DIFF
--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -171,17 +171,31 @@ def _pydantic_field_infos(model) -> dict[str, FieldInfo]:
     for python_name, pydantic_field in model.model_fields.items():
         names = []
         if pydantic_field.alias:
-            if model.model_config.get("validate_by_name", False) or model.model_config.get("populate_by_name", False):
-                names.append(python_name)
-            names.append(pydantic_field.alias)
+            # Register a CLI name only if the model would actually accept it during
+            # validation (cyclopts builds the model via TypeAdapter.validate_python).
+            #   * validate_by_name  -> field names are accepted.
+            #   * validate_by_alias -> aliases are accepted (defaults to True).
+            # populate_by_name is the pre-2.11 spelling of validate_by_name; it is not
+            # recommended in pydantic 2.11+ and is slated for removal in pydantic v3, so
+            # we honor both across the supported pydantic range. pydantic forbids both
+            # validate_by_* being False, so at least one name is always registered.
+            validate_by_name = model.model_config.get("validate_by_name", False) or model.model_config.get(
+                "populate_by_name", False
+            )
+            validate_by_alias = model.model_config.get("validate_by_alias", True)
 
-            # Add legacy-compatible CLI form if not already present.
-            # This allows both "user-name" (new) and "username" (legacy) to work as CLI options.
-            # Old transform behavior: alias.lower() (no pascal_to_snake)
-            # New transform behavior: _pascal_to_snake(alias).lower()
-            legacy_form = pydantic_field.alias.lower()
-            if legacy_form not in names:
-                names.append(legacy_form)
+            if validate_by_name:
+                names.append(python_name)
+            if validate_by_alias:
+                names.append(pydantic_field.alias)
+
+                # Add legacy-compatible CLI form if not already present.
+                # This allows both "user-name" (new) and "username" (legacy) to work as CLI options.
+                # Old transform behavior: alias.lower() (no pascal_to_snake)
+                # New transform behavior: _pascal_to_snake(alias).lower()
+                legacy_form = pydantic_field.alias.lower()
+                if legacy_form not in names:
+                    names.append(legacy_form)
         else:
             names.append(python_name)
 

--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -171,7 +171,7 @@ def _pydantic_field_infos(model) -> dict[str, FieldInfo]:
     for python_name, pydantic_field in model.model_fields.items():
         names = []
         if pydantic_field.alias:
-            if model.model_config.get("populate_by_name", False):
+            if model.model_config.get("validate_by_name", False) or model.model_config.get("populate_by_name", False):
                 names.append(python_name)
             names.append(pydantic_field.alias)
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -261,6 +261,33 @@ def test_pydantic_alias_1(app, console, assert_parse_args):
     )
 
 
+def test_pydantic_validate_by_name(app, assert_parse_args):
+    """Field-name CLI options are registered when ``validate_by_name`` is set.
+
+    https://github.com/BrianPugh/cyclopts/issues/908
+
+    pydantic 2.11 split ``validate_by_name`` out of ``populate_by_name``. A model
+    that configures ``validate_by_name=True`` accepts its field names during
+    validation, so cyclopts must register the field-name CLI option even though
+    ``populate_by_name`` is unset.
+    """
+
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_name=True)
+
+        full_name: str = Field(alias="userName")
+
+    @app.default
+    def main(model: Model):
+        pass
+
+    # The field name (the thing ``validate_by_name=True`` opts into).
+    assert_parse_args(main, "--model.full_name Alice", model=Model(userName="Alice"))
+
+    # The alias continues to work.
+    assert_parse_args(main, "--model.user-name Alice", model=Model(userName="Alice"))
+
+
 @pytest.mark.parametrize(
     "env_var",
     [

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, SecretBytes, Sec
 from pydantic import ValidationError as PydanticValidationError
 from pydantic.alias_generators import to_camel
 
-from cyclopts import MissingArgumentError, Parameter, ValidationError
+from cyclopts import MissingArgumentError, Parameter, UnknownOptionError, ValidationError
 
 
 # Modified from https://docs.pydantic.dev/latest/#pydantic-examples
@@ -286,6 +286,34 @@ def test_pydantic_validate_by_name(app, assert_parse_args):
 
     # The alias continues to work.
     assert_parse_args(main, "--model.user-name Alice", model=Model(userName="Alice"))
+
+
+def test_pydantic_validate_by_alias_false(app, assert_parse_args):
+    """When ``validate_by_alias=False``, the alias is not registered as a CLI option.
+
+    https://github.com/BrianPugh/cyclopts/issues/908
+
+    ``validate_by_alias=False`` tells pydantic to reject the alias during validation
+    (it implies ``validate_by_name=True``), so only the field-name CLI option should
+    be registered; the alias form must not silently parse into a value the model then
+    rejects.
+    """
+
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False)
+
+        full_name: str = Field(alias="userName")
+
+    @app.default
+    def main(model: Model):
+        pass
+
+    # The field name is accepted.
+    assert_parse_args(main, "--model.full_name Alice", model=Model.model_validate({"full_name": "Alice"}))
+
+    # The alias is not registered, since the model would reject it during validation.
+    with pytest.raises(UnknownOptionError):
+        app.parse_args("--model.user-name Alice", exit_on_error=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #908

## Summary

`_pydantic_field_infos` decides whether an aliased pydantic field's Python name is
registered as an acceptable CLI option by reading only
`model_config.get("populate_by_name")`. Since pydantic 2.11 split
`validate_by_name` out of that semantic, models that configure
`validate_by_name=True` (field names accepted during validation) get their
field-name CLI options rejected as "Unknown option" — while the model itself
accepts those names.

This mirrors the same bug in polyfactory, fixed upstream by reading both flags.

## Changes

- `cyclopts/field_info.py` (in `_pydantic_field_infos`):

  ```python
  - if model.model_config.get("populate_by_name", False):
  + if model.model_config.get("validate_by_name", False) or model.model_config.get("populate_by_name", False):
  ```

  No other name-registration path is touched.

## Testing

Verified with cyclopts 4.23.3 + pydantic 2.11.10:

- Model with `ConfigDict(validate_by_name=True)`, field `full_name: str = Field(alias="userName")`:
  - Before: `--model.full_name` → `Unknown option: --model.full_name. Did you mean --model.username?` (SystemExit 1).
  - After: `--model.full_name Alice` parses correctly.
  - Alias forms `--model.user-name` / `--model.username` continue to work in both cases.
- Model with `populate_by_name=True` (only): behavior unchanged.