### PR TITLE
feat(sphinx): add :anchor-prefix:/:anchor-suffix: to namespace ref labels

### DIFF
--- a/cyclopts/docs/rst.py
+++ b/cyclopts/docs/rst.py
@@ -263,14 +263,16 @@ def generate_rst_docs(
         title = base_title
 
     # Generate RST anchor/label with improved namespacing (RST uses a
-    # "cyclopts-" prefix for namespacing). Skip the anchor for a title-less root
-    # (e.g. the Sphinx ``.. cyclopts::`` directive, which always sets
-    # ``no_root_title``): a title-less root has nothing to reference, and its
+    # "cyclopts-" prefix for namespacing). Skip the anchor for an *unqualified*
+    # title-less root (e.g. the Sphinx ``.. cyclopts::`` directive, which always
+    # sets ``no_root_title``): a title-less root has nothing to reference, and its
     # bare ``cyclopts-<app>`` label is identical across every page documenting
     # the same app, producing "duplicate label" warnings that make the sections
-    # unreferenceable. Subcommand anchors (which have command_chain) are unique
-    # per command and are always emitted.
-    if not (no_root_title and not command_chain):
+    # unreferenceable. An ``anchor_prefix``/``anchor_suffix`` disambiguates that
+    # label, so it opts the root anchor back in. Subcommand anchors (which have
+    # command_chain) are unique per command and are always emitted.
+    unqualified_root = no_root_title and not command_chain and not anchor_prefix and not anchor_suffix
+    if not unqualified_root:
         # ``anchor_prefix`` sits outside the ``cyclopts-`` namespace (a page/section
         # namespace); ``anchor_suffix`` trails the command path (a per-page variant
         # qualifier). Both let the same command be documented by multiple directives

--- a/cyclopts/docs/rst.py
+++ b/cyclopts/docs/rst.py
@@ -171,6 +171,8 @@ def generate_rst_docs(
     code_block_title: bool = False,
     skip_preamble: bool = False,
     usage_name: str | None = None,
+    anchor_prefix: str = "",
+    anchor_suffix: str = "",
 ) -> str:
     """Generate reStructuredText documentation for a CLI application.
 
@@ -221,6 +223,17 @@ def generate_rst_docs(
         Optional replacement for the root app name used in ``Usage:`` lines
         only. Section headings, anchors, and TOC continue to use ``app.name[0]``.
         Default is None.
+    anchor_prefix : str
+        Optional token prepended to every generated anchor/label (outside the
+        ``cyclopts-`` namespace, e.g. ``<prefix>-cyclopts-<app>-<command>``).
+        Use it to namespace a whole directive by page or section so the same
+        command documented on multiple pages keeps distinct, referenceable
+        ``:ref:`` targets. Default is ``""`` (no prefix).
+    anchor_suffix : str
+        Optional token appended to every generated anchor/label (e.g.
+        ``cyclopts-<app>-<command>-<suffix>``). Use it to distinguish multiple
+        renderings of the same command on a single page. Default is ``""`` (no
+        suffix).
 
     Returns
     -------
@@ -258,12 +271,23 @@ def generate_rst_docs(
     # unreferenceable. Subcommand anchors (which have command_chain) are unique
     # per command and are always emitted.
     if not (no_root_title and not command_chain):
-        anchor_parts = ["cyclopts"]
+        # ``anchor_prefix`` sits outside the ``cyclopts-`` namespace (a page/section
+        # namespace); ``anchor_suffix`` trails the command path (a per-page variant
+        # qualifier). Both let the same command be documented by multiple directives
+        # while keeping distinct, referenceable ``:ref:`` targets.
+        anchor_parts = []
+        if anchor_prefix:
+            anchor_parts.append(anchor_prefix)
+        anchor_parts.append("cyclopts")
         if command_chain:
             anchor_parts.extend(command_chain)
         else:
             anchor_parts.append(app_name)
-        # Use shared anchor generation logic, then add RST-specific slash replacement
+        if anchor_suffix:
+            anchor_parts.append(anchor_suffix)
+        # generate_anchor() slugifies a space-joined command path into hyphens
+        # (the same contract used for markdown/HTML anchors); the join spaces never
+        # survive into the anchor. Then apply RST-specific slash replacement.
         anchor_name = generate_anchor(" ".join(anchor_parts)).replace("/", "-")
         lines.append(f".. _{anchor_name}:")
         lines.append("")
@@ -479,6 +503,8 @@ def generate_rst_docs(
                     code_block_title=code_block_title,
                     skip_preamble=is_single_target or is_intermediate_path,  # Skip preamble for target or intermediate
                     usage_name=usage_name,
+                    anchor_prefix=anchor_prefix,
+                    anchor_suffix=anchor_suffix,
                 )
             lines.append(subdocs)
 

--- a/cyclopts/ext/sphinx.py
+++ b/cyclopts/ext/sphinx.py
@@ -27,6 +27,8 @@ class DirectiveOptions:
     commands: list[str] | None = None
     exclude_commands: list[str] | None = None
     usage_name: str | None = None
+    anchor_prefix: str = ""
+    anchor_suffix: str = ""
 
     # All booleans must have ``False`` default.
     no_recursive: bool = False
@@ -360,6 +362,8 @@ class CycloptsDirective(SphinxDirective):  # type: ignore[misc,valid-type]
             code_block_title=opts.code_block_title,
             skip_preamble=opts.skip_preamble,
             usage_name=opts.usage_name,
+            anchor_prefix=opts.anchor_prefix,
+            anchor_suffix=opts.anchor_suffix,
         )
 
     def _create_nodes(self, rst_content: str, opts: DirectiveOptions) -> list["nodes.Node"]:

--- a/docs/source/sphinx_integration.rst
+++ b/docs/source/sphinx_integration.rst
@@ -213,6 +213,21 @@ Replace the app name shown in ``Usage:`` lines of the generated documentation wi
 
 This is useful when the documented invocation differs from the app's configured name. For example, an ``App(name="cli", ...)`` installed as a project entry point might typically be invoked as ``uv run cli``; setting ``:usage-name: uv run cli`` renders that in every ``Usage:`` block while section headings, anchors, and the table of contents continue to reference the plain ``cli`` name.
 
+``:anchor-prefix:`` / ``:anchor-suffix:`` - Namespace the Reference Labels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add a token to every generated reference label so the *same* command can be documented by more than one directive without colliding:
+
+.. code-block:: rst
+
+   .. cyclopts:: mypackage.cli:app
+      :anchor-prefix: admin
+
+   .. cyclopts:: mypackage.cli:app
+      :anchor-suffix: summary
+
+``:anchor-prefix:`` sits outside the ``cyclopts-`` namespace (``admin-cyclopts-myapp-deploy``) and is the natural choice for namespacing a whole directive by page or section. ``:anchor-suffix:`` trails the command path (``cyclopts-myapp-deploy-summary``) and is the natural choice for distinguishing multiple renderings of a command on a single page. Both apply to the root and every subcommand anchor, are slugified like the rest of the label, and can be combined (``admin-cyclopts-myapp-deploy-summary``).
+
 Automatic Reference Labels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -224,6 +239,8 @@ For example:
 - Nested subcommand: ``cyclopts-myapp-deploy-production``
 
 You can reference these commands elsewhere in your documentation using ``:ref:`cyclopts-myapp-deploy```.
+
+Because a reference label must be unique to be usable, documenting the same command with two directives emits the same label twice and Sphinx warns (``Duplicate explicit target name`` on one page, ``duplicate label`` across pages). Give one of the directives an ``:anchor-prefix:`` or ``:anchor-suffix:`` so each rendering keeps its own referenceable label.
 
 Complete Example
 ----------------

--- a/tests/test_sphinx_ext.py
+++ b/tests/test_sphinx_ext.py
@@ -1216,6 +1216,11 @@ def serve(port: int = 8000):
         both = render({"anchor-prefix": "admin", "anchor-suffix": "full"})
         assert ".. _admin-cyclopts-myapp-mycommand-full:" in both
 
+        # The title-less root normally has no anchor, but a prefix/suffix
+        # disambiguates its bare label and opts the root anchor back in.
+        assert ".. _admin-cyclopts-myapp:" in prefixed
+        assert ".. _cyclopts-myapp-full:" in suffixed
+
 
 class TestRstContentParsing:
     """Test RST content parsing and formatting."""

--- a/tests/test_sphinx_ext.py
+++ b/tests/test_sphinx_ext.py
@@ -1156,6 +1156,66 @@ def serve(port: int = 8000):
         assert ".. _cyclopts-myapp-make-x:" in page_x
         assert ".. _cyclopts-myapp-make-y:" in page_y
 
+    def test_anchor_prefix_and_suffix(self, importable_tmp_path):
+        """``:anchor-prefix:`` / ``:anchor-suffix:`` namespace the generated anchors.
+
+        Documenting the same app+command from more than one directive duplicates the
+        ``cyclopts-<app>-<command>`` label (an ambiguous ``:ref:`` target). A user-set
+        prefix (a page/section namespace, outside ``cyclopts-``) or suffix (a per-page
+        variant qualifier) disambiguates them while keeping predictable, referenceable
+        labels. Both apply to the root and every subcommand anchor and compose.
+        """
+        module_file = importable_tmp_path / "anchormod.py"
+        module_file.write_text(
+            dedent(
+                """\
+                from cyclopts import App
+
+                app = App(name="myapp", help="My app.")
+
+                @app.command
+                def mycommand(name: str):
+                    '''Do a thing.'''
+                    pass
+                """
+            )
+        )
+
+        from cyclopts.ext.sphinx import CycloptsDirective
+
+        def render(options: dict) -> str:
+            mock_state = MagicMock()
+            mock_state.nested_parse = MagicMock()
+            directive = CycloptsDirective(
+                name="cyclopts",
+                arguments=["anchormod:app"],
+                options=options,
+                content=StringList(),
+                lineno=1,
+                content_offset=0,
+                block_text="",
+                state=mock_state,
+                state_machine=MagicMock(),
+            )
+            directive.run()
+            return "\n".join(line for call in mock_state.nested_parse.call_args_list if call for line in call[0][0])
+
+        # Suffix trails the command path (variant qualifier).
+        suffixed = render({"anchor-suffix": "full"})
+        assert ".. _cyclopts-myapp-mycommand-full:" in suffixed
+
+        # Prefix sits outside the ``cyclopts-`` namespace (page/section namespace).
+        prefixed = render({"anchor-prefix": "admin"})
+        assert ".. _admin-cyclopts-myapp-mycommand:" in prefixed
+
+        # Values are slugified consistently with the rest of the anchor.
+        spaced = render({"anchor-prefix": "Admin Guide"})
+        assert ".. _admin-guide-cyclopts-myapp-mycommand:" in spaced
+
+        # Prefix and suffix compose.
+        both = render({"anchor-prefix": "admin", "anchor-suffix": "full"})
+        assert ".. _admin-cyclopts-myapp-mycommand-full:" in both
+
 
 class TestRstContentParsing:
     """Test RST content parsing and formatting."""


### PR DESCRIPTION
Follow-up to #912.

The Sphinx directive emits a stable `cyclopts-<app>-<command>` reference label for every command so it can be cross-referenced with `:ref:`. When the *same* app+command is documented by more than one `.. cyclopts::` directive, that label gets defined twice, which docutils/Sphinx correctly flag as an ambiguous target (`Duplicate explicit target name` within a page, `duplicate label` across pages). @carlfischerjba hit this in #912 after the root-anchor fix.

Auto-deduplicating the label would just hide the ambiguity and make `:ref:` resolve to whichever page Sphinx read first, so instead this adds two directive options so each rendering keeps its own referenceable label:

- `:anchor-prefix:` sits outside the `cyclopts-` namespace (`admin-cyclopts-myapp-deploy`), the natural choice for namespacing a whole directive by page or section.
- `:anchor-suffix:` trails the command path (`cyclopts-myapp-deploy-summary`), the natural choice for distinguishing multiple renderings of a command on a single page.

Both apply to the root and every subcommand anchor, are slugified like the rest of the label, and compose (`admin-cyclopts-myapp-deploy-summary`). The bare/unqualified duplicate case keeps docutils’ warning — it is correctly reporting an ambiguous target, and there is now a lever to resolve it.

Scoped to the RST/Sphinx path on purpose: HTML and Markdown anchors are in-page heading IDs local to a single generated document, not shared cross-reference targets, so they have no analogous collision (Markdown even already auto-suffixes `_N` for within-doc TOC duplicates). Also deliberately not added to `App.generate_docs()`, which is multi-format and whose anchors differ per format.

## Testing
- New `test_anchor_prefix_and_suffix` covers prefix, suffix, slugification of multi-word values, and composition.
- Verified end-to-end with a real Sphinx build under `-W`: three directives for the same command (plain / suffix / prefix) produce distinct, `:ref:`-resolvable anchors with zero warnings.
- Full suite green; ruff + pyright clean; docs build clean.

## Docs
- Documented both options in `docs/source/sphinx_integration.rst`, including the disambiguation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)