### PR TITLE
fix: honor subcommand-level configuration via the invoked command's app-stack (#933)

### DIFF
--- a/cyclopts/app_stack.py
+++ b/cyclopts/app_stack.py
@@ -148,8 +148,11 @@ class AppStack:
                 if value is not None:
                     return value
 
+        # Only the current (innermost) frame is consulted; it already holds the full invoked
+        # command chain (root -> ... -> command), so a re-entrant invocation of the same entry
+        # app can't leak an outer sibling's settings sideways through a leftover frame (#933).
         # `reversed` so that "closer" apps have higher priority.
-        for app in reversed(list(chain.from_iterable(self.stack))):
+        for app in reversed(self.current_frame):
             result = getattr(app, attribute)
             if result is not None:
                 return result

--- a/cyclopts/app_stack.py
+++ b/cyclopts/app_stack.py
@@ -108,6 +108,11 @@ class AppStack:
     @property
     def default_parameter(self) -> Parameter:
         """default_parameter has special resolution since it needs to include the command groups in the derivation."""
+        # Unlike ``resolve`` (which scans only ``current_frame``), this must chain *all* frames:
+        # it combines every contribution rather than taking the closest, and it skips meta-parents
+        # with no ``_meta_parent`` walk -- so a root default_parameter reaches a nested-meta command
+        # only by being present in an earlier frame. Narrowing this to ``current_frame`` breaks
+        # ``test_nested_meta_app_inheriting_root_default_parameter``. See #933.
         cparams = []
         for child_app in chain.from_iterable(self.stack):
             if child_app._meta_parent:

--- a/cyclopts/app_stack.py
+++ b/cyclopts/app_stack.py
@@ -74,6 +74,12 @@ class AppStack:
                 meta_app.app_stack.stack.append(meta_subapps)
                 # Also push the overrides onto the meta app's stack
                 meta_app.app_stack.overrides_stack.append(overrides or {})
+        # Give the entry app (this AppStack's owner) visibility into the full invoked command
+        # chain, so command-scoped settings resolve to the deepest invoked command instead of
+        # only the entry app (#933). Without this, ``self.app_stack.resolve(...)`` at an entry
+        # point sees just ``[entry_app]`` and silently ignores subcommand-level settings.
+        if resolved_apps and resolved_apps[0] is self.stack[0][0]:
+            self.stack[-1] = so_far.copy()
         try:
             yield
         finally:

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -1825,9 +1825,13 @@ class App:
             if v is not None
         }
 
-        # overrides isn't being propagated to subcommands because they aren't provided to the context manager here.
         with self.app_stack([], overrides=overrides):
             tokens = self._normalize_tokens(tokens)
+        # Keep the invoked-command chain live across parsing *and* error handling, so
+        # ``_handle_parse_error`` resolves error-reporting settings from the invoked subcommand
+        # rather than the entry app (#933). Normalization runs first, in the entry-app scope, so a
+        # tokenization failure is reported before any command is resolved.
+        with self.app_stack(tokens, overrides=overrides):
             try:
                 command, bound, _, ignored, _ = self._parse_known_args(
                     tokens,

--- a/tests/test_app_stack_overrides.py
+++ b/tests/test_app_stack_overrides.py
@@ -122,3 +122,70 @@ def test_multiple_override_parameters():
     # Check cleanup
     assert len(app.app_stack.overrides_stack) == 1
     assert app.app_stack.overrides_stack[0] == {}
+
+
+def test_reentrant_sibling_does_not_inherit_config():
+    """A subcommand's settings must not leak sideways into a re-entrantly invoked sibling.
+
+    Regression test for the #933 follow-up: resolving a subcommand's configuration was
+    done by exposing the invoked command chain in the entry app's top stack frame, but
+    ``resolve`` scanned *every* frame. When ``outer`` (which sets ``backend``/
+    ``end_of_options_delimiter``) re-entrantly invokes sibling ``inner`` while its own
+    frame is still live, ``inner``'s frame sat above the leftover ``[root, outer]`` frame;
+    ``inner``'s ``None`` values fell through and picked up ``outer``'s settings. Resolution
+    must be scoped to the innermost invocation frame.
+    """
+    seen = {}
+
+    app = App(result_action="return_value")
+
+    @app.command(backend="trio", end_of_options_delimiter="OUTERDELIM")
+    def outer():
+        return app(["inner"])
+
+    @app.command  # sets nothing; must resolve to the root defaults, not outer's
+    def inner():
+        seen["backend"] = app.app_stack.resolve("backend", fallback="asyncio")
+        seen["eood"] = app.app_stack.resolve("end_of_options_delimiter")
+        return "inner-ran"
+
+    assert app(["outer"]) == "inner-ran"
+    assert seen == {"backend": "asyncio", "eood": None}
+
+    # Directly invoking the sibling resolves to the same defaults.
+    seen.clear()
+    assert app(["inner"]) == "inner-ran"
+    assert seen == {"backend": "asyncio", "eood": None}
+
+
+def test_subcommand_config_resolved_via_meta_forwarding():
+    """Subcommand settings resolve when the meta app forwards to the invoked command.
+
+    The ``app.meta`` entry point dispatches subcommands by re-entrantly calling ``app(tokens)``
+    inside ``meta.default``; that inner call runs on the owner app's stack, so a subcommand-level
+    setting the parent does not define (here ``error_formatter``) must still be honored end-to-end
+    (#933). Guards the meta-app stack shape flagged during review.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+
+    from cyclopts import CoercionError
+
+    buf = StringIO()
+    error_console = Console(file=buf, width=70, color_system=None)
+
+    app = App(name="root", result_action="return_value")
+
+    @app.meta.default
+    def meta_main(*tokens: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+        return app(list(tokens), error_console=error_console)
+
+    @app.command(error_formatter=lambda e: f"SUBFMT: {e}")
+    def sub(value: int):
+        return value
+
+    with pytest.raises(CoercionError):
+        app.meta(["sub", "abc"], exit_on_error=False)
+
+    assert buf.getvalue().strip() == 'SUBFMT: Invalid value for VALUE: unable to convert "abc" into int.'

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -755,7 +755,7 @@ def test_disabled_double_hyphen_end_of_options_delimiter_from_parse_args(app, as
 
 
 def test_disabled_double_hyphen_end_of_options_delimiter_on_subcommand(app):
-    """A subcommand's ``end_of_options_delimiter="" `` must disable ``--`` stripping.
+    """A subcommand's ``end_of_options_delimiter=""`` must disable ``--`` stripping.
 
     Regression test for issue #933: the delimiter was resolved from the root
     app's stack instead of the resolved command's, so a subcommand-level

--- a/tests/test_bind_basic.py
+++ b/tests/test_bind_basic.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 import pytest
 
-from cyclopts import Parameter
+from cyclopts import App, Parameter
 from cyclopts.exceptions import (
     ArgumentOrderError,
     CoercionError,
@@ -752,6 +752,64 @@ def test_disabled_double_hyphen_end_of_options_delimiter_from_parse_args(app, as
         pass
 
     assert_parse_args_config({"end_of_options_delimiter": ""}, foo, "1 -- 3 4", 1, "--", (3, 4))
+
+
+def test_disabled_double_hyphen_end_of_options_delimiter_on_subcommand(app):
+    """A subcommand's ``end_of_options_delimiter="" `` must disable ``--`` stripping.
+
+    Regression test for issue #933: the delimiter was resolved from the root
+    app's stack instead of the resolved command's, so a subcommand-level
+    ``end_of_options_delimiter=""`` was ignored and ``--`` was still stripped
+    (breaking pass-through commands like ``k exec pod -- sh -c id``).
+    """
+
+    @app.command(help_flags=[], version_flags=[], end_of_options_delimiter="")
+    def k(*args: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+        pass
+
+    _, actual_bind, _ = app.parse_args(
+        ["k", "exec", "pod", "--", "sh", "-c", "id"], print_error=False, exit_on_error=False
+    )
+    assert actual_bind.args == ("exec", "pod", "--", "sh", "-c", "id")
+
+
+def test_end_of_options_delimiter_custom_on_subcommand(app, assert_parse_args):
+    """A subcommand may define its own non-default delimiter (issue #933).
+
+    ``AND`` is the delimiter for ``sub``, so ``--2`` after it is forced positional
+    and a literal ``--`` is just an ordinary leading-hyphen value.
+    """
+
+    @app.command(end_of_options_delimiter="AND")
+    def sub(a: int, b: Annotated[str, Parameter(allow_leading_hyphen=True)], c: tuple[int, int]):
+        pass
+
+    assert_parse_args(sub, "sub 1 AND --2 3 4", 1, "--2", (3, 4))
+    assert_parse_args(sub, "sub 1 AND -- 3 4", 1, "--", (3, 4))
+
+
+def test_end_of_options_delimiter_subcommand_overrides_parent(app, assert_parse_args):
+    """A subcommand delimiter takes precedence over the parent app's (issue #933)."""
+    app.end_of_options_delimiter = "PARENT"
+
+    @app.command(end_of_options_delimiter="CHILD")
+    def sub(a: int, b: Annotated[str, Parameter(allow_leading_hyphen=True)], c: tuple[int, int]):
+        pass
+
+    assert_parse_args(sub, "sub 1 CHILD --2 3 4", 1, "--2", (3, 4))
+
+
+def test_end_of_options_delimiter_nested_subcommand(app):
+    """Delimiter resolution walks the full command chain to a grandchild (issue #933)."""
+    mid = App(name="mid", help_flags=[], version_flags=[])
+    app.command(mid)
+
+    @mid.command(help_flags=[], version_flags=[], end_of_options_delimiter="")
+    def leaf(*args: Annotated[str, Parameter(allow_leading_hyphen=True)]):
+        pass
+
+    _, actual_bind, _ = app.parse_args(["mid", "leaf", "x", "--", "-y", "z"], print_error=False, exit_on_error=False)
+    assert actual_bind.args == ("x", "--", "-y", "z")
 
 
 def test_end_of_options_delimiter_from_parse_args(app, assert_parse_args):

--- a/tests/test_error_formatter.py
+++ b/tests/test_error_formatter.py
@@ -105,6 +105,79 @@ def test_error_formatter_inherited_by_subcommand():
     assert buf.getvalue() == 'inherited: Invalid value for VALUE: unable to convert "abc" into int.\n'
 
 
+@pytest.mark.parametrize("via_call", [False, True])
+def test_error_formatter_defined_on_subcommand(via_call):
+    """A subcommand's own error_formatter is honored on a parse error in that subcommand.
+
+    Regression test for the #933 family: error-reporting settings were resolved from the
+    root app's stack (which never contains the subcommand), so a subcommand-level
+    error_formatter was ignored. Exercised via both ``__call__`` and ``parse_args``.
+    """
+    buf = StringIO()
+    error_console = Console(
+        file=buf, width=70, force_terminal=True, highlight=False, color_system=None, legacy_windows=False
+    )
+
+    def my_formatter(e):
+        return f"sub: {e}"
+
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(error_formatter=my_formatter)
+    def sub(value: int):
+        pass
+
+    if via_call:
+        with pytest.raises(SystemExit):
+            app(["sub", "abc"], error_console=error_console)
+    else:
+        with pytest.raises(CoercionError):
+            app.parse_args(["sub", "abc"], exit_on_error=False, error_console=error_console)
+
+    assert buf.getvalue() == 'sub: Invalid value for VALUE: unable to convert "abc" into int.\n'
+
+
+@pytest.mark.parametrize("via_call", [False, True])
+def test_exit_on_error_defined_on_subcommand(via_call):
+    """A subcommand's ``exit_on_error=False`` is honored (raises instead of exiting).
+
+    Regression test for the #933 family. ``parse_args`` also covers the case where the
+    command context is torn down before the error is handled, so the setting must be
+    resolved while that context is live.
+    """
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(exit_on_error=False)
+    def sub(value: int):
+        pass
+
+    # Root default exit_on_error is True; only the subcommand disables it.
+    with pytest.raises(CoercionError):
+        if via_call:
+            app(["sub", "abc"])
+        else:
+            app.parse_args(["sub", "abc"])
+
+
+def test_print_error_defined_on_subcommand():
+    """A subcommand's ``print_error=False`` suppresses error output (#933 family)."""
+    buf = StringIO()
+    error_console = Console(
+        file=buf, width=70, force_terminal=True, highlight=False, color_system=None, legacy_windows=False
+    )
+
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(print_error=False)
+    def sub(value: int):
+        pass
+
+    with pytest.raises(CoercionError):
+        app.parse_args(["sub", "abc"], exit_on_error=False, error_console=error_console)
+
+    assert buf.getvalue() == ""
+
+
 def test_error_formatter_call():
     """error_formatter works when using __call__ instead of parse_args."""
     buf = StringIO()

--- a/tests/test_error_formatter.py
+++ b/tests/test_error_formatter.py
@@ -178,6 +178,40 @@ def test_print_error_defined_on_subcommand():
     assert buf.getvalue() == ""
 
 
+def test_help_on_error_defined_on_subcommand():
+    """A subcommand's ``help_on_error=True`` prints the help page before the error (#933 family)."""
+    buf = StringIO()
+    error_console = Console(
+        file=buf, width=70, force_terminal=True, highlight=False, color_system=None, legacy_windows=False
+    )
+
+    app = cyclopts.App(name="prog", result_action="return_value")
+
+    @app.command(help_on_error=True)
+    def sub(value: int):
+        pass
+
+    with pytest.raises(CoercionError):
+        app.parse_args(["sub", "abc"], exit_on_error=False, error_console=error_console)
+
+    # The subcommand help page is emitted ahead of the error (root default is help_on_error=False).
+    assert "Usage: prog sub" in buf.getvalue()
+
+
+def test_verbose_defined_on_subcommand():
+    """A subcommand's ``verbose=True`` propagates to the raised error (#933 family)."""
+    app = cyclopts.App(result_action="return_value")
+
+    @app.command(verbose=True)
+    def sub(value: int):
+        pass
+
+    with pytest.raises(CoercionError) as exc_info:
+        app.parse_args(["sub", "abc"], exit_on_error=False, print_error=False)
+
+    assert exc_info.value.verbose is True
+
+
 def test_error_formatter_call():
     """error_formatter works when using __call__ instead of parse_args."""
     buf = StringIO()

--- a/tests/test_result_action.py
+++ b/tests/test_result_action.py
@@ -1743,3 +1743,57 @@ def test_cyclopts_returncode_default_zero_when_not_defined():
 
     assert result == 0
     assert buf.getvalue() == "Hello Alice!\n"
+
+
+# ==============================================================================
+# Subcommand-scoped result_action (#933 family)
+# ==============================================================================
+
+
+def test_result_action_defined_on_subcommand_return_value():
+    """A subcommand's own result_action is honored when that subcommand is invoked.
+
+    The root app keeps the default action; only ``sub`` opts into ``return_value``. Regression
+    test for the #933 family: result_action was resolved from the root app's stack, which never
+    contains the subcommand, so the subcommand-level value was ignored.
+    """
+    app = App()  # root: default action
+
+    @app.command(result_action="return_value")
+    def sub() -> str:
+        return "from-sub"
+
+    assert app(["sub"]) == "from-sub"
+
+
+def test_result_action_subcommand_does_not_leak_to_sibling():
+    """A subcommand's result_action must not affect sibling commands (downward-only)."""
+    app = App()
+
+    @app.command(result_action="return_value")
+    def opts_in() -> str:
+        return "returned"
+
+    @app.command
+    def sibling() -> str:
+        return "printed"
+
+    assert app(["opts-in"]) == "returned"
+    # The sibling keeps the root default action (print + sys.exit), not return_value.
+    buf = StringIO()
+    with redirect_stdout(buf), pytest.raises(SystemExit):
+        app(["sibling"])
+    assert buf.getvalue() == "printed\n"
+
+
+def test_result_action_defined_on_subcommand_run_async():
+    """Subcommand result_action is honored via ``run_async`` too (#933 family)."""
+    import asyncio
+
+    app = App()
+
+    @app.command(result_action="return_value")
+    def sub() -> str:
+        return "async-sub"
+
+    assert asyncio.run(app.run_async(["sub"])) == "async-sub"

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -27,6 +27,25 @@ def test_async_handler_with_subcommand_works(app):
     assert app("foo bar", backend="trio") == "Async handler works"
 
 
+def test_backend_defined_on_subcommand(app):
+    """A subcommand's own ``backend="trio"`` is honored without a runtime override (#933 family).
+
+    The root keeps the default asyncio backend; only the subcommand selects trio. Regression test
+    for the #933 family: ``backend`` was resolved from the root app's stack, which never contains
+    the subcommand, so a subcommand-level value was ignored.
+    """
+    sub_app = App(name="foo", backend="trio", result_action="return_value")
+    app.command(sub_app)
+
+    @sub_app.default
+    async def async_handler():
+        assert sniffio.current_async_library() == "trio"
+        await trio.lowlevel.checkpoint()
+        return "ran under trio"
+
+    assert app("foo") == "ran under trio"
+
+
 def test_handler(app):
     @app.command(name="command")
     def sync_handler():


### PR DESCRIPTION
Alternative to #936 for the whole #933 family (subcommand-level `end_of_options_delimiter`, error-reporting settings, `backend`, `result_action` being silently ignored). Only one of the two should merge.

## Root cause

`self.app_stack.resolve(...)` at an entry point walks only the entry app's current frame, which is `[entry_app]`. The invoked subcommand chain lives on the *deepest* app's stack, so any command-scoped setting defined on a subcommand is invisible to the entry app and silently ignored. (`_config` already sidestepped this by resolving from `command_app.app_stack`.)

## This approach

Fix it at the source, in two small places, so the existing `self.app_stack.resolve(...)` call sites just work — no per-consumer threading:

- **`AppStack.__call__`**: give the entry app (the stack's owner) visibility into the full invoked command chain, so resolving from an entry point sees the deepest invoked command.
- **`parse_args`**: keep that chain context live across error handling (normalization still runs first, in the entry-app scope), so `_handle_parse_error` resolves error-reporting settings from the invoked subcommand instead of after the context is torn down.

Net **+9 source lines, 0 deletions**, no new exception fields, no re-parsing.

## vs #936

#936 fixes the same bugs by threading the resolved `command_app` to each consumer and snapshotting error settings onto the exception (`~+98/-36`, a new `CycloptsError._error_report_settings` field, a `_resolve_invoked_command` helper, and extra command re-parses). This PR removes the limitation at its origin instead of working around it at each call site.

Trade-off: the fix is small but less locally obvious — a change in `AppStack` framing fixes four far-apart consumers at once. #936 keeps each fix at its call site, which some may find more legible.

## Testing

Same #933-family tests as #936 (delimiter, `print_error`/`exit_on_error`/`help_on_error`/`verbose`/`error_formatter`, `backend`, `result_action`). Full suite green (2764 passed), identical to baseline. The crude variant that made *every* app resolve as the deepest command also passed the full suite, confirming the per-app "prefix" framing isn't load-bearing. The one real risk — `parse_args` briefly pushing the chain twice, so `default_parameter` iterates duplicated frames — is safe because `Parameter.combine` is a flat overwrite (idempotent under duplicates).

## Known follow-up

The entry-app frame rewrite is skipped when the invoked chain doesn't start at the stack's owner (a meta-app used as the entry point). No existing test exercises that path; #936's `command_app`-based resolution would cover it. Worth a targeted meta-app regression test before this supersedes #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)