### PR TITLE
ci: fix pre-commit cache key so hook environments are actually reused

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,13 @@ jobs:
 
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
-        run: uv python install ${{ matrix.python-version }}
+        run: |
+          uv python install ${{ matrix.python-version }}
+          # Exact patch version (e.g. 3.11.13) for the pre-commit cache key. pre-commit's
+          # hook environments embed the interpreter path, so the cache must be keyed on the
+          # resolved interpreter, not just the "3.11" matrix value; otherwise a restored
+          # environment fails pre-commit's health check and every hook is reinstalled.
+          echo "version=$("$(uv python find ${{ matrix.python-version }})" -c 'import platform; print(platform.python_version())')" >> "$GITHUB_OUTPUT"
 
       - name: Install library
         run: uv sync --all-extras
@@ -70,7 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit/
-          key: pre-commit-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ runner.os }}-py${{ steps.setup-python.outputs.version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Pre-commit run
         run: uv run pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
## Problem

The pre-commit cache has never worked on any runner. The cache key is:

```
key: pre-commit-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
```

`env.pythonLocation` is only set by `actions/setup-python`, but this workflow installs Python with `uv python install`, so that segment is always **empty**. All five Python jobs (3.10–3.14) on a given OS therefore share a single cache key like `pre-commit-Windows--<hash>` (note the double dash).

The first job to finish saves its hook environments (built against one interpreter path). Every other job restores that cache, but pre-commit's environment health-check sees a different interpreter path and **reinstalls all six hook environments** — and because the key already exists, no job ever re-saves. So the cache is restored but never actually used.

This is visible in the logs: every job on every OS prints `Installing environment for …` six times, even on a cache hit.

## Impact

On Windows this costs ~126s per job (process spawning + filesystem ops are slow there); `Pre-commit run` takes ~252s on Windows vs ~47s on Ubuntu. The same wasted reinstalls happen on Linux/macOS too, just cheaply enough to go unnoticed.

## Fix

Key the cache on the **exact resolved Python patch version** (e.g. `3.11.13`) instead of the empty `env.pythonLocation`. The `Set up python` step now emits that as an output, and the key becomes:

```
key: pre-commit-${{ runner.os }}-py${{ steps.setup-python.outputs.version }}-${{ hashFiles('.pre-commit-config.yaml') }}
```

Now each `(os, python, config)` combination gets its own cache that stays valid across runs (the interpreter path matches, so the health-check passes and hooks are reused), and it auto-invalidates when a Python patch bump changes the interpreter path.

## Notes

- The **first** run per key after this lands is still a clean miss → install → save; the speedup shows up on subsequent runs. Merging to `main` populates the default-branch caches that all PRs inherit.
- Applies to every runner in the matrix, not just Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)