### PR TITLE
fix: resolve forward references nested inside generics

### DIFF
--- a/cyclopts/field_info.py
+++ b/cyclopts/field_info.py
@@ -385,12 +385,7 @@ def signature_parameters(f: Any) -> dict[str, FieldInfo]:
 
     out = {}
     for name, iparam in inspect.signature(f).parameters.items():
-        # Prefer the raw iparam.annotation; fall back to get_type_hints only for forward
-        # references (strings) or empty annotations, which need resolving.
-        if iparam.annotation is inspect.Parameter.empty or isinstance(iparam.annotation, str):
-            annotation = type_hints.get(name, iparam.annotation)
-        else:
-            annotation = iparam.annotation
+        annotation = type_hints.get(name, iparam.annotation)
         out[name] = FieldInfo.from_iparam(iparam, annotation=annotation)
 
     if inspect.isclass(func):

--- a/tests/test_bind_list.py
+++ b/tests/test_bind_list.py
@@ -436,3 +436,21 @@ def test_frozenset_multi_token_union(app, assert_parse_args):
 
     _, bound, _ = app.parse_args("1 2 hello 3 4", print_error=False, exit_on_error=False)
     assert bound.arguments["values"] == frozenset({(1, 2), "hello", (3, 4)})
+
+
+class Point:
+    def __init__(self, x: int):
+        self.x = x
+
+    def __eq__(self, other):
+        return isinstance(other, Point) and other.x == self.x
+
+
+def test_list_of_forward_ref(app, assert_parse_args):
+    """A string forward reference nested inside a generic must resolve to the class."""
+
+    @app.default
+    def foo(a: list["Point"]):
+        pass
+
+    assert_parse_args(foo, "1 2", [Point(1), Point(2)])


### PR DESCRIPTION
## Resolve forward references nested inside generics again

`signature_parameters` was changed in d5119bb0 to prefer the raw `inspect` annotation over `get_type_hints`, falling back only when the whole annotation is a string. That broke `def f(x: list["Foo"])`, which converts in v4.25.2 and raises `'str' object is not callable` on v5-develop, because the string is never evaluated when it sits inside a generic.

The preference existed to work around Python 3.10's `get_type_hints` reordering unions. v5 requires 3.11+, where union order is preserved, so this reverts to the v4 behavior of always using `get_type_hints`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
