### PR TITLE
fix(completion): start the __complete marker on its own line

### DIFF
--- a/cyclopts/core.py
+++ b/cyclopts/core.py
@@ -2754,7 +2754,9 @@ class App:
         def sanitize(text: str) -> str:
             return text.replace("\t", " ").replace("\n", " ").replace("\r", " ").lstrip("\x1f")
 
-        print("\x1fbegin")
+        # Leading newline: import-time output that ended without one would
+        # otherwise glue onto the marker and hide it from the shell readers.
+        print("\n\x1fbegin")
         try:
             # Completers are user code; anything they (or their subprocesses) print
             # must not be parsed as a record.

--- a/tests/completion/test_dynamic.py
+++ b/tests/completion/test_dynamic.py
@@ -19,8 +19,7 @@ from cyclopts.utils import UNSET
 def _records(captured_out: str) -> list[str]:
     r"""Candidate lines from ``__complete`` stdout, after the ``\x1fbegin`` start marker."""
     lines = captured_out.rstrip("\n").splitlines()
-    assert lines[0] == "\x1fbegin"
-    return lines[1:]
+    return lines[lines.index("\x1fbegin") + 1 :]
 
 
 @pytest.fixture
@@ -131,6 +130,14 @@ def test_complete_command_prints_tab_separated(app, capsys):
     app(["__complete", "deploy", ""], exit_on_error=False)
     out = _records(capsys.readouterr().out)
     assert out == ["dev\tDevelopment", "prod\tProduction"]
+
+
+def test_complete_marker_starts_its_own_line(app, capsys):
+    """Import-time output with no trailing newline must not swallow the start marker."""
+    sys.stdout.write("Loading...")
+    app(["__complete", "deploy", ""], exit_on_error=False)
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[:2] == ["Loading...", "\x1fbegin"]
 
 
 def test_complete_command_bare_values_have_no_tab(app, capsys):


### PR DESCRIPTION
## Start the `__complete` marker on its own line

The `\x1fbegin` marker that opens the completion record stream was printed without a leading newline. If the program writes to stdout at import time and that output does not end in a newline (a progress message, a spinner), the marker is glued onto it as `Loading...\x1fbegin`. All three shell readers match the marker line exactly, so they never see it and the junk line becomes a completion candidate.

Prepending a newline fixes this and is compatible with already-installed completion scripts, which already drop every line before the marker, blank ones included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
