### PR TITLE
v5: move interactive_shell loop into _shell.py (alternative to #939)

### DIFF
--- a/cyclopts/_shell.py
+++ b/cyclopts/_shell.py
@@ -1,0 +1,87 @@
+"""Interactive shell backing :meth:`cyclopts.App.interactive_shell`.
+
+Imported lazily: ``readline`` mutates :func:`input` for the whole process, so programs
+that merely import cyclopts should not pay for it.
+"""
+
+import traceback
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Any
+
+from cyclopts.exceptions import CycloptsError
+
+try:
+    # Makes arrow keys and history work inside the shell.
+    import readline
+except ImportError:  # pragma: no cover
+    # Not available on windows
+    readline = None
+
+if TYPE_CHECKING:
+    from cyclopts.core import App
+    from cyclopts.protocols import Dispatcher
+
+
+def _get_line_buffer() -> str:
+    # typeshed guards ``get_line_buffer`` behind ``sys.platform != "win32"``;
+    # ``readline`` is ``None`` on Windows anyway, so this branch never runs there.
+    return readline.get_line_buffer() if readline else ""  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def run_shell(
+    app: "App",
+    *,
+    prompt: str,
+    quit_words: Collection[str],
+    dispatcher: "Dispatcher",
+    parse_kwargs: dict[str, Any],
+) -> None:
+    """Read lines until a quit word, EOF, or Ctrl-C on an empty line.
+
+    Must be called inside the caller's ``app_stack`` override context.
+    """
+    # libedit (macOS) keeps reporting the previous line from ``get_line_buffer`` until
+    # new text is typed, so an interrupted buffer equal to the last seen line means the
+    # line was actually empty. GNU readline reports "" directly.
+    previous_line = ""
+    while True:
+        try:
+            user_input = input(prompt)
+        except EOFError:  # pragma: no cover
+            break
+        except KeyboardInterrupt:
+            print()
+            line_buffer = _get_line_buffer()
+            if line_buffer in ("", previous_line):
+                break
+            previous_line = line_buffer
+            continue
+        previous_line = user_input + "\n"
+
+        try:
+            tokens = app._normalize_tokens(user_input)
+        except CycloptsError:
+            # Already reported (respecting ``exit_on_error``); keep the shell running.
+            continue
+        if not tokens:
+            continue
+        if tokens[0] in quit_words:
+            break
+
+        # Keep the exception handlers inside the token ``app_stack`` context so that
+        # context-sensitive settings (e.g. ``error_console``) resolve from the invoked
+        # subcommand rather than the root app.
+        with app.app_stack(tokens):
+            try:
+                command, bound, ignored = app.parse_args(tokens, **parse_kwargs)
+                result = dispatcher(command, bound, ignored)
+                app._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
+            except CycloptsError:
+                # Upstream ``parse_args`` already printed the error
+                pass
+            except KeyboardInterrupt:
+                if not app.suppress_keyboard_interrupt:
+                    raise
+                print()
+            except Exception:
+                app.error_console.print(traceback.format_exc(), markup=False, highlight=False, soft_wrap=True)

--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2,7 +2,6 @@ import importlib
 import inspect
 import os
 import sys
-import traceback
 from collections.abc import Callable, Coroutine, Iterable, Iterator, Sequence
 from contextlib import suppress
 from copy import copy
@@ -65,13 +64,6 @@ from cyclopts.utils import (
     to_list_converter,
     to_tuple_converter,
 )
-
-try:
-    # By importing, makes things like the arrow-keys work.
-    import readline
-except ImportError:  # pragma: no cover
-    # Not available on windows
-    readline = None
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -2905,6 +2897,7 @@ class App:
     def interactive_shell(
         self,
         prompt: str = "$ ",
+        *,
         quit: None | str | Iterable[str] = None,
         dispatcher: Dispatcher | None = None,
         console: "Console | None" = None,
@@ -2954,6 +2947,8 @@ class App:
         `**kwargs`
             Get passed along to :meth:`parse_args`.
         """
+        from cyclopts._shell import run_shell
+
         if os.name == "posix":  # pragma: no cover
             # Mac/Linux
             print("Interactive shell. Press Ctrl-D to exit.")
@@ -2963,8 +2958,10 @@ class App:
 
         if quit is None:
             quit = ["q", "quit"]
-        if isinstance(quit, str):
+        elif isinstance(quit, str):
             quit = [quit]
+        else:
+            quit = list(quit)
 
         def default_dispatcher(command, bound, _):
             resolved_backend = cast(Literal["asyncio", "trio"], self.app_stack.resolve("backend", fallback="asyncio"))
@@ -2982,55 +2979,8 @@ class App:
             overrides["_error_console"] = error_console
         overrides["exit_on_error"] = exit_on_error
 
-        # libedit (macOS) keeps reporting the previous line from ``get_line_buffer`` until
-        # new text is typed, so an interrupted buffer equal to the last seen line means the
-        # line was actually empty. GNU readline reports "" directly.
-        previous_line = ""
         with self.app_stack([], overrides):
-            while True:
-                try:
-                    user_input = input(prompt)
-                except EOFError:  # pragma: no cover
-                    break
-                except KeyboardInterrupt:
-                    print()
-                    # typeshed guards ``get_line_buffer`` behind ``sys.platform != "win32"``;
-                    # ``readline`` is ``None`` on Windows anyway, so this branch never runs there.
-                    line_buffer = readline.get_line_buffer() if readline else ""  # pyright: ignore[reportAttributeAccessIssue]
-                    if line_buffer in ("", previous_line):
-                        break
-                    previous_line = line_buffer
-                    continue
-                previous_line = user_input + "\n"
-
-                try:
-                    tokens = self._normalize_tokens(user_input)
-                except CycloptsError:
-                    # ``_normalize_tokens`` already reported the error (respecting
-                    # ``exit_on_error``); keep the shell running.
-                    continue
-                if not tokens:
-                    continue
-                if tokens[0] in quit:
-                    break
-
-                # Keep the exception handlers inside the token ``app_stack`` context so that
-                # context-sensitive settings (e.g. ``error_console``) resolve from the invoked
-                # subcommand rather than the root app.
-                with self.app_stack(tokens):
-                    try:
-                        command, bound, ignored = self.parse_args(tokens, **kwargs)
-                        result = dispatcher(command, bound, ignored)
-                        self._handle_result_action(result, fallback="print_non_int_return_int_as_exit_code")
-                    except CycloptsError:
-                        # Upstream ``parse_args`` already printed the error
-                        pass
-                    except KeyboardInterrupt:
-                        if not self.suppress_keyboard_interrupt:
-                            raise
-                        print()
-                    except Exception:
-                        self.error_console.print(traceback.format_exc(), markup=False, highlight=False, soft_wrap=True)
+            run_shell(self, prompt=prompt, quit_words=quit, dispatcher=dispatcher, parse_kwargs=kwargs)
 
     def _handle_result_action(self, result: Any, fallback: ResultAction = "print_non_int_sys_exit") -> Any:
         """Handle command result based on result_action.

--- a/tests/test_interactive_shell.py
+++ b/tests/test_interactive_shell.py
@@ -5,7 +5,7 @@ from cyclopts import App
 
 def test_interactive_shell(app, mocker, console):
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "foo 1 2 3",
             "bad-command 123",
@@ -47,7 +47,7 @@ def test_interactive_shell_result_action_default_string(mocker, console):
     app = App()
 
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "greet Alice",
             "quit",
@@ -68,7 +68,7 @@ def test_interactive_shell_result_action_default_string(mocker, console):
 def test_interactive_shell_result_action_default_int(app, mocker, console):
     """Test that int returns are not printed in interactive shell (default behavior)."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "get-code 42",
             "quit",
@@ -89,7 +89,7 @@ def test_interactive_shell_result_action_default_int(app, mocker, console):
 def test_interactive_shell_result_action_default_bool_true(app, mocker, console):
     """Test that True returns are not printed in interactive shell."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "check",
             "quit",
@@ -110,7 +110,7 @@ def test_interactive_shell_result_action_default_bool_true(app, mocker, console)
 def test_interactive_shell_result_action_default_bool_false(app, mocker, console):
     """Test that False returns are not printed in interactive shell."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "check",
             "quit",
@@ -131,7 +131,7 @@ def test_interactive_shell_result_action_default_bool_false(app, mocker, console
 def test_interactive_shell_result_action_default_none(app, mocker, console):
     """Test that None returns are not printed in interactive shell."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "do-nothing",
             "quit",
@@ -154,7 +154,7 @@ def test_interactive_shell_result_action_default_list(mocker, console):
     app = App()
 
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "get-list",
             "quit",
@@ -177,7 +177,7 @@ def test_interactive_shell_result_action_custom_app(app, mocker, console):
     custom_app = App(result_action="print_non_none_return_int_as_exit_code")
 
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "get-number",
             "quit",
@@ -198,7 +198,7 @@ def test_interactive_shell_result_action_custom_app(app, mocker, console):
 def test_interactive_shell_result_action_override_parameter(app, mocker, console):
     """Test that result_action parameter overrides App setting."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "greet Bob",
             "quit",
@@ -219,7 +219,7 @@ def test_interactive_shell_result_action_override_parameter(app, mocker, console
 def test_interactive_shell_result_action_callable(app, mocker, console):
     """Test that callable result_action works in interactive shell."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "greet Alice",
             "quit",
@@ -249,7 +249,7 @@ def test_interactive_shell_async_command(mocker, console):
     app = App(backend="asyncio")
 
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "start",
             "quit",
@@ -277,7 +277,7 @@ def test_interactive_shell_async_command(mocker, console):
 def test_interactive_shell_no_sys_exit_on_command(app, mocker, console):
     """Test that commands continue to execute (no sys.exit called) in interactive shell."""
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "cmd1",
             "cmd2",
@@ -315,7 +315,7 @@ def test_interactive_shell_no_sys_exit_on_command(app, mocker, console):
 
 def test_interactive_shell_unbalanced_quote(app, mocker, console):
     """A tokenization error should be reported and the shell should keep running."""
-    mocker.patch("cyclopts.core.input", side_effect=['foo "1', "foo 2", "quit"])
+    mocker.patch("builtins.input", side_effect=['foo "1', "foo 2", "quit"])
 
     calls = []
 
@@ -336,8 +336,8 @@ def test_interactive_shell_unbalanced_quote(app, mocker, console):
 
 def test_interactive_shell_keyboard_interrupt_clears_typed_line(app, mocker):
     """Ctrl-C with text on the line should discard the line, not exit the shell."""
-    mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
-    mocker.patch("cyclopts.core.readline").get_line_buffer.return_value = "foo 5"
+    mocker.patch("builtins.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
+    mocker.patch("cyclopts._shell.readline").get_line_buffer.return_value = "foo 5"
 
     calls = []
 
@@ -351,8 +351,8 @@ def test_interactive_shell_keyboard_interrupt_clears_typed_line(app, mocker):
 
 
 def test_interactive_shell_keyboard_interrupt_empty_line_exits(app, mocker):
-    mock_input = mocker.patch("cyclopts.core.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
-    mocker.patch("cyclopts.core.readline").get_line_buffer.return_value = ""
+    mock_input = mocker.patch("builtins.input", side_effect=[KeyboardInterrupt(), "foo 1", "quit"])
+    mocker.patch("cyclopts._shell.readline").get_line_buffer.return_value = ""
 
     calls = []
 
@@ -368,10 +368,8 @@ def test_interactive_shell_keyboard_interrupt_empty_line_exits(app, mocker):
 
 def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_interrupt(app, mocker):
     """Libedit reports the previous line until new text is typed; a repeat means the line was empty."""
-    mock_input = mocker.patch(
-        "cyclopts.core.input", side_effect=["foo 1", KeyboardInterrupt(), KeyboardInterrupt(), "quit"]
-    )
-    mocker.patch("cyclopts.core.readline").get_line_buffer.side_effect = ["foo 2", "foo 2"]
+    mock_input = mocker.patch("builtins.input", side_effect=["foo 1", KeyboardInterrupt(), KeyboardInterrupt(), "quit"])
+    mocker.patch("cyclopts._shell.readline").get_line_buffer.side_effect = ["foo 2", "foo 2"]
 
     calls = []
 
@@ -386,8 +384,8 @@ def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_interru
 
 
 def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_line(app, mocker):
-    mock_input = mocker.patch("cyclopts.core.input", side_effect=["foo 1", KeyboardInterrupt(), "quit"])
-    mocker.patch("cyclopts.core.readline").get_line_buffer.return_value = "foo 1\n"
+    mock_input = mocker.patch("builtins.input", side_effect=["foo 1", KeyboardInterrupt(), "quit"])
+    mocker.patch("cyclopts._shell.readline").get_line_buffer.return_value = "foo 1\n"
 
     calls = []
 
@@ -403,7 +401,7 @@ def test_interactive_shell_keyboard_interrupt_stale_libedit_buffer_after_line(ap
 
 def test_interactive_shell_keyboard_interrupt_in_command(app, mocker):
     """Ctrl-C during a command should return to the prompt when suppress_keyboard_interrupt is set."""
-    mocker.patch("cyclopts.core.input", side_effect=["foo", "bar", "quit"])
+    mocker.patch("builtins.input", side_effect=["foo", "bar", "quit"])
 
     calls = []
 
@@ -420,7 +418,7 @@ def test_interactive_shell_keyboard_interrupt_in_command(app, mocker):
 
 
 def test_interactive_shell_keyboard_interrupt_in_command_not_suppressed(mocker):
-    mocker.patch("cyclopts.core.input", side_effect=["foo", "quit"])
+    mocker.patch("builtins.input", side_effect=["foo", "quit"])
     app = App(suppress_keyboard_interrupt=False)
 
     @app.command
@@ -432,7 +430,7 @@ def test_interactive_shell_keyboard_interrupt_in_command_not_suppressed(mocker):
 
 
 def test_interactive_shell_exception_goes_to_error_console(app, mocker, console):
-    mocker.patch("cyclopts.core.input", side_effect=["foo", "quit"])
+    mocker.patch("builtins.input", side_effect=["foo", "quit"])
 
     @app.command
     def foo():
@@ -448,7 +446,7 @@ def test_interactive_shell_exception_goes_to_error_console(app, mocker, console)
 
 def test_interactive_shell_subcommand_error_console(mocker, console):
     """A subcommand's own error_console must not be overridden by the root's."""
-    mocker.patch("cyclopts.core.input", side_effect=["sub foo notanint", "quit"])
+    mocker.patch("builtins.input", side_effect=["sub foo notanint", "quit"])
 
     root = App()
     sub = App(name="sub", error_console=console)

--- a/tests/test_tokenization_error.py
+++ b/tests/test_tokenization_error.py
@@ -55,6 +55,6 @@ def test_run_async_raises(foo_app, console):
 
 
 def test_interactive_shell_respects_exit_on_error(foo_app, mocker, console):
-    mocker.patch("cyclopts.core.input", side_effect=['foo "1', "quit"])
+    mocker.patch("builtins.input", side_effect=['foo "1', "quit"])
     with console.capture(), pytest.raises(SystemExit):
         foo_app.interactive_shell(exit_on_error=True)

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -62,7 +62,7 @@ def test_interactive_shell_async_command(mocker, console):
     app = App(backend="trio")
 
     mocker.patch(
-        "cyclopts.core.input",
+        "builtins.input",
         side_effect=[
             "start",
             "quit",


### PR DESCRIPTION
## Move `interactive_shell` loop into `cyclopts/_shell.py`

Alternative to #939 for independent comparison. Same two breaking changes, same test updates, but the original hand-written loop is kept as a plain function instead of subclassing `cmd.Cmd`. Targets the `v5-develop-interactive-shell` staging branch.

- `run_shell()` in the new lazily imported `cyclopts/_shell.py` is the old loop body verbatim. `App.interactive_shell` keeps only argument normalization and the `app_stack` override context.
- **Breaking:** parameters after `prompt` are now keyword-only, the only public `App` method that lacked the `*`.
- **Breaking:** `import readline` moved out of `cyclopts/core.py` module level into `_shell.py`. Programs that only import cyclopts no longer get `input()` altered or pay the import cost.
- Tests now patch `builtins.input` and `cyclopts._shell.readline` instead of `cyclopts.core.*`.

Versus #939: no `EOF` sentinel word, no `interrupted_in_command` flag, no `run()`/`cmdloop()` retry wrapper. The completion PR will call `readline.set_completer` directly, which is under ten lines either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
