### PR TITLE
ci: make codecov statuses informational (non-blocking)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,9 +6,13 @@ coverage:
         # project coverage decrease by more than 2%
         target: auto
         threshold: 2%
+        # Report coverage changes without failing the check.
+        informational: true
     patch:
       default:
         # Be tolerant on code coverage diff on PRs to limit
         # noisy red coverage status on github PRs.
         target: auto
         threshold: 20%
+        # Report coverage changes without failing the check.
+        informational: true


### PR DESCRIPTION
Sets `informational: true` on both the `project` and `patch` coverage statuses in `.codecov.yml`.

Codecov still posts the coverage status and PR comment (so the signal is preserved), but insufficient coverage now reads as a warning instead of a failing check that blocks merge. This also stops spurious red X's from coverage-upload flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)