### PR TITLE
fix: honor subcommand-level configuration (end_of_options_delimiter, error settings, backend, result_action)

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -132,6 +132,16 @@ def _get_version_command(app):
         return app.version_print
 
 
+#: Attributes controlling how a parse error is reported. Resolved together so the invoked
+#: command's scope is applied consistently (see ``App._handle_parse_error``).
+_ERROR_REPORT_ATTRIBUTES = ("print_error", "exit_on_error", "help_on_error", "verbose", "error_formatter")
+
+
+def _resolve_error_report_settings(app_stack: AppStack) -> dict[str, Any]:
+    """Resolve the error-reporting settings from ``app_stack`` (unset values stay ``None``)."""
+    return {name: app_stack.resolve(name) for name in _ERROR_REPORT_ATTRIBUTES}
+
+
 def _apply_parent_defaults_to_app(app: "App", parent_app: "App") -> None:
     """Apply parent app's group defaults to app if not already set.
 
@@ -1744,6 +1754,12 @@ class App:
                     e.command_chain = command_chain
                 if e.console is None:
                     e.console = command_app.error_console
+                # Resolve error-reporting settings now, while the invoked command's context
+                # (full command chain + propagated overrides) is live on ``command_app.app_stack``.
+                # ``_handle_parse_error`` runs after this context is torn down, where ``self`` (the
+                # entry app) can no longer see subcommand-level settings (issue #933 family).
+                if e._error_report_settings is None:
+                    e._error_report_settings = _resolve_error_report_settings(command_app.app_stack)
                 raise
 
         return command, bound, unused_tokens, ignored, argument_collection
@@ -1854,10 +1870,15 @@ class App:
 
     def _handle_parse_error(self, e: CycloptsError, tokens: list[str]) -> NoReturn:
         """Print ``e`` according to the resolved error settings, then exit or re-raise it."""
-        print_error = self.app_stack.resolve("print_error")
-        exit_on_error = self.app_stack.resolve("exit_on_error")
-        help_on_error = self.app_stack.resolve("help_on_error")
-        verbose = self.app_stack.resolve("verbose")
+        # ``error_report_settings`` is resolved from the invoked command's app-stack while its
+        # context is live (see ``_parse_known_args``). It is ``None`` only for errors that occur
+        # before a command is resolved (e.g. tokenization), for which ``self`` (the entry app) is
+        # the correct scope.
+        settings = e._error_report_settings or _resolve_error_report_settings(self.app_stack)
+        print_error = settings["print_error"]
+        exit_on_error = settings["exit_on_error"]
+        help_on_error = settings["help_on_error"]
+        verbose = settings["verbose"]
 
         e.verbose = verbose if verbose is not None else False
         e.root_input_tokens = tokens
@@ -1866,7 +1887,7 @@ class App:
         if help_on_error if help_on_error is not None else False:
             self.help_print(tokens, console=e.console)
         if print_error if print_error is not None else True:
-            resolved_error_formatter = self.app_stack.resolve("error_formatter")
+            resolved_error_formatter = settings["error_formatter"]
             if resolved_error_formatter is not None:
                 e.console.print(resolved_error_formatter(e))
             else:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1618,6 +1618,28 @@ class App:
 
         return command, bound, unused_tokens, ignored
 
+    def _resolve_invoked_command(self, tokens: list[str]) -> tuple[tuple[str, ...], "App", list[str]]:
+        """Resolve the invoked command: the deepest executing app, its chain, and the leftover tokens.
+
+        Trailing help/version pseudo-commands are trimmed so the result is the real command the
+        user targeted. This is the canonical "which command am I running" answer; resolve any
+        command-scoped configuration (delimiter, error settings, backend, result_action, ...) from
+        the returned app's ``app_stack`` rather than ``self.app_stack`` (the entry app's per-app
+        stack never contains the subcommand -- see the #933 family).
+        """
+        command_chain, execution_apps, unused_tokens = self.parse_commands(tokens, include_parent_meta=False)
+        # We don't want the command_app to be the version/help handler; we handle those specially.
+        with suppress(IndexError):
+            # When users provide multiple flags (e.g., "myapp cmd --help --help"), the parser may
+            # treat trailing help/version flags as commands in the chain. Remove ALL such trailing
+            # commands and keep command_chain synchronized with execution_apps.
+            while command_chain and command_chain[-1] in set(
+                execution_apps[-2].help_flags + execution_apps[-2].version_flags  # pyright: ignore[reportOperatorIssue]
+            ):
+                execution_apps = execution_apps[:-1]
+                command_chain = command_chain[:-1]
+        return command_chain, execution_apps[-1], unused_tokens
+
     def _parse_known_args(
         self,
         tokens: None | str | Iterable[str] = None,
@@ -1631,29 +1653,10 @@ class App:
 
         meta_parent = self
 
-        # We need both versions of the apps list:
-        # 1. apps_for_context (with parent metas) - for setting up the app_stack context
-        # 2. execution_apps (without parent metas) - for determining the actual execution command
-        # These can differ when parse_commands is called from a meta app, so we must
-        # call parse_commands twice. This is not inefficient since the parsing is fast.
+        # apps_for_context (with parent metas) sets up the app_stack context; it can differ from
+        # the execution chain when parse_commands is called from a meta app.
         _, apps_for_context, _ = self.parse_commands(tokens, include_parent_meta=True)
-        command_chain, execution_apps, unused_tokens = self.parse_commands(tokens, include_parent_meta=False)
-
-        # We don't want the command_app to be the version/help handler; we handle those specially
-        command_app = execution_apps[-1]
-        with suppress(IndexError):
-            # Remove trailing help/version commands from the execution chain.
-            # When users provide multiple flags (e.g., "myapp cmd --help --help"), the parser
-            # may treat trailing help/version flags as commands in the chain. We must remove ALL
-            # such trailing commands and keep command_chain synchronized with execution_apps.
-            while command_chain and command_chain[-1] in set(
-                execution_apps[-2].help_flags + execution_apps[-2].version_flags  # pyright: ignore[reportOperatorIssue]
-            ):
-                execution_apps = execution_apps[:-1]
-                command_chain = command_chain[:-1]
-
-        command_app = execution_apps[-1]
-        del execution_apps  # Always use AppStack from here-on.
+        command_chain, command_app, unused_tokens = self._resolve_invoked_command(tokens)
 
         ignored: dict[str, Any] = {}
 
@@ -1994,10 +1997,16 @@ class App:
                 end_of_options_delimiter=end_of_options_delimiter,
             )
 
-            resolved_backend = cast(Literal["asyncio", "trio"], self.app_stack.resolve("backend", fallback="asyncio"))
+            # ``backend``/``result_action`` are command-scoped: resolve them from the invoked
+            # command's app-stack, not ``self`` (the entry app), so a subcommand-level value is
+            # honored (#933 family).
+            command_app = self._resolve_invoked_command(tokens)[1]
+            resolved_backend = cast(
+                Literal["asyncio", "trio"], command_app.app_stack.resolve("backend", fallback="asyncio")
+            )
             try:
                 result = _run_maybe_async_command(command, bound, resolved_backend)
-                return self._handle_result_action(result)
+                return self._handle_result_action(result, command_app=command_app)
             except KeyboardInterrupt:
                 if self.suppress_keyboard_interrupt:
                     sys.exit(130)  # Use the same exit code as Python's default KeyboardInterrupt handling.
@@ -2123,6 +2132,8 @@ class App:
                 console=console,
                 end_of_options_delimiter=end_of_options_delimiter,
             )
+            # ``result_action`` is command-scoped (#933 family); resolve from the invoked command.
+            command_app = self._resolve_invoked_command(tokens)[1]
 
             try:
                 if inspect.iscoroutinefunction(command):
@@ -2130,7 +2141,7 @@ class App:
                 else:
                     result = command(*bound.args, **bound.kwargs)
 
-                return self._handle_result_action(result)
+                return self._handle_result_action(result, command_app=command_app)
             except KeyboardInterrupt:
                 if self.suppress_keyboard_interrupt:
                     sys.exit(130)  # Use the same exit code as Python's default KeyboardInterrupt handling.
@@ -2753,8 +2764,14 @@ class App:
         if isinstance(quit, str):
             quit = [quit]
 
+        # Set to the invoked command each iteration so ``default_dispatcher`` can scope
+        # ``backend`` to it (#933 family). The public ``dispatcher`` signature is fixed, so this
+        # is threaded via closure rather than an argument.
+        invoked_command_app: App | None = None
+
         def default_dispatcher(command, bound, _):
-            resolved_backend = cast(Literal["asyncio", "trio"], self.app_stack.resolve("backend", fallback="asyncio"))
+            scope = invoked_command_app or self
+            resolved_backend = cast(Literal["asyncio", "trio"], scope.app_stack.resolve("backend", fallback="asyncio"))
             return _run_maybe_async_command(command, bound, resolved_backend)
 
         if dispatcher is None:
@@ -2807,8 +2824,13 @@ class App:
                 with self.app_stack(tokens):
                     try:
                         command, bound, ignored = self.parse_args(tokens, **kwargs)
+                        invoked_command_app = self._resolve_invoked_command(tokens)[1]
                         result = dispatcher(command, bound, ignored)
-                        self._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
+                        self._handle_result_action(
+                            result,
+                            fallback="print_non_int_return_int_as_exit_code",
+                            command_app=invoked_command_app,
+                        )
                     except CycloptsError:
                         # Upstream ``parse_args`` already printed the error
                         pass
@@ -2819,7 +2841,9 @@ class App:
                     except Exception:
                         self.error_console.print(traceback.format_exc(), markup=False, highlight=False, soft_wrap=True)
 
-    def _handle_result_action(self, result: Any, fallback: ResultAction = "print_non_int_sys_exit") -> Any:
+    def _handle_result_action(
+        self, result: Any, fallback: ResultAction = "print_non_int_sys_exit", *, command_app: "App | None" = None
+    ) -> Any:
         """Handle command result based on result_action.
 
         Parameters
@@ -2828,6 +2852,11 @@ class App:
             The command's return value.
         fallback : ResultAction
             The fallback result_action if none is configured. Defaults to "print_non_int_sys_exit".
+        command_app : App | None
+            The invoked command, whose ``app_stack`` scopes ``result_action`` (and the output
+            console). ``result_action`` is command-scoped: the entry app's per-app stack cannot
+            see a subcommand's value (#933 family). Falls back to ``self`` when not provided
+            (e.g. errors raised before a command is resolved).
 
         Returns
         -------
@@ -2836,12 +2865,13 @@ class App:
         """
         from cyclopts._result_action import handle_result_action
 
+        scope = command_app or self
         action = cast(
             ResultAction,
-            self.app_stack.resolve("result_action", fallback=fallback),
+            scope.app_stack.resolve("result_action", fallback=fallback),
         )
 
-        return handle_result_action(result, action, lambda x: self.console.print(x))
+        return handle_result_action(result, action, lambda x: scope.console.print(x))
 
     def update(self, app: "App"):
         """Copy over all commands from another :class:`App`.

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1650,7 +1650,11 @@ class App:
         with self.app_stack(apps_for_context):
             config: tuple[Callable, ...] = command_app.app_stack.resolve("_config") or ()
             config = tuple(partial(x, command_app, command_chain) for x in config)
-            end_of_options_delimiter = self.app_stack.resolve("end_of_options_delimiter", fallback="--")
+            # Resolve from ``command_app.app_stack`` (like ``_config`` above), not
+            # ``self.app_stack``: ``AppStack`` is per-app, and only the resolved
+            # command's stack contains the full command chain. Resolving from the
+            # root app's stack ignores a subcommand-level setting (issue #933).
+            end_of_options_delimiter = command_app.app_stack.resolve("end_of_options_delimiter", fallback="--")
 
             # Special flags (help/version) get intercepted by the root app.
             # Special flags are allows to be **anywhere** in the token stream.

--- a/cyclopts/exceptions.py
+++ b/cyclopts/exceptions.py
@@ -146,6 +146,13 @@ class CycloptsError(Exception):
     console: Optional["Console"] = field(default=None, kw_only=True)
     """:class:`~rich.console.Console` to display runtime errors."""
 
+    # Internal: error-reporting settings (``print_error``, ``exit_on_error``, ...) resolved from
+    # the invoked command's app-stack while its context is live. ``App._handle_parse_error``
+    # consumes this so a subcommand-level setting is honored even though the handler runs after the
+    # command context is torn down (per-app ``AppStack`` cannot see the subcommand from the root
+    # app). Underscore-prefixed to stay out of the public API surface.
+    _error_report_settings: dict[str, Any] | None = field(default=None, kw_only=True)
+
     def _resolved_msg(self) -> "Text":
         """Resolve ``self.msg`` (str | Text) into a Rich ``Text`` instance.
 

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 import pytest
 
-from cyclopts import Parameter
+from cyclopts import App, Parameter
 from cyclopts.exceptions import (
     ArgumentOrderError,
     CoercionError,
@@ -771,6 +771,45 @@ def test_disabled_double_hyphen_end_of_options_delimiter_on_subcommand(app):
         ["k", "exec", "pod", "--", "sh", "-c", "id"], print_error=False, exit_on_error=False
     )
     assert actual_bind.args == ("exec", "pod", "--", "sh", "-c", "id")
+
+
+def test_end_of_options_delimiter_custom_on_subcommand(app, assert_parse_args):
+    """A subcommand may define its own non-default delimiter (issue #933).
+
+    ``AND`` is the delimiter for ``sub``, so ``--2`` after it is forced positional
+    and a literal ``--`` is just an ordinary leading-hyphen value.
+    """
+
+    @app.command(end_of_options_delimiter="AND")
+    def sub(a: int, b: Annotated[str, Parameter(allow_leading_hyphen=True)], c: tuple[int, int]):
+        pass
+
+    assert_parse_args(sub, "sub 1 AND --2 3 4", 1, "--2", (3, 4))
+    assert_parse_args(sub, "sub 1 AND -- 3 4", 1, "--", (3, 4))
+
+
+def test_end_of_options_delimiter_subcommand_overrides_parent(app, assert_parse_args):
+    """A subcommand delimiter takes precedence over the parent app's (issue #933)."""
+    app.end_of_options_delimiter = "PARENT"
+
+    @app.command(end_of_options_delimiter="CHILD")
+    def sub(a: int, b: Annotated[str, Parameter(allow_leading_hyphen=True)], c: tuple[int, int]):
+        pass
+
+    assert_parse_args(sub, "sub 1 CHILD --2 3 4", 1, "--2", (3, 4))
+
+
+def test_end_of_options_delimiter_nested_subcommand(app):
+    """Delimiter resolution walks the full command chain to a grandchild (issue #933)."""
+    mid = App(name="mid", help_flags=[], version_flags=[])
+    app.command(mid)
+
+    @mid.command(help_flags=[], version_flags=[], end_of_options_delimiter="")
+    def leaf(*args: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+        pass
+
+    _, actual_bind, _ = app.parse_args(["mid", "leaf", "x", "--", "-y", "z"], print_error=False, exit_on_error=False)
+    assert actual_bind.args == ("x", "--", "-y", "z")
 
 
 def test_end_of_options_delimiter_from_parse_args(app, assert_parse_args):

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -754,6 +754,25 @@ def test_disabled_double_hyphen_end_of_options_delimiter_from_parse_args(app, as
     assert_parse_args_config({"end_of_options_delimiter": ""}, foo, "1 -- 3 4", 1, "--", (3, 4))
 
 
+def test_disabled_double_hyphen_end_of_options_delimiter_on_subcommand(app):
+    """A subcommand's ``end_of_options_delimiter="" `` must disable ``--`` stripping.
+
+    Regression test for issue #933: the delimiter was resolved from the root
+    app's stack instead of the resolved command's, so a subcommand-level
+    ``end_of_options_delimiter=""`` was ignored and ``--`` was still stripped
+    (breaking pass-through commands like ``k exec pod -- sh -c id``).
+    """
+
+    @app.command(help_flags=[], version_flags=[], end_of_options_delimiter="")
+    def k(*args: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+        pass
+
+    _, actual_bind, _ = app.parse_args(
+        ["k", "exec", "pod", "--", "sh", "-c", "id"], print_error=False, exit_on_error=False
+    )
+    assert actual_bind.args == ("exec", "pod", "--", "sh", "-c", "id")
+
+
 def test_end_of_options_delimiter_from_parse_args(app, assert_parse_args):
     app.end_of_options_delimiter = "AND"
 

--- a/tests/test_error_formatter.py
+++ b/tests/test_error_formatter.py
@@ -105,6 +105,79 @@ def test_error_formatter_inherited_by_subcommand():
     assert buf.getvalue() == 'inherited: Invalid value for VALUE: unable to convert "abc" into int.\n'
 
 
+@pytest.mark.parametrize("via_call", [False, True])
+def test_error_formatter_defined_on_subcommand(via_call):
+    """A subcommand's own error_formatter is honored on a parse error in that subcommand.
+
+    Regression test for the #933 family: error-reporting settings were resolved from the
+    root app's stack (which never contains the subcommand), so a subcommand-level
+    error_formatter was ignored. Exercised via both ``__call__`` and ``parse_args``.
+    """
+    buf = StringIO()
+    error_console = Console(
+        file=buf, width=70, force_terminal=True, highlight=False, color_system=None, legacy_windows=False
+    )
+
+    def my_formatter(e):
+        return f"sub: {e}"
+
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(error_formatter=my_formatter)
+    def sub(value: int):
+        pass
+
+    if via_call:
+        with pytest.raises(SystemExit):
+            app(["sub", "abc"], error_console=error_console)
+    else:
+        with pytest.raises(CoercionError):
+            app.parse_args(["sub", "abc"], exit_on_error=False, error_console=error_console)
+
+    assert buf.getvalue() == 'sub: Invalid value for VALUE: unable to convert "abc" into int.\n'
+
+
+@pytest.mark.parametrize("via_call", [False, True])
+def test_exit_on_error_defined_on_subcommand(via_call):
+    """A subcommand's ``exit_on_error=False`` is honored (raises instead of exiting).
+
+    Regression test for the #933 family. ``parse_args`` also covers the case where the
+    command context is torn down before the error is handled, so the setting must be
+    resolved while that context is live.
+    """
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(exit_on_error=False)
+    def sub(value: int):
+        pass
+
+    # Root default exit_on_error is True; only the subcommand disables it.
+    with pytest.raises(CoercionError):
+        if via_call:
+            app(["sub", "abc"])
+        else:
+            app.parse_args(["sub", "abc"])
+
+
+def test_print_error_defined_on_subcommand():
+    """A subcommand's ``print_error=False`` suppresses error output (#933 family)."""
+    buf = StringIO()
+    error_console = Console(
+        file=buf, width=70, force_terminal=True, highlight=False, color_system=None, legacy_windows=False
+    )
+
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(print_error=False)
+    def sub(value: int):
+        pass
+
+    with pytest.raises(CoercionError):
+        app.parse_args(["sub", "abc"], exit_on_error=False, error_console=error_console)
+
+    assert buf.getvalue() == ""
+
+
 def test_error_formatter_call():
     """error_formatter works when using __call__ instead of parse_args."""
     buf = StringIO()

--- a/tests/test_result_action.py
+++ b/tests/test_result_action.py
@@ -1743,3 +1743,57 @@ def test_cyclopts_returncode_default_zero_when_not_defined():
 
     assert result == 0
     assert buf.getvalue() == "Hello Alice!\n"
+
+
+# ==============================================================================
+# Subcommand-scoped result_action (#933 family)
+# ==============================================================================
+
+
+def test_result_action_defined_on_subcommand_return_value():
+    """A subcommand's own result_action is honored when that subcommand is invoked.
+
+    The root app keeps the default action; only ``sub`` opts into ``return_value``. Regression
+    test for the #933 family: result_action was resolved from the root app's stack, which never
+    contains the subcommand, so the subcommand-level value was ignored.
+    """
+    app = App()  # root: default action
+
+    @app.command(result_action="return_value")
+    def sub() -> str:
+        return "from-sub"
+
+    assert app(["sub"]) == "from-sub"
+
+
+def test_result_action_subcommand_does_not_leak_to_sibling():
+    """A subcommand's result_action must not affect sibling commands (downward-only)."""
+    app = App()
+
+    @app.command(result_action="return_value")
+    def opts_in() -> str:
+        return "returned"
+
+    @app.command
+    def sibling() -> str:
+        return "printed"
+
+    assert app(["opts-in"]) == "returned"
+    # The sibling keeps the root default action (print + sys.exit), not return_value.
+    buf = StringIO()
+    with redirect_stdout(buf), pytest.raises(SystemExit):
+        app(["sibling"])
+    assert buf.getvalue() == "printed\n"
+
+
+def test_result_action_defined_on_subcommand_run_async():
+    """Subcommand result_action is honored via ``run_async`` too (#933 family)."""
+    import asyncio
+
+    app = App()
+
+    @app.command(result_action="return_value")
+    def sub() -> str:
+        return "async-sub"
+
+    assert asyncio.run(app.run_async(["sub"])) == "async-sub"

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -27,6 +27,25 @@ def test_async_handler_with_subcommand_works(app):
     assert app("foo bar", backend="trio") == "Async handler works"
 
 
+def test_backend_defined_on_subcommand(app):
+    """A subcommand's own ``backend="trio"`` is honored without a runtime override (#933 family).
+
+    The root keeps the default asyncio backend; only the subcommand selects trio. Regression test
+    for the #933 family: ``backend`` was resolved from the root app's stack, which never contains
+    the subcommand, so a subcommand-level value was ignored.
+    """
+    sub_app = App(name="foo", backend="trio", result_action="return_value")
+    app.command(sub_app)
+
+    @sub_app.default
+    async def async_handler():
+        assert sniffio.current_async_library() == "trio"
+        await trio.lowlevel.checkpoint()
+        return "ran under trio"
+
+    assert app("foo") == "ran under trio"
+
+
 def test_handler(app):
     @app.command(name="command")
     def sync_handler():


### PR DESCRIPTION
Fixes #933. Replaces #935, which GitHub auto-closed when #934 (the combined-short fix it was stacked on) merged and its base branch was deleted; this branch is rebased onto `main`.

## The bug (one root cause, four symptoms)

`AppStack` is **per-app**: entering the command context pushes the full chain `[root, sub]` onto the *subcommand's* stack but only `[root]` onto the *root's* stack. Several top-level orchestration methods on the *entry* app resolved command-scoped configuration via `self.app_stack` (the root/entry app), which can never see the invoked subcommand — so a subcommand-level setting was silently ignored and the root's value (or a default) was used instead.

This surfaced as four distinct regressions, all the same root cause:

| Setting | Symptom when set on a subcommand |
|---|---|
| `end_of_options_delimiter` | ignored; `--` was still stripped (the reported #933 — breaks pass-through commands) |
| `print_error` / `exit_on_error` / `help_on_error` / `verbose` / `error_formatter` | ignored; a subcommand's `exit_on_error=False` still exited, its `error_formatter` never ran |
| `backend` | ignored; a subcommand's `backend="trio"` ran under asyncio |
| `result_action` | ignored; a subcommand's `result_action` was never applied |

None of these leak upward or sideways — a subcommand's setting governs only that subcommand's invocation, with parents supplying defaults (standard child-overrides-parent).

## The fix

The rule: **resolve command-scoped config from the invoked command's `app_stack`**, which equals `self.app_stack` only when `self` is that command.

- `end_of_options_delimiter` — resolve from `command_app.app_stack` in `_parse_known_args` (alongside `_config`, which already did).
- error-reporting settings — resolved inside `_parse_known_args` while the invoked command's context (full chain + propagated overrides) is live, then carried to `_handle_parse_error` on the exception (a private `CycloptsError._error_report_settings`), since the handler runs after the context is torn down. Falls back to `self.app_stack` for errors raised before a command is resolved (e.g. tokenization), where the root scope is correct.
- `backend` / `result_action` — factor the "which command am I running" logic (command-chain resolution + help/version trimming) out of `_parse_known_args` into `_resolve_invoked_command`, and use it at the execution sites (`__call__`, `run_async`, `interactive_shell`) to resolve from the invoked command. `_handle_result_action` now scopes both `result_action` and the output console to the invoked command.

## Why `self.app_stack` is still used elsewhere

`self.app_stack` remains correct wherever `self` already *is* the app whose config is wanted — the property accessors (`config`, `console`, `error_console`, `version_format`, `default_parameter`) and the `version_print`/`help_print` commands bound to the invoked command — and as the fallback when no subcommand is involved (single-app use, or pre-command errors). The per-app design is fine; only the entry-app orchestration sites were resolving from the wrong app.

## Tests

Each fix has a failing-test-first / fix / coverage structure. New guards cover: subcommand `end_of_options_delimiter` (the repro, plus a custom delimiter, child-overrides-parent, and a nested grandchild); subcommand `error_formatter` / `exit_on_error` / `print_error` via both `__call__` and `parse_args`; subcommand `backend="trio"` and `result_action` via both `__call__` and `run_async`, plus a sibling-isolation guard. Existing suites only ever set these on the root app. Full suite green (2764 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
