### PR TITLE
Interactive shell no longer exits on Ctrl-C or malformed input

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2652,14 +2652,16 @@ class App:
         quit: None | str | Iterable[str] = None,
         dispatcher: Dispatcher | None = None,
         console: "Console | None" = None,
-        error_console: "Console | None" = None,
         exit_on_error: bool = False,
         result_action: ResultAction | None = None,
+        error_console: "Console | None" = None,
         **kwargs,
     ) -> None:
         """Create a blocking, interactive shell.
 
         All registered commands can be executed in the shell.
+        Ctrl-C at the prompt discards the current line; Ctrl-C during a command
+        returns to the prompt unless :attr:`App.suppress_keyboard_interrupt` is :obj:`False`.
 
         Parameters
         ----------
@@ -2683,8 +2685,6 @@ class App:
             async commands itself (e.g. via :func:`asyncio.run`).
         console: Console | None
             Rich Console to use for output. If :obj:`None`, uses :attr:`App.console`.
-        error_console: Console | None
-            Rich Console to use for error messages and tracebacks. If :obj:`None`, uses :attr:`App.error_console`.
         exit_on_error: bool
             Whether to call ``sys.exit`` on parsing errors. Defaults to :obj:`False`.
         result_action: ResultAction | None
@@ -2692,6 +2692,8 @@ class App:
             Defaults to ``"print_non_int_return_int_as_exit_code"`` which prints non-int results
             and returns int/bool as exit codes without calling sys.exit.
             If :obj:`None`, inherits from :attr:`App.result_action`.
+        error_console: Console | None
+            Rich Console to use for error messages and tracebacks. If :obj:`None`, uses :attr:`App.error_console`.
         `**kwargs`
             Get passed along to :meth:`parse_args`.
         """
@@ -2719,49 +2721,43 @@ class App:
             overrides["result_action"] = result_action
         if console is not None:
             overrides["_console"] = console
+        if error_console is not None:
+            overrides["_error_console"] = error_console
 
-        if error_console is None:
-            error_console = self.error_console
+        with self.app_stack([], overrides):
+            while True:
+                try:
+                    user_input = input(prompt)
+                except EOFError:  # pragma: no cover
+                    break
+                except KeyboardInterrupt:
+                    print()
+                    continue
 
-        while True:
-            try:
-                user_input = input(prompt)
-            except EOFError:  # pragma: no cover
-                break
-            except KeyboardInterrupt:
-                print()
-                continue
+                try:
+                    tokens = normalize_tokens(user_input)
+                except ValueError as e:
+                    self.error_console.print(CycloptsPanel(CycloptsError(msg=str(e))))
+                    continue
+                if not tokens:
+                    continue
+                if tokens[0] in quit:
+                    break
 
-            try:
-                tokens = normalize_tokens(user_input)
-            except ValueError as e:
-                error_console.print(CycloptsPanel(CycloptsError(msg=str(e))))
-                continue
-            if not tokens:
-                continue
-            if tokens[0] in quit:
-                break
-
-            try:
-                with self.app_stack(tokens, overrides):
-                    command, bound, ignored = self.parse_args(
-                        tokens,
-                        console=console,
-                        error_console=error_console,
-                        exit_on_error=exit_on_error,
-                        **kwargs,
-                    )
-                    result = dispatcher(command, bound, ignored)
-                    self._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
-            except CycloptsError:
-                # Upstream ``parse_args`` already printed the error
-                pass
-            except KeyboardInterrupt:
-                if not self.suppress_keyboard_interrupt:
-                    raise
-                print()
-            except Exception:
-                error_console.print(traceback.format_exc(), markup=False, highlight=False)
+                try:
+                    with self.app_stack(tokens):
+                        command, bound, ignored = self.parse_args(tokens, exit_on_error=exit_on_error, **kwargs)
+                        result = dispatcher(command, bound, ignored)
+                        self._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
+                except CycloptsError:
+                    # Upstream ``parse_args`` already printed the error
+                    pass
+                except KeyboardInterrupt:
+                    if not self.suppress_keyboard_interrupt:
+                        raise
+                    print()
+                except Exception:
+                    self.error_console.print(traceback.format_exc(), markup=False, highlight=False, soft_wrap=True)
 
     def _handle_result_action(self, result: Any, fallback: ResultAction = "print_non_int_sys_exit") -> Any:
         """Handle command result based on result_action.

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -57,11 +57,6 @@ from cyclopts.utils import (
     to_tuple_converter,
 )
 
-if sys.version_info < (3, 11):  # pragma: no cover
-    pass
-else:  # pragma: no cover
-    pass
-
 with suppress(ImportError):
     # By importing, makes things like the arrow-keys work.
     # Not available on windows
@@ -2657,6 +2652,7 @@ class App:
         quit: None | str | Iterable[str] = None,
         dispatcher: Dispatcher | None = None,
         console: "Console | None" = None,
+        error_console: "Console | None" = None,
         exit_on_error: bool = False,
         result_action: ResultAction | None = None,
         **kwargs,
@@ -2687,6 +2683,8 @@ class App:
             async commands itself (e.g. via :func:`asyncio.run`).
         console: Console | None
             Rich Console to use for output. If :obj:`None`, uses :attr:`App.console`.
+        error_console: Console | None
+            Rich Console to use for error messages and tracebacks. If :obj:`None`, uses :attr:`App.error_console`.
         exit_on_error: bool
             Whether to call ``sys.exit`` on parsing errors. Defaults to :obj:`False`.
         result_action: ResultAction | None
@@ -2722,13 +2720,23 @@ class App:
         if console is not None:
             overrides["_console"] = console
 
+        if error_console is None:
+            error_console = self.error_console
+
         while True:
             try:
                 user_input = input(prompt)
             except EOFError:  # pragma: no cover
                 break
+            except KeyboardInterrupt:
+                print()
+                continue
 
-            tokens = normalize_tokens(user_input)
+            try:
+                tokens = normalize_tokens(user_input)
+            except ValueError as e:
+                error_console.print(CycloptsPanel(CycloptsError(msg=str(e))))
+                continue
             if not tokens:
                 continue
             if tokens[0] in quit:
@@ -2737,15 +2745,23 @@ class App:
             try:
                 with self.app_stack(tokens, overrides):
                     command, bound, ignored = self.parse_args(
-                        tokens, console=console, exit_on_error=exit_on_error, **kwargs
+                        tokens,
+                        console=console,
+                        error_console=error_console,
+                        exit_on_error=exit_on_error,
+                        **kwargs,
                     )
                     result = dispatcher(command, bound, ignored)
                     self._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
             except CycloptsError:
                 # Upstream ``parse_args`` already printed the error
                 pass
+            except KeyboardInterrupt:
+                if not self.suppress_keyboard_interrupt:
+                    raise
+                print()
             except Exception:
-                print(traceback.format_exc())
+                error_console.print(traceback.format_exc(), markup=False, highlight=False)
 
     def _handle_result_action(self, result: Any, fallback: ResultAction = "print_non_int_sys_exit") -> Any:
         """Handle command result based on result_action.

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -57,10 +57,12 @@ from cyclopts.utils import (
     to_tuple_converter,
 )
 
-with suppress(ImportError):
+try:
     # By importing, makes things like the arrow-keys work.
+    import readline
+except ImportError:  # pragma: no cover
     # Not available on windows
-    import readline  # noqa: F401
+    readline = None
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -2660,8 +2662,9 @@ class App:
         """Create a blocking, interactive shell.
 
         All registered commands can be executed in the shell.
-        Ctrl-C at the prompt discards the current line; Ctrl-C during a command
-        returns to the prompt unless :attr:`App.suppress_keyboard_interrupt` is :obj:`False`.
+        Ctrl-C clears a partially typed line; on an empty line it exits the shell.
+        Ctrl-C during a command returns to the prompt unless
+        :attr:`App.suppress_keyboard_interrupt` is :obj:`False`.
 
         Parameters
         ----------
@@ -2724,6 +2727,10 @@ class App:
         if error_console is not None:
             overrides["_error_console"] = error_console
 
+        # libedit (macOS) keeps reporting the previous line from ``get_line_buffer`` until
+        # new text is typed, so an interrupted buffer equal to the last seen line means the
+        # line was actually empty. GNU readline reports "" directly.
+        previous_line = ""
         with self.app_stack([], overrides):
             while True:
                 try:
@@ -2732,7 +2739,12 @@ class App:
                     break
                 except KeyboardInterrupt:
                     print()
+                    line_buffer = readline.get_line_buffer() if readline else ""
+                    if line_buffer in ("", previous_line):
+                        break
+                    previous_line = line_buffer
                     continue
+                previous_line = user_input + "\n"
 
                 try:
                     tokens = normalize_tokens(user_input)

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2739,7 +2739,9 @@ class App:
                     break
                 except KeyboardInterrupt:
                     print()
-                    line_buffer = readline.get_line_buffer() if readline else ""
+                    # typeshed guards ``get_line_buffer`` behind ``sys.platform != "win32"``;
+                    # ``readline`` is ``None`` on Windows anyway, so this branch never runs there.
+                    line_buffer = readline.get_line_buffer() if readline else ""  # pyright: ignore[reportAttributeAccessIssue]
                     if line_buffer in ("", previous_line):
                         break
                     previous_line = line_buffer

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2756,20 +2756,23 @@ class App:
                 if tokens[0] in quit:
                     break
 
-                try:
-                    with self.app_stack(tokens):
+                # Keep the exception handlers inside the token ``app_stack`` context so that
+                # context-sensitive settings (e.g. ``error_console``) resolve from the invoked
+                # subcommand rather than the root app.
+                with self.app_stack(tokens):
+                    try:
                         command, bound, ignored = self.parse_args(tokens, exit_on_error=exit_on_error, **kwargs)
                         result = dispatcher(command, bound, ignored)
                         self._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
-                except CycloptsError:
-                    # Upstream ``parse_args`` already printed the error
-                    pass
-                except KeyboardInterrupt:
-                    if not self.suppress_keyboard_interrupt:
-                        raise
-                    print()
-                except Exception:
-                    self.error_console.print(traceback.format_exc(), markup=False, highlight=False, soft_wrap=True)
+                    except CycloptsError:
+                        # Upstream ``parse_args`` already printed the error
+                        pass
+                    except KeyboardInterrupt:
+                        if not self.suppress_keyboard_interrupt:
+                            raise
+                        print()
+                    except Exception:
+                        self.error_console.print(traceback.format_exc(), markup=False, highlight=False, soft_wrap=True)
 
     def _handle_result_action(self, result: Any, fallback: ResultAction = "print_non_int_sys_exit") -> Any:
         """Handle command result based on result_action.

--- a/tests/test_interactive_shell.py
+++ b/tests/test_interactive_shell.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cyclopts import App
 
 
@@ -309,3 +311,84 @@ def test_interactive_shell_no_sys_exit_on_command(app, mocker, console):
     assert cmd1_called == 1
     assert cmd2_called == 1
     assert cmd3_called == 1
+
+
+def test_interactive_shell_unbalanced_quote(app, mocker, console):
+    """A tokenization error should be reported and the shell should keep running."""
+    mocker.patch("cyclopts.core.input", side_effect=['foo "1', "foo 2", "quit"])
+
+    calls = []
+
+    @app.command
+    def foo(a: int):
+        calls.append(a)
+
+    with console.capture() as capture:
+        app.interactive_shell(error_console=console)
+
+    assert calls == [2]
+    assert capture.get() == (
+        "╭─ Error ────────────────────────────────────────────────────────────╮\n"
+        "│ No closing quotation                                               │\n"
+        "╰────────────────────────────────────────────────────────────────────╯\n"
+    )
+
+
+def test_interactive_shell_keyboard_interrupt_at_prompt(app, mocker):
+    """Ctrl-C at the prompt should abandon the line, not exit the shell."""
+    mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
+
+    calls = []
+
+    @app.command
+    def foo(a: int):
+        calls.append(a)
+
+    app.interactive_shell()
+
+    assert calls == [1]
+
+
+def test_interactive_shell_keyboard_interrupt_in_command(app, mocker):
+    """Ctrl-C during a command should return to the prompt when suppress_keyboard_interrupt is set."""
+    mocker.patch("cyclopts.core.input", side_effect=["foo", "bar", "quit"])
+
+    calls = []
+
+    @app.command
+    def foo():
+        raise KeyboardInterrupt
+
+    @app.command
+    def bar():
+        calls.append("bar")
+
+    app.interactive_shell()
+    assert calls == ["bar"]
+
+
+def test_interactive_shell_keyboard_interrupt_in_command_not_suppressed(mocker):
+    mocker.patch("cyclopts.core.input", side_effect=["foo", "quit"])
+    app = App(suppress_keyboard_interrupt=False)
+
+    @app.command
+    def foo():
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        app.interactive_shell()
+
+
+def test_interactive_shell_exception_goes_to_error_console(app, mocker, console):
+    mocker.patch("cyclopts.core.input", side_effect=["foo", "quit"])
+
+    @app.command
+    def foo():
+        raise RuntimeError("boom")
+
+    with console.capture() as capture:
+        app.interactive_shell(error_console=console)
+
+    actual = capture.get()
+    assert "Traceback (most recent call last):" in actual
+    assert "RuntimeError: boom" in actual

--- a/tests/test_interactive_shell.py
+++ b/tests/test_interactive_shell.py
@@ -334,9 +334,10 @@ def test_interactive_shell_unbalanced_quote(app, mocker, console):
     )
 
 
-def test_interactive_shell_keyboard_interrupt_at_prompt(app, mocker):
-    """Ctrl-C at the prompt should abandon the line, not exit the shell."""
+def test_interactive_shell_keyboard_interrupt_clears_typed_line(app, mocker):
+    """Ctrl-C with text on the line should discard the line, not exit the shell."""
     mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
+    mocker.patch("cyclopts.core.readline.get_line_buffer", return_value="foo 5")
 
     calls = []
 
@@ -347,6 +348,57 @@ def test_interactive_shell_keyboard_interrupt_at_prompt(app, mocker):
     app.interactive_shell()
 
     assert calls == [1]
+
+
+def test_interactive_shell_keyboard_interrupt_empty_line_exits(app, mocker):
+    mock_input = mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
+    mocker.patch("cyclopts.core.readline.get_line_buffer", return_value="")
+
+    calls = []
+
+    @app.command
+    def foo(a: int):
+        calls.append(a)
+
+    app.interactive_shell()
+
+    assert calls == []
+    assert mock_input.call_count == 1
+
+
+def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_interrupt(app, mocker):
+    """Libedit reports the previous line until new text is typed; a repeat means the line was empty."""
+    mock_input = mocker.patch(
+        "cyclopts.core.input", side_effect=["foo 1", KeyboardInterrupt(), KeyboardInterrupt(), "quit"]
+    )
+    mocker.patch("cyclopts.core.readline.get_line_buffer", side_effect=["foo 2", "foo 2"])
+
+    calls = []
+
+    @app.command
+    def foo(a: int):
+        calls.append(a)
+
+    app.interactive_shell()
+
+    assert calls == [1]
+    assert mock_input.call_count == 3
+
+
+def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_line(app, mocker):
+    mock_input = mocker.patch("cyclopts.core.input", side_effect=["foo 1", KeyboardInterrupt(), "quit"])
+    mocker.patch("cyclopts.core.readline.get_line_buffer", return_value="foo 1\n")
+
+    calls = []
+
+    @app.command
+    def foo(a: int):
+        calls.append(a)
+
+    app.interactive_shell()
+
+    assert calls == [1]
+    assert mock_input.call_count == 2
 
 
 def test_interactive_shell_keyboard_interrupt_in_command(app, mocker):

--- a/tests/test_interactive_shell.py
+++ b/tests/test_interactive_shell.py
@@ -392,3 +392,21 @@ def test_interactive_shell_exception_goes_to_error_console(app, mocker, console)
     actual = capture.get()
     assert "Traceback (most recent call last):" in actual
     assert "RuntimeError: boom" in actual
+
+
+def test_interactive_shell_subcommand_error_console(mocker, console):
+    """A subcommand's own error_console must not be overridden by the root's."""
+    mocker.patch("cyclopts.core.input", side_effect=["sub foo notanint", "quit"])
+
+    root = App()
+    sub = App(name="sub", error_console=console)
+    root.command(sub)
+
+    @sub.command
+    def foo(a: int):
+        pass
+
+    with console.capture() as capture:
+        root.interactive_shell()
+
+    assert "Error" in capture.get()

--- a/tests/test_interactive_shell.py
+++ b/tests/test_interactive_shell.py
@@ -337,7 +337,7 @@ def test_interactive_shell_unbalanced_quote(app, mocker, console):
 def test_interactive_shell_keyboard_interrupt_clears_typed_line(app, mocker):
     """Ctrl-C with text on the line should discard the line, not exit the shell."""
     mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
-    mocker.patch("cyclopts.core.readline.get_line_buffer", return_value="foo 5")
+    mocker.patch("cyclopts.core.readline").get_line_buffer.return_value = "foo 5"
 
     calls = []
 
@@ -352,7 +352,7 @@ def test_interactive_shell_keyboard_interrupt_clears_typed_line(app, mocker):
 
 def test_interactive_shell_keyboard_interrupt_empty_line_exits(app, mocker):
     mock_input = mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
-    mocker.patch("cyclopts.core.readline.get_line_buffer", return_value="")
+    mocker.patch("cyclopts.core.readline").get_line_buffer.return_value = ""
 
     calls = []
 
@@ -371,7 +371,7 @@ def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_interru
     mock_input = mocker.patch(
         "cyclopts.core.input", side_effect=["foo 1", KeyboardInterrupt(), KeyboardInterrupt(), "quit"]
     )
-    mocker.patch("cyclopts.core.readline.get_line_buffer", side_effect=["foo 2", "foo 2"])
+    mocker.patch("cyclopts.core.readline").get_line_buffer.side_effect = ["foo 2", "foo 2"]
 
     calls = []
 
@@ -387,7 +387,7 @@ def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_interru
 
 def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_line(app, mocker):
     mock_input = mocker.patch("cyclopts.core.input", side_effect=["foo 1", KeyboardInterrupt(), "quit"])
-    mocker.patch("cyclopts.core.readline.get_line_buffer", return_value="foo 1\n")
+    mocker.patch("cyclopts.core.readline").get_line_buffer.return_value = "foo 1\n"
 
     calls = []
 


### PR DESCRIPTION
## Interactive shell no longer exits on Ctrl-C or malformed input

`App.interactive_shell` died on several routine inputs. Ctrl-C raised `KeyboardInterrupt` out of the loop, and an unbalanced quote (`foo "bar`) raised `ValueError` from `shlex` before the try block.

- Ctrl-C now behaves like a normal REPL: with text on the line it clears the line; on an empty line it exits the shell (same as Ctrl-D). During a command it returns to the prompt, unless `App.suppress_keyboard_interrupt` is `False`, in which case it still propagates.
- Telling "empty line" from "text typed" uses `readline.get_line_buffer()`. libedit (macOS) keeps reporting the previous line until new text is typed, so a buffer equal to the last seen line is treated as empty. GNU readline reports `""` directly. Both verified through a pty. Without a `readline` module, Ctrl-C exits.
- Unbalanced quotes print a standard Cyclopts error panel and reprompt.
- `error_console` is now an explicit `interactive_shell` parameter (appended after `result_action`, so positional callers are unaffected). The whole loop runs inside one `app_stack` override context so `console`/`error_console` resolve consistently, including for subcommands with their own `error_console`. Tracebacks from uncaught command exceptions print there instead of stdout.
- Removed a dead `if sys.version_info` block left over from the trio work.

Follow-up (separate PR): raise a `CycloptsError` from `normalize_tokens` so bad quoting is handled uniformly by `parse_args`, `__call__`, and the shell, honoring `error_formatter`/`exit_on_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
