### PR TITLE
ci: fail a hung test in 60s via pytest-timeout instead of stalling the job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,9 +226,6 @@ markers = [
     "slow: marks tests as slow (deselected by default, use --run-slow to include)",
 ]
 addopts = "-m 'not slow'"
-# Fail a hung test in 60s (~25x the slowest real test) with a traceback, instead
-# of letting it stall the whole CI job for the 45-minute job timeout. Auto-picks
-# SIGALRM on POSIX / thread-dump on Windows, and disables itself under a debugger.
 timeout = 60
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest>=8.2.0",
     "pytest-cov>=3.0.0",
     "pytest-mock>=3.7.0",
+    "pytest-timeout>=2.3.0",
     "pydantic>=2.11.2,<3.0.0",
     "syrupy>=4.0.0",
     "toml>=0.10.2,<1.0.0",
@@ -225,6 +226,10 @@ markers = [
     "slow: marks tests as slow (deselected by default, use --run-slow to include)",
 ]
 addopts = "-m 'not slow'"
+# Fail a hung test in 60s (~25x the slowest real test) with a traceback, instead
+# of letting it stall the whole CI job for the 45-minute job timeout. Auto-picks
+# SIGALRM on POSIX / thread-dump on Windows, and disables itself under a debugger.
+timeout = 60
 
 [tool.codespell]
 skip = 'uv.lock,tests/test_help.py'

--- a/uv.lock
+++ b/uv.lock
@@ -368,6 +368,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "pyyaml" },
     { name = "syrupy" },
     { name = "toml" },
@@ -416,6 +417,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.7.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.6.0" },
@@ -476,7 +478,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -596,17 +598,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -622,18 +624,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -645,7 +647,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1308,6 +1310,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

On PR #934's CI (run `34130342116`), a single test cell — `test (ubuntu-24.04-arm, 3.10)` — hung for **27 minutes** while every sibling job finished in ~2 min. The job's `Run tests` step started and simply never returned; the only backstop was the 45-minute job-level `timeout-minutes`, and when the job was finally killed the log was purged, so we still can't tell which test wedged. The shell-completion tests (the slowest in the suite, and the only ones spawning real shells) are the prime suspect on Linux-ARM.

A job-level timeout can't help diagnose this: it kills the whole matrix cell with no traceback. A per-test timeout can.

## What

- Add `pytest-timeout` to the `dev` dependency group.
- Set `timeout = 60` in `[tool.pytest.ini_options]`.

60s is ~25× the slowest real test (2.46s, `test_meta_positional_before_subcommand`, with `--run-slow`), so there's no false-positive risk even as the suite grows. pytest-timeout auto-picks SIGALRM on POSIX (clean per-test failure + traceback, run continues and reports the offending test) and a thread-dump fallback on Windows, and it disables itself under a debugger so local `--pdb`/breakpoints are unaffected.

Verified: full `--run-slow` suite passes clean under the cap (2763 passed), and a synthetic 5s test with `--timeout=1` fails fast with `Failed: Timeout (>1.0s) from pytest-timeout` plus the hanging traceback.

The existing job-level `timeout-minutes` stays as the backstop for hangs *outside* pytest (a wedged `uv sync`, runner hiccup) — the two are complementary.

## Note on the lockfile

The `uv.lock` diff is the new `pytest-timeout` entry plus incidental marker reformatting on the `debug` extra's ipython dependency tree. No dependency versions change (the only new `version =` is pytest-timeout's `2.4.0`); it's pre-existing drift that surfaces on any lock-touching change. CI installs via `uv sync --all-extras` (not `--frozen`), so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
