### PR TITLE
fix: reject NaN in numeric range validators

### DIFF
--- a/cyclopts/validators/_number.py
+++ b/cyclopts/validators/_number.py
@@ -69,16 +69,17 @@ class Number:
             if not isinstance(value, int | float):
                 return
 
-            if self.lt is not None and value >= self.lt:
+            # Negate the required comparison so NaN cannot bypass a bound.
+            if self.lt is not None and not value < self.lt:
                 raise ValueError(f"Must be < {self.lt}.")
 
-            if self.lte is not None and value > self.lte:
+            if self.lte is not None and not value <= self.lte:
                 raise ValueError(f"Must be <= {self.lte}.")
 
-            if self.gt is not None and value <= self.gt:
+            if self.gt is not None and not value > self.gt:
                 raise ValueError(f"Must be > {self.gt}.")
 
-            if self.gte is not None and value < self.gte:
+            if self.gte is not None and not value >= self.gte:
                 raise ValueError(f"Must be >= {self.gte}.")
 
             if self.modulo is not None and value % self.modulo:

--- a/tests/types/test_types_number.py
+++ b/tests/types/test_types_number.py
@@ -9,8 +9,12 @@ from cyclopts.types import (
     HexUInt16,
     HexUInt32,
     HexUInt64,
+    NegativeFloat,
+    NonNegativeFloat,
+    NonPositiveFloat,
     NormFloat,
     PercentInt,
+    PositiveFloat,
     SignedNormFloat,
     UInt8,
 )
@@ -132,6 +136,15 @@ def test_signed_norm_float(app, assert_parse_args):
         app.parse_args("-- -1.1", exit_on_error=False)
     with pytest.raises(ValidationError):
         app.parse_args("1.1", exit_on_error=False)
+
+
+@pytest.mark.parametrize(
+    "type_hint",
+    [PositiveFloat, NonNegativeFloat, NegativeFloat, NonPositiveFloat, NormFloat, SignedNormFloat],
+)
+def test_float_range_rejects_nan(convert, type_hint):
+    with pytest.raises(ValidationError, match="Must be"):
+        convert(type_hint, "nan")
 
 
 def test_percent_int(app, assert_parse_args):

--- a/tests/validators/test_validator_number.py
+++ b/tests/validators/test_validator_number.py
@@ -67,6 +67,39 @@ def test_validator_number_gte():
         validator(int, 4)
 
 
+@pytest.mark.parametrize(
+    "validator, message",
+    [
+        (Number(lt=0), "Must be < 0."),
+        (Number(lte=0), "Must be <= 0."),
+        (Number(gt=0), "Must be > 0."),
+        (Number(gte=0), "Must be >= 0."),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), [float("nan")], {"value": [float("nan")]}],
+    ids=["scalar", "list", "nested_mapping"],
+)
+def test_validator_number_nan(validator, message, value):
+    with pytest.raises(ValueError) as exc_info:
+        validator(float, value)
+    assert str(exc_info.value) == message
+
+
+@pytest.mark.parametrize(
+    "validator, value",
+    [
+        (Number(lt=0), float("-inf")),
+        (Number(lte=0), float("-inf")),
+        (Number(gt=0), float("inf")),
+        (Number(gte=0), float("inf")),
+    ],
+)
+def test_validator_number_infinity(validator, value):
+    validator(float, value)
+
+
 def test_validator_number_modulo():
     validator = Number(modulo=4)
     validator(int, 8)


### PR DESCRIPTION
`NaN` currently passes every `Number` range check. For example, this returns without an error:

```python
from cyclopts.validators import Number

Number(gte=0, lte=1)(float, float("nan"))
```

The same happens when parsing `nan` for a `NormFloat` CLI parameter. The checks reject values using the opposite comparison, but comparisons with NaN are false in either direction.

This negates each required comparison instead. It keeps the existing error messages and still permits infinities where the bound allows them.

Added tests for all four bounds, scalar and nested-container inputs, and the six constrained float aliases. All 18 NaN regression cases fail before the fix; four additional cases cover allowed infinities.

Validation on Python 3.13.14:

- Focused numeric tests: 44 passed.
- Full suite with coverage: 2,740 passed, 56 skipped, 12 deselected; 24 snapshots passed.
- All pre-commit checks passed, including Ruff and Pyright.
