### PR TITLE
Edit documentation of color styles

### DIFF
--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -291,35 +291,35 @@ element; keys you don't define fall back to the built-in default.
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 20 50
+   :widths: 30 50 20
 
    * - Style name
-     - Default
      - Applies to
-   * - ``cyclopts.name``
-     - ``cyan``
-     - Parameter and command names.
-   * - ``cyclopts.required_marker``
-     - ``red bold``
-     - The ``*`` required marker.
-   * - ``cyclopts.required``
-     - ``red``
-     - The ``[required]`` annotation.
-   * - ``cyclopts.default``
-     - ``gray58``
-     - The ``[default: ...]`` annotation.
-   * - ``cyclopts.choices``
-     - ``gray58``
-     - The ``[choices: ...]`` annotation.
-   * - ``cyclopts.env_var``
-     - ``gray58``
-     - The ``[env var: ...]`` annotation.
-   * - ``cyclopts.border``
-     - ``none``
-     - The help panel border.
-   * - ``cyclopts.usage``
-     - ``bold``
-     - The ``Usage:`` line.
+     - Default
+   * - ``"cyclopts.name"``
+     - parameter and command names
+     - ``"cyan"``
+   * - ``"cyclopts.required_marker"``
+     - the asterisk marker for required parameters
+     - ``"red bold"``
+   * - ``"cyclopts.required"``
+     - the "[required]" annotation
+     - ``"red"``
+   * - ``"cyclopts.default"``
+     - the "[default: ...]" annotation
+     - ``"gray58"``
+   * - ``"cyclopts.choices"``
+     - the "[choices: ...]" annotation
+     - ``"gray58"``
+   * - ``"cyclopts.env_var"``
+     - the "[env var: ...]" annotation
+     - ``"gray58"``
+   * - ``"cyclopts.border"``
+     - the help panel border
+     - ``"none"``
+   * - ``"cyclopts.usage"``
+     - the "Usage:" line
+     - ``"bold"``
 
 Override any key to match your own palette:
 
@@ -374,8 +374,8 @@ Per-Group Styles
 ^^^^^^^^^^^^^^^^
 
 To restyle a single panel, give its :class:`~cyclopts.Group` a
-:attr:`~cyclopts.Group.theme`. It accepts the same ``cyclopts.*`` keys as the
-app-wide styles (as a mapping or a :class:`~rich.theme.Theme`) and layers them on
+:attr:`~cyclopts.Group.theme`. It accepts the same ``"cyclopts."``-prefixed keys as
+the app-wide styles (as a mapping or a :class:`~rich.theme.Theme`) and layers them on
 top for just that group's panel, leaving every other panel on the app's styles:
 
 .. code-block:: python


### PR DESCRIPTION
This PR builds on #916 with several changes intended to improve readability of the new documentation of the named styles. The changes are as follows:

*   In the table of styles:
    *   Move the column of default values to the end.
    *   In the columns of names and defaults, add quotation marks to string literals. (This matches how string literals appear in the [table](https://github.com/BrianPugh/cyclopts/blob/c8df0e40e786732c2915f40fbd9628a4047cc49c/docs/source/api.rst?plain=1#L654) of values of `App.result_action`.
    *   In the "Applies to" column, capitalize and punctuate as phrases rather than sentences, change literal text to quoted text, and clarify the asterisk marker.
*   Edit a subsequent reference to the prefix.

The table appears as follows before and after this PR, respectively:

<img width="626" height="306" alt="Color style table, previous" src="https://github.com/user-attachments/assets/67b64b15-12be-4f08-9cae-afe35ae99692" />

<img width="665" height="306" alt="Color style table, revised" src="https://github.com/user-attachments/assets/d71d2b2f-6426-4a66-a5f8-76fe6ba93303" />

A further improvement would be to reorder the rows of the table either alphabetically by style name or by order of appearance in rendered help (i.e., usage, border, name, etc.).