### PR TITLE
feat(help): make help colors themeable via cyclopts.* named styles

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2439,7 +2439,7 @@ class App:
                 try:
                     _, command_panel = panels[group.name]
                 except KeyError:
-                    command_panel = HelpPanel(title=group.name, format="command")
+                    command_panel = HelpPanel(title=group.name, theme=group.theme, format="command")
                     panels[group.name] = (group, command_panel)
 
                 if group.help:

--- a/cyclopts/group.py
+++ b/cyclopts/group.py
@@ -25,6 +25,8 @@ from cyclopts.utils import (
 )
 
 if TYPE_CHECKING:
+    from rich.theme import Theme
+
     from cyclopts.argument import ArgumentCollection
     from cyclopts.help.protocols import HelpFormatter
     from cyclopts.parameter import Parameter
@@ -107,6 +109,8 @@ class Group:
         default=None, converter=help_formatter_converter, kw_only=True
     )
 
+    theme: Union[dict[str, str], "Theme", None] = field(default=None, eq=False, kw_only=True)
+
     @property
     def name(self) -> str:
         return "" if type(self._name) is object else self._name
@@ -142,6 +146,7 @@ class Group:
         validator=None,
         default_parameter=None,
         help_formatter=None,
+        theme=None,
     ) -> Self:
         """Create a group with a globally incrementing :attr:`~Group.sort_key`.
 
@@ -168,6 +173,8 @@ class Group:
             Default parameter for elements within the group.
         help_formatter: cyclopts.help.protocols.HelpFormatter | None
             Custom help formatter for this group's help display.
+        theme: dict[str, str] | rich.theme.Theme | None
+            Per-group theme overriding ``cyclopts.*`` styles for this group's help panel.
         """
         count = next(_sort_key_counter)
         if inspect.isgenerator(sort_key):
@@ -186,6 +193,7 @@ class Group:
             validator=validator,
             default_parameter=default_parameter,
             help_formatter=help_formatter,
+            theme=theme,
         )
 
 

--- a/cyclopts/help/formatters/default.py
+++ b/cyclopts/help/formatters/default.py
@@ -153,17 +153,21 @@ class DefaultFormatter:
         if usage:
             from rich.text import Text
 
+            from cyclopts.help.specs import DefaultStyled
+
             # Add "Usage:" prefix if not already present (for custom usage strings)
             usage_str = str(usage)
             if not usage_str.strip().startswith("Usage:"):
                 if isinstance(usage, Text):
-                    usage_with_label = Text("Usage: ", style="bold") + usage
+                    usage_with_label = Text("Usage: ", style="cyclopts.usage") + usage
                 else:
-                    usage_with_label = Text(f"Usage: {usage}", style="bold")
+                    usage_with_label = Text(f"Usage: {usage}", style="cyclopts.usage")
             else:
                 # Custom usage already has "Usage:", use as-is
-                usage_with_label = usage if isinstance(usage, Text) else Text(str(usage), style="bold")
-            console.print(usage_with_label)
+                usage_with_label = usage if isinstance(usage, Text) else Text(str(usage), style="cyclopts.usage")
+            # Wrap so the bare cyclopts.usage style name resolves (defaults to bold);
+            # render_usage prints outside the panel's DefaultStyled wrapper.
+            console.print(DefaultStyled(usage_with_label))
 
     def render_description(self, console: "Console", options: "ConsoleOptions", description: Any) -> None:
         """Render the description.

--- a/cyclopts/help/formatters/default.py
+++ b/cyclopts/help/formatters/default.py
@@ -236,5 +236,6 @@ class DefaultFormatter:
             panel = panel_spec.build(RichGroup(panel_description, table))
 
         # Wrap so the bare cyclopts.* style names resolve on whatever console
-        # prints this, regardless of the print path.
-        return DefaultStyled(panel)
+        # prints this, regardless of the print path; the group's theme (if any)
+        # is layered on top to restyle just this panel.
+        return DefaultStyled(panel, theme=help_panel.theme)

--- a/cyclopts/help/formatters/default.py
+++ b/cyclopts/help/formatters/default.py
@@ -107,12 +107,14 @@ class DefaultFormatter:
             name_column = ColumnSpec(
                 renderer=NameRenderer(max_width=max_width),
                 header="Option",
-                style="cyan",
+                style="cyclopts.name",
                 max_width=max_width,
             )
 
             description_column = ColumnSpec(
-                renderer=DescriptionRenderer(newline_metadata=True), header="Description", overflow="fold"
+                renderer=DescriptionRenderer(newline_metadata=True),
+                header="Description",
+                overflow="fold",
             )
 
             if any(x.required for x in entries):
@@ -188,6 +190,7 @@ class DefaultFormatter:
         from rich.text import Text
 
         from cyclopts.help.specs import (
+            DefaultStyled,
             PanelSpec,
             TableSpec,
             get_default_command_columns,
@@ -228,4 +231,6 @@ class DefaultFormatter:
         else:
             panel = panel_spec.build(RichGroup(panel_description, table))
 
-        return panel
+        # Wrap so the bare cyclopts.* style names resolve on whatever console
+        # prints this, regardless of the print path.
+        return DefaultStyled(panel)

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -10,6 +10,7 @@ from typing import (
     ForwardRef,
     Literal,
     Self,
+    Union,
 )
 
 from attrs import define, evolve, field
@@ -25,6 +26,7 @@ from cyclopts.utils import SortHelper, frozen, is_class_and_subclass, resolve_ca
 
 if TYPE_CHECKING:
     from rich.console import RenderableType
+    from rich.theme import Theme
 
     from cyclopts.argument import Argument, ArgumentCollection
     from cyclopts.core import App
@@ -150,6 +152,9 @@ class HelpPanel:
 
     entries: list[HelpEntry] = field(factory=list)
     """List of help entries to display (in order) in the panel."""
+
+    theme: Union[dict[str, str], "Theme", None] = None
+    """Per-group theme (from :attr:`Group.theme`) layered over the ``cyclopts.*`` style defaults for this panel."""
 
     def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)
@@ -577,6 +582,7 @@ def create_parameter_help_panel(
     kwargs = {
         "format": "parameter",
         "title": group.name,
+        "theme": group.theme,
         "description": InlineText.from_format(group.help, format=format, force_empty_end=True)
         if group.help
         else Text(),

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -329,7 +329,7 @@ def format_usage(
         else:
             usage.append("[ARGS]")
 
-    return Text(" ".join(usage) + "\n", style="bold")
+    return Text(" ".join(usage) + "\n", style="cyclopts.usage")
 
 
 def _smart_join(strings: Sequence[str]) -> str:

--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -35,6 +35,7 @@ DEFAULT_STYLES: Mapping[str, str] = MappingProxyType(
         "cyclopts.default": "gray58",  # [default: ...]
         "cyclopts.required": "red",  # [required]
         "cyclopts.border": "none",  # help panel border
+        "cyclopts.usage": "bold",  # "Usage:" line
     }
 )
 

--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -67,14 +67,30 @@ class DefaultStyled:
     renderable applies that theme at render time, so the styles resolve on any
     console and via any print path (a user's own theme keys still win) without
     callers having to set up the theme themselves.
+
+    A per-group ``theme`` (from :attr:`Group.theme`) is layered on top so its
+    ``cyclopts.*`` keys override the defaults for just that group's panel.
     """
 
-    def __init__(self, renderable: "RenderableType"):
+    def __init__(self, renderable: "RenderableType", theme: "dict[str, str] | Theme | None" = None):
         self.renderable = renderable
+        self.theme = theme
 
     def __rich_console__(self, console: "Console", options: "ConsoleOptions") -> "RenderResult":
+        from contextlib import nullcontext
+
+        from rich.theme import Theme
+
+        theme = self.theme
+        if theme is not None and not isinstance(theme, Theme):
+            # A mapping is wrapped with inherit=False so it carries only its own
+            # keys, overriding just those when layered over the defaults below.
+            theme = Theme(theme, inherit=False)
+
         with console.use_theme(default_styles_theme(console)):
-            yield from console.render(self.renderable, options)
+            # The group theme is pushed on top so its keys win for this panel.
+            with console.use_theme(theme) if theme is not None else nullcontext():
+                yield from console.render(self.renderable, options)
 
 
 class NameRenderer:

--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -1,7 +1,8 @@
 import math
 import textwrap
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from operator import attrgetter
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Optional, Self, Union
 
 from attrs import evolve
@@ -10,14 +11,68 @@ from cyclopts.utils import frozen
 
 if TYPE_CHECKING:
     from rich.box import Box
-    from rich.console import Console, ConsoleOptions, RenderableType
+    from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
     from rich.padding import PaddingDimensions
     from rich.panel import Panel
     from rich.style import StyleType
     from rich.table import Table
+    from rich.theme import Theme
 
     from cyclopts.help import HelpEntry
     from cyclopts.help.protocols import Renderer
+
+
+# Every color Cyclopts renders in help output is referred to by one of these
+# named styles. Define any of these keys in your Console's ``rich.theme.Theme``
+# to restyle that element, e.g. ``Theme({"cyclopts.required": "bold yellow"})``;
+# keys you don't define fall back to the paired default below.
+DEFAULT_STYLES: Mapping[str, str] = MappingProxyType(
+    {
+        "cyclopts.name": "cyan",  # parameter / command name column
+        "cyclopts.required_marker": "red bold",  # required "*" marker
+        "cyclopts.choices": "gray58",  # [choices: ...]
+        "cyclopts.env_var": "gray58",  # [env var: ...]
+        "cyclopts.default": "gray58",  # [default: ...]
+        "cyclopts.required": "red",  # [required]
+    }
+)
+
+
+def default_styles_theme(console: "Console") -> "Theme":
+    """Build a theme supplying the ``cyclopts.*`` defaults ``console`` lacks.
+
+    Only names the console doesn't already resolve are included, so a user's own
+    theme keys take precedence (Rich's :meth:`~rich.console.Console.use_theme`
+    layers on top, so a full default theme would otherwise clobber overrides).
+    """
+    from rich.errors import MissingStyle
+    from rich.theme import Theme
+
+    styles: dict[str, str] = {}
+    for name, fallback in DEFAULT_STYLES.items():
+        try:
+            console.get_style(name)
+        except MissingStyle:
+            styles[name] = fallback
+    return Theme(styles)
+
+
+class DefaultStyled:
+    """Wrap a renderable so it renders under the ``cyclopts.*`` style defaults.
+
+    Help output refers to colors by bare ``cyclopts.*`` style names; those names
+    only resolve while :func:`default_styles_theme` is active. Wrapping the
+    renderable applies that theme at render time, so the styles resolve on any
+    console and via any print path (a user's own theme keys still win) without
+    callers having to set up the theme themselves.
+    """
+
+    def __init__(self, renderable: "RenderableType"):
+        self.renderable = renderable
+
+    def __rich_console__(self, console: "Console", options: "ConsoleOptions") -> "RenderResult":
+        with console.use_theme(default_styles_theme(console)):
+            yield from console.render(self.renderable, options)
 
 
 class NameRenderer:
@@ -184,17 +239,17 @@ class DescriptionRenderer:
 
         if entry.choices:
             choices_str = ", ".join(entry.choices)
-            metadata_items.append(Text(rf"[choices: {choices_str}]", "dim"))
+            metadata_items.append(Text(rf"[choices: {choices_str}]", "cyclopts.choices"))
 
         if entry.env_var:
             env_vars_str = ", ".join(entry.env_var)
-            metadata_items.append(Text(rf"[env var: {env_vars_str}]", "dim"))
+            metadata_items.append(Text(rf"[env var: {env_vars_str}]", "cyclopts.env_var"))
 
         if entry.default is not None:
-            metadata_items.append(Text(rf"[default: {entry.default}]", "dim"))
+            metadata_items.append(Text(rf"[default: {entry.default}]", "cyclopts.default"))
 
         if entry.required:
-            metadata_items.append(Text(r"[required]", "dim red"))
+            metadata_items.append(Text(r"[required]", "cyclopts.required"))
 
         # Apply metadata based on formatting mode
         if self.newline_metadata and metadata_items:
@@ -404,7 +459,7 @@ AsteriskColumn = ColumnSpec(
     header="",
     justify="left",
     width=1,
-    style="red bold",
+    style="cyclopts.required_marker",
 )
 
 NameColumn = ColumnSpec(
@@ -441,7 +496,7 @@ def get_default_command_columns(
         renderer=CommandNameRenderer(max_width=max_width),
         header="Command",
         justify="left",
-        style="cyan",
+        style="cyclopts.name",
         max_width=max_width,
     )
 
@@ -475,7 +530,7 @@ def get_default_parameter_columns(
         renderer=NameRenderer(max_width=max_width),
         header="Option",
         justify="left",
-        style="cyan",
+        style="cyclopts.name",
         max_width=max_width,
     )
 

--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -467,7 +467,7 @@ NameColumn = ColumnSpec(
     renderer=NameRenderer(),
     header="Option",
     justify="left",
-    style="cyan",
+    style="cyclopts.name",
 )
 
 DescriptionColumn = ColumnSpec(renderer=DescriptionRenderer(), header="Description", justify="left", overflow="fold")

--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -34,6 +34,7 @@ DEFAULT_STYLES: Mapping[str, str] = MappingProxyType(
         "cyclopts.env_var": "gray58",  # [env var: ...]
         "cyclopts.default": "gray58",  # [default: ...]
         "cyclopts.required": "red",  # [required]
+        "cyclopts.border": "none",  # help panel border
     }
 )
 
@@ -803,10 +804,12 @@ class PanelSpec:
     Corresponds to the ``style`` parameter of :class:`~rich.panel.Panel`.
     """
 
-    border_style: Optional["StyleType"] = "none"
+    border_style: Optional["StyleType"] = "cyclopts.border"
     """Style applied to the panel border.
 
     Corresponds to the ``border_style`` parameter of :class:`~rich.panel.Panel`.
+    Defaults to the ``cyclopts.border`` named style (``none``), which can be
+    remapped via a :class:`~rich.theme.Theme` on the :class:`~cyclopts.App`'s console.
     """
 
     box: Optional["Box"] = None  # Will use ROUNDED as default when building

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1869,6 +1869,17 @@ API
 
       See :ref:`Help Customization` for detailed examples.
 
+   .. attribute:: theme
+      :type: Union[dict[str, str], rich.theme.Theme, None]
+      :value: None
+
+      Per-group theme overriding ``cyclopts.*`` styles for this group's help panel.
+
+      Accepts a ``{style_name: definition}`` mapping or a :class:`~rich.theme.Theme`, keyed by the
+      same ``cyclopts.*`` names as the app-wide help styles (e.g. ``{"cyclopts.border": "red"}``).
+      These layer on top of the app's styles for just this group's panel; keys the theme doesn't
+      define fall through to the app's styles. See :ref:`Help Customization` for detailed examples.
+
    .. attribute:: sort_key
       :type: Any
       :value: None

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -110,8 +110,8 @@ Output:
    │ <span style="color: #0088cc">--version</span>  Display application version.                                      │
    ╰──────────────────────────────────────────────────────────────────────────────╯
    ╭─ Parameters ─────────────────────────────────────────────────────────────────╮
-   │ <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">NAME --name</span>    Person to greet. <span style="color: #cc3333; opacity: 0.7">[required]</span>                                │
-   │    <span style="color: #0088cc">COUNT --count</span>  Number of times to greet. <span style="opacity: 0.7">[default: 1]</span>                     │
+   │ <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">NAME --name</span>    Person to greet. <span style="color: #cc3333">[required]</span>                                │
+   │    <span style="color: #0088cc">COUNT --count</span>  Number of times to greet. <span style="color: #949494">[default: 1]</span>                     │
    ╰──────────────────────────────────────────────────────────────────────────────╯</pre>
    </div>
 
@@ -215,8 +215,8 @@ Output:
    <span style="color: #0088cc">╚══════════════════════════════════════════════════════════════════════╝</span>
    <span style="color: #0088cc">╔═ Parameters ═════════════════════════════════════════════════════════╗</span>
    <span style="color: #0088cc">║                                                                      ║</span>
-   <span style="color: #0088cc">║  </span><span style="color: #cc3333; font-weight: bold">*  </span><span style="color: #0088cc">PATH --path                   </span>  <span style="color: #cc3333; opacity: 0.7">[required]</span>                       <span style="color: #0088cc">║</span>
-   <span style="color: #0088cc">║     </span><span style="color: #0088cc">VERBOSE --verbose</span>  <span style="opacity: 0.7">[default: False]</span>                              <span style="color: #0088cc">║</span>
+   <span style="color: #0088cc">║  </span><span style="color: #cc3333; font-weight: bold">*  </span><span style="color: #0088cc">PATH --path                   </span>  <span style="color: #cc3333">[required]</span>                       <span style="color: #0088cc">║</span>
+   <span style="color: #0088cc">║     </span><span style="color: #0088cc">VERBOSE --verbose</span>  <span style="color: #949494">[default: False]</span>                              <span style="color: #0088cc">║</span>
    <span style="color: #0088cc">║       </span><span style="color: #0088cc">--no-verbose   </span>                                                <span style="color: #0088cc">║</span>
    <span style="color: #0088cc">║                                                                      ║</span>
    <span style="color: #0088cc">╚══════════════════════════════════════════════════════════════════════╝</span></pre>
@@ -273,9 +273,9 @@ Output:
    ╭─ Parameters ─────────────────────────────────────────────────────────────────╮
    │    <span style="color: #00aa00">│</span>Option             <span style="color: #00aa00">│</span>Description                                          │
    │ <span style="color: #00aa00">───┼───────────────────┼────────────────────────────────────────────────────</span> │
-   │ <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #00aa00">│</span><span style="color: #0088cc">PATH --path</span>        <span style="color: #00aa00">│</span><span style="color: #cc3333; opacity: 0.7">[required]</span>                                           │
+   │ <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #00aa00">│</span><span style="color: #0088cc">PATH --path</span>        <span style="color: #00aa00">│</span><span style="color: #cc3333">[required]</span>                                           │
    │ <span style="color: #00aa00">───┼───────────────────┼────────────────────────────────────────────────────</span> │
-   │    <span style="color: #00aa00">│</span><span style="color: #0088cc">VERBOSE --verbose</span>  <span style="color: #00aa00">│</span><span style="opacity: 0.7">[default: False]</span>                                     │
+   │    <span style="color: #00aa00">│</span><span style="color: #0088cc">VERBOSE --verbose</span>  <span style="color: #00aa00">│</span><span style="color: #949494">[default: False]</span>                                     │
    │    <span style="color: #00aa00">│</span><span style="color: #0088cc">  --no-verbose</span>     <span style="color: #00aa00">│</span>                                                     │
    ╰──────────────────────────────────────────────────────────────────────────────╯</pre>
    </div>
@@ -283,13 +283,41 @@ Output:
 Color Styles
 ^^^^^^^^^^^^
 
-Cyclopts renders the inline metadata annotations (``[default: ...]``,
-``[choices: ...]``, ``[env var: ...]``) with Rich's ``dim`` style, and
-``[required]`` with ``dim red``. On some dark terminal color schemes ``dim``
-text can be hard to read. Because Rich resolves a style string against the
-console's theme *before* parsing it, you can remap these annotations by
-redefining those style strings in a :class:`~rich.theme.Theme` and passing the
-themed :class:`~rich.console.Console` to your :class:`~cyclopts.App`:
+Every color Cyclopts renders in help output is routed through a named
+`Rich style <https://rich.readthedocs.io/en/stable/style.html#style-themes>`_.
+Define any of these keys in your :class:`~rich.theme.Theme` and pass the themed
+:class:`~rich.console.Console` to your :class:`~cyclopts.App` to restyle that
+element; keys you don't define fall back to the built-in default.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Style name
+     - Default
+     - Applies to
+   * - ``cyclopts.name``
+     - ``cyan``
+     - Parameter and command names.
+   * - ``cyclopts.required_marker``
+     - ``red bold``
+     - The ``*`` required marker.
+   * - ``cyclopts.required``
+     - ``red``
+     - The ``[required]`` annotation.
+   * - ``cyclopts.default``
+     - ``gray58``
+     - The ``[default: ...]`` annotation.
+   * - ``cyclopts.choices``
+     - ``gray58``
+     - The ``[choices: ...]`` annotation.
+   * - ``cyclopts.env_var``
+     - ``gray58``
+     - The ``[env var: ...]`` annotation.
+
+The muted annotations default to ``gray58``, a fixed grey that stays legible
+across light and dark terminal themes. Override any key to match your own
+palette:
 
 .. code-block:: python
 
@@ -300,7 +328,13 @@ themed :class:`~rich.console.Console` to your :class:`~cyclopts.App`:
 
    from cyclopts import App
 
-   theme = Theme({"dim": "grey58", "dim red": "bright_red"})
+   theme = Theme(
+       {
+           "cyclopts.default": "blue",
+           "cyclopts.required": "bright_red",
+           "cyclopts.name": "bright_cyan",
+       }
+   )
    app = App(console=Console(theme=theme))
 
    @app.default
@@ -310,9 +344,8 @@ themed :class:`~rich.console.Console` to your :class:`~cyclopts.App`:
    if __name__ == "__main__":
        app()
 
-Note that redefining ``dim`` affects **all** text Cyclopts styles as ``dim``,
-not just parameter metadata. This is usually what you want for readability, but
-it is not a per-annotation override.
+Because the console is resolved through the app hierarchy, a theme set on a
+parent :class:`~cyclopts.App` is inherited by its subcommands' help output.
 
 Combining Customizations
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -362,8 +395,8 @@ Output:
    <span style="color: #00aaaa">│ </span><span style="color: #0088cc">--version</span>  Display application version.                             <span style="color: #00aaaa">│</span>
    <span style="color: #00aaaa">╰─────────────────────────────────────────────────────────────────────╯</span>
    <span style="color: #00aaaa">╭─ Parameters ────────────────────────────────────────────────────────╮</span>
-   <span style="color: #00aaaa">│ </span><span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">PATH --path</span>       <span style="color: #cc3333; opacity: 0.7">[required]</span>                                     <span style="color: #00aaaa">│</span>
-   <span style="color: #00aaaa">│    </span><span style="color: #0088cc">VERBOSE --verbose</span> <span style="opacity: 0.7">[default: False]</span>                               <span style="color: #00aaaa">│</span>
+   <span style="color: #00aaaa">│ </span><span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">PATH --path</span>       <span style="color: #cc3333">[required]</span>                                     <span style="color: #00aaaa">│</span>
+   <span style="color: #00aaaa">│    </span><span style="color: #0088cc">VERBOSE --verbose</span> <span style="color: #949494">[default: False]</span>                               <span style="color: #00aaaa">│</span>
    <span style="color: #00aaaa">╰─────────────────────────────────────────────────────────────────────╯</span></pre>
    </div>
 
@@ -436,13 +469,13 @@ Output:
    │ <span style="color: #0088cc">--version</span>  Display application version.                                      │
    ╰──────────────────────────────────────────────────────────────────────────────╯
    <span style="color: #00aa00">   Optional Settings                                                            </span>
-   <span style="color: #00aa00"> </span> <span style="color: #0088cc">VERBOSE --verbose</span>  <span style="opacity: 0.7">[default: False]</span>                                          <span style="color: #00aa00"> </span>
+   <span style="color: #00aa00"> </span> <span style="color: #0088cc">VERBOSE --verbose</span>  <span style="color: #949494">[default: False]</span>                                          <span style="color: #00aa00"> </span>
    <span style="color: #00aa00"> </span> <span style="color: #0088cc">  --no-verbose</span>     <span style="opacity: 0.7"></span>                                                          <span style="color: #00aa00"> </span>
-   <span style="color: #00aa00"> </span> <span style="color: #0088cc">THREADS --threads</span>  <span style="opacity: 0.7">[default: 4]</span>                                              <span style="color: #00aa00"> </span>
+   <span style="color: #00aa00"> </span> <span style="color: #0088cc">THREADS --threads</span>  <span style="color: #949494">[default: 4]</span>                                              <span style="color: #00aa00"> </span>
    <span style="color: #00aa00">                                                                                </span>
    <span style="color: #cc3333; font-weight: bold">╔═ Required Options ═══════════════════════════════════════════════════════════╗</span>
-   <span style="color: #cc3333; font-weight: bold">║</span> <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">INPUT-FILE --input-file</span>  <span style="color: #cc3333; opacity: 0.7">[required]</span>                                       <span style="color: #cc3333; font-weight: bold">║</span>
-   <span style="color: #cc3333; font-weight: bold">║</span> <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">OUTPUT-DIR --output-dir</span>  <span style="color: #cc3333; opacity: 0.7">[required]</span>                                       <span style="color: #cc3333; font-weight: bold">║</span>
+   <span style="color: #cc3333; font-weight: bold">║</span> <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">INPUT-FILE --input-file</span>  <span style="color: #cc3333">[required]</span>                                       <span style="color: #cc3333; font-weight: bold">║</span>
+   <span style="color: #cc3333; font-weight: bold">║</span> <span style="color: #cc3333; font-weight: bold">*</span>  <span style="color: #0088cc">OUTPUT-DIR --output-dir</span>  <span style="color: #cc3333">[required]</span>                                       <span style="color: #cc3333; font-weight: bold">║</span>
    <span style="color: #cc3333; font-weight: bold">╚══════════════════════════════════════════════════════════════════════════════╝</span></pre>
    </div>
 

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -321,9 +321,7 @@ element; keys you don't define fall back to the built-in default.
      - ``bold``
      - The ``Usage:`` line.
 
-The muted annotations default to ``gray58``, a fixed grey that stays legible
-across light and dark terminal themes. Override any key to match your own
-palette:
+Override any key to match your own palette:
 
 .. code-block:: python
 

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -348,6 +348,25 @@ Override any key to match your own palette:
    if __name__ == "__main__":
        app()
 
+Output:
+
+.. raw:: html
+
+   <div class="highlight-default notranslate">
+         <pre style="font-family: monospace;"><span style="font-weight: bold">Usage: demo.py SRC [ARGS]</span>
+
+   Compress a file.
+
+   ╭─ Commands ───────────────────────────────────────────────────────────╮
+   │ <span style="color: #00cccc">--help (-h)  </span>Display this message and exit.                          │
+   │ <span style="color: #00cccc">--version    </span>Display application version.                            │
+   ╰──────────────────────────────────────────────────────────────────────╯
+   ╭─ Parameters ─────────────────────────────────────────────────────────╮
+   │ <span style="color: #cc3333; font-weight: bold">*  </span><span style="color: #00cccc">SRC --src  </span><span style="color: #ff3333">[required]</span>                                             │
+   │ <span style="color: #cc3333; font-weight: bold">   </span><span style="color: #00cccc">DST --dst  </span><span style="color: #3333cc">[default: out.zip]</span>                                     │
+   ╰──────────────────────────────────────────────────────────────────────╯</pre>
+   </div>
+
 Because the console is resolved through the app hierarchy, a theme set on a
 parent :class:`~cyclopts.App` is inherited by its subcommands' help output.
 

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -370,6 +370,53 @@ Output:
 Because the console is resolved through the app hierarchy, a theme set on a
 parent :class:`~cyclopts.App` is inherited by its subcommands' help output.
 
+Per-Group Styles
+^^^^^^^^^^^^^^^^
+
+To restyle a single panel, give its :class:`~cyclopts.Group` a
+:attr:`~cyclopts.Group.theme`. It accepts the same ``cyclopts.*`` keys as the
+app-wide styles (as a mapping or a :class:`~rich.theme.Theme`) and layers them on
+top for just that group's panel, leaving every other panel on the app's styles:
+
+.. code-block:: python
+
+   from cyclopts import App, Group
+
+   app = App()
+
+   danger = Group("Danger Zone", theme={"cyclopts.border": "red", "cyclopts.name": "bright_red"})
+
+   @app.command
+   def build():
+       """Build the project."""
+
+   @app.command(group=danger)
+   def destroy():
+       """Tear down all infrastructure."""
+
+   if __name__ == "__main__":
+       app()
+
+Output:
+
+.. raw:: html
+
+   <div class="highlight-default notranslate">
+         <pre style="font-family: monospace;"><span style="font-weight: bold">Usage: demo.py COMMAND</span>
+
+   ╭─ Commands ───────────────────────────────────────────────────────────╮
+   │ <span style="color: #0088cc">build        </span>Build the project.                                      │
+   │ <span style="color: #0088cc">--help (-h)  </span>Display this message and exit.                          │
+   │ <span style="color: #0088cc">--version    </span>Display application version.                            │
+   ╰──────────────────────────────────────────────────────────────────────╯
+   <span style="color: #cc3333">╭─ Danger Zone ────────────────────────────────────────────────────────╮</span>
+   <span style="color: #cc3333">│</span> <span style="color: #ff3333">destroy  </span>Tear down all infrastructure.                               <span style="color: #cc3333">│</span>
+   <span style="color: #cc3333">╰──────────────────────────────────────────────────────────────────────╯</span></pre>
+   </div>
+
+Keys the group's theme doesn't define fall through to the app's styles, so a
+group can override just its border while inheriting every other color.
+
 Combining Customizations
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -317,6 +317,9 @@ element; keys you don't define fall back to the built-in default.
    * - ``cyclopts.border``
      - ``none``
      - The help panel border.
+   * - ``cyclopts.usage``
+     - ``bold``
+     - The ``Usage:`` line.
 
 The muted annotations default to ``gray58``, a fixed grey that stays legible
 across light and dark terminal themes. Override any key to match your own

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -314,6 +314,9 @@ element; keys you don't define fall back to the built-in default.
    * - ``cyclopts.env_var``
      - ``gray58``
      - The ``[env var: ...]`` annotation.
+   * - ``cyclopts.border``
+     - ``none``
+     - The help panel border.
 
 The muted annotations default to ``gray58``, a fixed grey that stays legible
 across light and dark terminal themes. Override any key to match your own

--- a/docs/source/migration/v5.rst
+++ b/docs/source/migration/v5.rst
@@ -357,4 +357,19 @@ default. It is now equivalent to ``--no-description``.
    # v5: myapp
    #     └── greet
 
+Help Metadata Colors Changed; Colors Are Now Themeable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Affects:** the appearance of the default help page, not behavior.
+
+The ``dim`` styling on the help annotations was hard to read on some terminal
+color schemes. The ``[required]`` annotation is now plain ``red`` (was
+``dim red``), and the ``[default: ...]``, ``[choices: ...]``, and
+``[env var: ...]`` annotations are now ``gray58``, a fixed grey that stays
+legible across light and dark themes (was ``dim``). Every color in the default
+help output is also now routed through a named Rich style (``cyclopts.name``,
+``cyclopts.required_marker``, ``cyclopts.required``, ``cyclopts.default``,
+``cyclopts.choices``, ``cyclopts.env_var``), so you can restyle any of them by
+defining that key in your Console's :class:`~rich.theme.Theme`. See
+:ref:`Help Customization`.
+
 .. _Click: https://click.palletsprojects.com

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -1695,3 +1695,36 @@ def test_help_column_style_override_end_to_end():
     # The name column is a Table column style; it only resolves through the
     # DefaultStyled wrapper, so this also guards that path.
     assert "\x1b[35mSRC --src" in output  # cyclopts.name -> magenta
+
+
+def test_help_border_style_override_end_to_end():
+    """A theme override of cyclopts.border restyles the help panel border."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    console = Console(
+        theme=Theme({"cyclopts.border": "magenta"}),
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console)
+
+    @app.default
+    def main(src: str):
+        """Compress a file.
+
+        Parameters
+        ----------
+        src: str
+            File to compress.
+        """
+
+    with console.capture() as capture:
+        app.help_print([])
+    output = capture.get()
+
+    # The rounded panel border is drawn in magenta.
+    assert "\x1b[35m╭" in output  # cyclopts.border -> magenta

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -1544,3 +1544,154 @@ def test_description_renderer_no_extra_whitespace():
         if line.strip():  # Skip empty lines
             # The line should start with "[metadata...]" with no indentation
             assert line.startswith("["), f"Line should not be indented: {repr(line)}"
+
+
+def test_default_styles_theme_gap_fill():
+    """default_styles_theme supplies only the cyclopts.* keys the console lacks."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    from cyclopts.help.specs import DEFAULT_STYLES, default_styles_theme
+
+    # No user theme -> every default is supplied.
+    plain = default_styles_theme(Console())
+    assert set(plain.styles) >= set(DEFAULT_STYLES)
+    assert str(plain.styles["cyclopts.required"]) == "red"
+
+    # User defines a key -> it is omitted (so the user's value wins downstream).
+    themed = default_styles_theme(Console(theme=Theme({"cyclopts.required": "green"})))
+    assert "cyclopts.required" not in themed.styles
+    assert "cyclopts.default" in themed.styles
+
+
+def test_description_renderer_theme_override():
+    """Under the formatter's theme, a cyclopts.* key restyles its annotation."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    from cyclopts.help.specs import default_styles_theme
+
+    entry = HelpEntry(
+        positive_names=("src",),
+        positive_shorts=("--src",),
+        description="File to compress",
+        required=True,
+    )
+
+    console = Console(
+        theme=Theme({"cyclopts.required": "green"}),
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+    )
+    rendered = DescriptionRenderer()(entry)
+    with console.use_theme(default_styles_theme(console)):
+        with console.capture() as capture:
+            console.print(rendered, end="")
+    output = capture.get()
+
+    assert "[required]" in output
+    assert "\x1b[32m" in output  # override green applied
+    assert "\x1b[31m" not in output  # default red not used
+
+
+def test_help_theme_override_end_to_end():
+    """A theme on the App's console reaches the rendered help page."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    console = Console(
+        theme=Theme({"cyclopts.required": "green"}),
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console)
+
+    @app.default
+    def main(src: str):
+        """Compress a file.
+
+        Parameters
+        ----------
+        src: str
+            File to compress.
+        """
+
+    with console.capture() as capture:
+        app.help_print([])
+    output = capture.get()
+
+    assert "[required]" in output
+    assert "\x1b[32m" in output  # themed required color reached the page
+
+
+def test_help_default_colors_end_to_end():
+    """With no theme, the built-in cyclopts.* defaults render (no dim)."""
+    from rich.console import Console
+
+    console = Console(
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console)
+
+    @app.default
+    def main(src: str, dst: str = "out.zip"):
+        """Compress a file.
+
+        Parameters
+        ----------
+        src: str
+            File to compress.
+        dst: str
+            Where to write it.
+        """
+
+    with console.capture() as capture:
+        app.help_print([])
+    output = capture.get()
+
+    assert "\x1b[31m[required]" in output  # cyclopts.required -> red
+    assert "\x1b[38;5;246m[default:" in output  # cyclopts.default -> gray58
+    assert "\x1b[2m" not in output  # no dim styling anywhere
+
+
+def test_help_column_style_override_end_to_end():
+    """A theme override of the cyclopts.name column style reaches the page."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    console = Console(
+        theme=Theme({"cyclopts.name": "magenta"}),
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console)
+
+    @app.default
+    def main(src: str):
+        """Compress a file.
+
+        Parameters
+        ----------
+        src: str
+            File to compress.
+        """
+
+    with console.capture() as capture:
+        app.help_print([])
+    output = capture.get()
+
+    # The name column is a Table column style; it only resolves through the
+    # DefaultStyled wrapper, so this also guards that path.
+    assert "\x1b[35mSRC --src" in output  # cyclopts.name -> magenta

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -1728,3 +1728,55 @@ def test_help_border_style_override_end_to_end():
 
     # The rounded panel border is drawn in magenta.
     assert "\x1b[35m╭" in output  # cyclopts.border -> magenta
+
+
+def test_help_usage_default_style_end_to_end():
+    """With no theme, the Usage line defaults to bold."""
+    from rich.console import Console
+
+    console = Console(
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console, name="mytool")
+
+    @app.default
+    def main(src: str):
+        """Compress a file."""
+
+    with console.capture() as capture:
+        app.help_print([])
+    output = capture.get()
+
+    assert "\x1b[1mUsage:" in output  # cyclopts.usage -> bold
+
+
+def test_help_usage_style_override_end_to_end():
+    """A theme override of cyclopts.usage restyles the Usage line."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    console = Console(
+        theme=Theme({"cyclopts.usage": "magenta"}),
+        width=80,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console, name="mytool")
+
+    @app.default
+    def main(src: str):
+        """Compress a file."""
+
+    with console.capture() as capture:
+        app.help_print([])
+    output = capture.get()
+
+    # The Usage line is printed outside the panel's DefaultStyled wrapper, so
+    # this also guards that render_usage applies the theme.
+    assert "\x1b[35mUsage:" in output  # cyclopts.usage -> magenta

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -1780,3 +1780,53 @@ def test_help_usage_style_override_end_to_end():
     # The Usage line is printed outside the panel's DefaultStyled wrapper, so
     # this also guards that render_usage applies the theme.
     assert "\x1b[35mUsage:" in output  # cyclopts.usage -> magenta
+
+
+def test_group_theme_does_not_affect_equality():
+    """Group.theme is excluded from equality (presentation, not identity)."""
+    from cyclopts import Group
+
+    assert Group("X") == Group("X")
+    assert Group("X", theme={"cyclopts.border": "red"}) == Group("X")
+
+
+def test_help_group_theme_end_to_end():
+    """Group.theme restyles only its own panel; both dict and Theme forms work."""
+    from rich.console import Console
+    from rich.theme import Theme
+
+    from cyclopts import Group
+
+    console = Console(
+        width=70,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        highlight=False,
+    )
+    app = App(console=console, name="demo")
+    danger = Group("Danger Zone", theme={"cyclopts.border": "red", "cyclopts.name": "bright_red"})
+    safe = Group("Safe Zone", theme=Theme({"cyclopts.border": "green"}))
+
+    @app.command(group=danger)
+    def delete():
+        """Delete everything."""
+
+    @app.command(group=safe)
+    def keep():
+        """Keep things."""
+
+    with console.capture() as capture:
+        app.help_print([])
+    lines = capture.get().splitlines()
+
+    danger_border = next(x for x in lines if "Danger Zone" in x)
+    safe_border = next(x for x in lines if "Safe Zone" in x)
+    danger_row = next(x for x in lines if "delete" in x)
+    safe_row = next(x for x in lines if "keep" in x)
+
+    assert "\x1b[31m╭" in danger_border  # border -> red (dict form)
+    assert "\x1b[91mdelete" in danger_row  # name -> bright_red (reaches the cell)
+    assert "\x1b[32m╭" in safe_border  # border -> green (Theme form)
+    # Safe Zone only overrode its border; its names fall back to the base cyan.
+    assert "\x1b[36mkeep" in safe_row


### PR DESCRIPTION
Makes every color in the default (Rich) help output overridable through a named `cyclopts.*` [Rich style](https://rich.readthedocs.io/en/stable/style.html#style-themes), and fixes the low-contrast `dim` defaults that #914 reported.

Users restyle any element by defining that key in their Console's `rich.theme.Theme`:

```python
from rich.console import Console
from rich.theme import Theme
from cyclopts import App

app = App(console=Console(theme=Theme({"cyclopts.required": "bold yellow"})))
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)