### PR TITLE
docs: refresh Typer comparison pages against Typer 0.27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [the docs](https://cyclopts.readthedocs.io) for more advanced usage.
 
 # Compared to Typer
 Cyclopts is what you thought Typer was.
-Cyclopts's includes information from docstrings, support more complex types (even Unions and Literals!), and include proper validation support.
+Cyclopts includes information from docstrings, supports more complex types (even Unions!), and includes proper validation support.
 See [the documentation for a complete Typer comparison](https://cyclopts.readthedocs.io/en/latest/vs_typer/README.html).
 
 Consider the following short 29-line Cyclopts application:
@@ -167,20 +167,14 @@ $ my-script --version
 0.0.0
 ```
 
-In its current state, this application would be impossible to implement in Typer.
-However, lets see how close we can get with Typer (47-lines):
+In its current state, this application would be impossible to implement in Typer; Typer does not support the union type-hint of `replicas`.
+However, let's see how close we can get with Typer (41-lines):
 
 ```python
 import typer
 from typing import Annotated, Literal
-from enum import Enum
 
 app = typer.Typer()
-
-class Environment(str, Enum):
-    dev = "dev"
-    staging = "staging"
-    prod = "prod"
 
 def replica_parser(value: str):
     if value == "default":
@@ -205,7 +199,7 @@ def callback(
 
 @app.command(help="Deploy code to an environment.")
 def deploy(
-    env: Annotated[Environment, typer.Argument(help="Environment to deploy to.")],
+    env: Annotated[Literal["dev", "staging", "prod"], typer.Argument(help="Environment to deploy to.")],
     replicas: Annotated[
         int,
         typer.Argument(
@@ -214,7 +208,7 @@ def deploy(
         ),
     ] = replica_parser("default"),
 ):
-    print(f"Deploying to {env.name} with {replicas} replicas.")
+    print(f"Deploying to {env} with {replicas} replicas.")
 
 if __name__ == "__main__":
     app()
@@ -223,13 +217,13 @@ if __name__ == "__main__":
 ```console
 $ my-script deploy --help
 
-Usage: my-script deploy [OPTIONS] ENV:{dev|staging|prod} [REPLICAS]
+ Usage: my-script deploy [OPTIONS] {env}:<dev|staging|prod> [replicas]
 
  Deploy code to an environment.
 
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────╮
-│ *    env           ENV:{dev|staging|prod}  Environment to deploy to. [default: None] [required] │
-│      replicas      [REPLICAS]              Number of workers to spin up. [default: 10]          │
+│ *    env           <dev|staging|prod>  Environment to deploy to. [required]                     │
+│      replicas      <replica_parser>    Number of workers to spin up. [default: 10]              │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                                     │
@@ -245,19 +239,19 @@ $ my-script deploy staging performance
 Deploying to staging with 20 replicas.
 
 $ my-script deploy nonexistent-env
-Usage: my-script.py deploy [OPTIONS] ENV:{dev|staging|prod} [REPLICAS]
-Try 'my-script.py deploy --help' for help.
+Usage: my-script deploy [OPTIONS] {env}:<dev|staging|prod> [replicas]
+Try 'my-script deploy --help' for help.
 ╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────╮
-│ Invalid value for '[REPLICAS]': nonexistent-env                                                 │
+│ Invalid value for 'env': 'nonexistent-env' is not one of 'dev', 'staging', 'prod'.              │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 $ my-script --version
 0.0.0
 ```
 
-The Typer implementation is 47 lines long, while the Cyclopts implementation is just 29 (38% shorter!).
+The Typer implementation is 41 lines long, while the Cyclopts implementation is just 29 (29% shorter!).
 Not only is the Cyclopts implementation significantly shorter, but the code is easier to read.
-Since Typer does not support Unions, the choices for ``replica`` could not be displayed on the help page.
+Since Typer does not support Unions, the choices for ``replicas`` could not be displayed on the help page.
 Cyclopts is much more terse, much more readable, and much more intuitive to use.
 
 # Contributing

--- a/docs/source/vs_typer/choices/README.rst
+++ b/docs/source/vs_typer/choices/README.rst
@@ -23,7 +23,7 @@ With Typer, this is accomplished via declaring an :class:`~enum.Enum`.
 
    typer_app = typer.Typer()
 
-   @typer_app.command
+   @typer_app.command()
    def foo(env: Environment = Environment.DEV):
        print(f"Using: {env.name}")
 

--- a/docs/source/vs_typer/docstring/README.rst
+++ b/docs/source/vs_typer/docstring/README.rst
@@ -41,15 +41,18 @@ Consider the following Typer program:
 
    $ my-script foo --help
    Foo Docstring.
-   Parameters ---------- bar: str     Bar parameter docstring.
+
+   Parameters
+   ----------
+   bar: str
+       Bar parameter docstring.
 
    ╭─ Arguments ───────────────────────────────────────────────────────────╮
-   │ *    bar      TEXT  [default: None] [required]                        │
+   │ *    bar      <str>  [required]                                       │
    ╰───────────────────────────────────────────────────────────────────────╯
 
 The ``foo`` command's short description was properly parsed from the docstring.
-However, it mangles the Numpy-style docstring (or any docstring format for that matter) and doesn't correctly display ``bar``'s help.
-Typer just displays the entire docstring.
+However, the entire docstring (``Parameters`` section and all) is dumped into the command's long description, and ``bar``'s help is not displayed.
 
 To achieve the desired result with Typer, we have to explicitly annotate the parameter ``bar``:
 

--- a/docs/source/vs_typer/docstring/main.py
+++ b/docs/source/vs_typer/docstring/main.py
@@ -32,13 +32,18 @@ typer_app(["--help"], standalone_mode=False)
 # ╰────────────────────────────────────────────────────────────────╯
 
 
-# However, it fails at parsing the rest of the docstring.
+# However, it dumps the entire docstring into the long description
+# instead of parsing out the parameter help.
 typer_app(["foo", "--help"], standalone_mode=False)
 # Foo Docstring.
-#  Parameters ---------- bar: str     Bar parameter docstring.
+#
+# Parameters
+# ----------
+# bar: str
+#     Bar parameter docstring.
 #
 # ╭─ Arguments ────────────────────────────────────────────────────╮
-# │ *    bar      TEXT  [default: None] [required]                 │
+# │ *    bar      <str>  [required]                                │
 # ╰────────────────────────────────────────────────────────────────╯
 
 cyclopts_app = cyclopts.App()

--- a/docs/source/vs_typer/documentation/README.rst
+++ b/docs/source/vs_typer/documentation/README.rst
@@ -8,4 +8,7 @@ Typer's documentation contains many good tutorials and demonstrations on how to 
 Frequently the only way to discover options and behavior is to dive into the source code.
 This becomes further confusing as the lines of where Typer ends and Click begins is quite blurred.
 
+.. note::
+   Typer added an `API reference section <https://typer.tiangolo.com/reference/>`_ to its documentation in February 2026.
+
 Cyclopts has a full :ref:`API` page, containing all the configurable options and defined behaviors in a single place.

--- a/docs/source/vs_typer/validation/README.rst
+++ b/docs/source/vs_typer/validation/README.rst
@@ -17,6 +17,7 @@ Typer has builtin argument validation for certain type annotations.
 This works for a select few builtins, but the Typer solution doesn't abstract out validation properly.
 Why does the generic ``typer.Argument`` have fields that only have meaning if the annotated type is a number?
 The ``typer.Argument`` signature has a ridiculous number of fields that only apply for certain types.
+The signature below is from Typer v0.9.0; later versions have only grown it further (35 parameters as of v0.27).
 
 .. code-block:: python
 
@@ -76,7 +77,7 @@ Cyclopts has an explicit :attr:`~.Parameter.validator` field that accepts a func
 
 .. code-block:: python
 
-   from cyclopts import App, parameter
+   from cyclopts import App, Parameter
    from typing import Annotated
 
    cyclopts_app = App()
@@ -89,7 +90,7 @@ Cyclopts has an explicit :attr:`~.Parameter.validator` field that accepts a func
    def foo(age: Annotated[int, Parameter(validator=age_validator)]):
        pass
 
-    cyclopts_app()
+   cyclopts_app()
 
 This solution is similar to how other libraries, like Attrs_ or Pydantic_, perform validation.
 


### PR DESCRIPTION
## Refresh Typer comparison docs against Typer 0.27.1

Re-verified every `vs_typer` qualm against the latest Typer (0.27.1, Aug 2026). Most claims still hold verbatim (union support, positional-or-keyword, single-command quirk, docstring parameter parsing, etc.) — this PR only updates what drifted.

- `documentation`: note that Typer added an API reference section in February 2026.
- `docstring`: refresh the Typer help output — current Typer no longer mangles the docstring onto one line, shows `<str>` instead of `TEXT`, and no longer prints `[default: None]` for required args. The core qualm (whole docstring dumped, no parameter help) is unchanged.
- `validation`: label the inlined `typer.Argument` signature as v0.9-era (it has since grown to 35 parameters); fix `parameter`→`Parameter` import typo and an indentation error.
- `choices`: add missing `()` on `@typer_app.command` in the prose snippet.
- Delete `argument_vs_option/main.py` — an empty, unreferenced stray file.
- `README.md`: modernize the Typer counter-example — Typer supports `Literal` since 0.19.0, so the Enum class goes away (47 → 41 lines, "38% shorter" → "29% shorter") and the help/error output is re-captured from 0.27.1. The union type-hint is still unsupported, so the "impossible to implement in Typer" claim stands and now says why.

Left alone deliberately: the top-level "built on Click" framing (Click is vendored since Typer 0.26.0, but the parser and its quirks are still Click's) and `keyword_multiple_values` (still impossible; Click issue link still explains the root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
