### PR TITLE
ci: fix pre-existing v5-develop failures (3.10 lint cell, fuzz bulk timeout)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-15, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Check out repository

--- a/tests/test_parse_mode_fuzz.py
+++ b/tests/test_parse_mode_fuzz.py
@@ -357,6 +357,9 @@ def test_fuzz_mixed_accounting(seed):
 
 
 @pytest.mark.slow
+# ~10s locally but well over the global 60s pytest-timeout under coverage on CI runners.
+# A hung parse is still caught by the per-parse ``_run_with_watchdog`` timeout.
+@pytest.mark.timeout(600)
 def test_fuzz_bulk():
     """Large corpus; run with ``pytest --run-slow``."""
     for seed in BULK_SEEDS:


### PR DESCRIPTION
## Fix the two CI cells that are red on every `v5-develop` PR

Both failures are visible on #941 and reproduce on `v5-develop` itself; neither is caused by any feature branch.

- **`lint (windows-latest, 3.10)`**: the lint matrix still includes 3.10, but v5 requires `>=3.11`, so pyright fails on `StrEnum`, `tomllib`, `Self`, `NotRequired`, and friends. The test matrix already dropped 3.10; this brings lint in line. Only the Windows cell was failing because the POSIX cells resolve those stubs differently, but 3.10 is meaningless for v5 on every OS.
- **`test_fuzz_bulk` timeout**: #937 (merged forward from `main`) added a global 60s `pytest-timeout`. This test runs 1000 seeds and takes ~10s locally, but under `--cov` on CI runners it exceeds 60s on Linux, macOS, and Windows alike. It now carries a per-test `@pytest.mark.timeout(600)`. A hung parse is still caught by the test's own 15s per-parse watchdog, so the outer timeout only guards against the whole loop stalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
