### PR TITLE
fix(help): resolve cyclopts.* spec defaults outside DefaultFormatter

### DIFF
--- a/cyclopts/help/specs.py
+++ b/cyclopts/help/specs.py
@@ -1,6 +1,7 @@
 import math
 import textwrap
 from collections.abc import Iterable, Mapping
+from functools import cache
 from operator import attrgetter
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Optional, Self, Union
@@ -57,6 +58,24 @@ def default_styles_theme(console: "Console") -> "Theme":
         except MissingStyle:
             styles[name] = fallback
     return Theme(styles)
+
+
+@cache
+def _default_styled(cls: type[Any]) -> type[Any]:
+    """Subclass ``cls`` so it renders under the ``cyclopts.*`` defaults on any console.
+
+    Spec defaults are bare ``cyclopts.*`` style names (so they're themeable), which
+    Rich can only resolve while :func:`default_styles_theme` is active. The
+    subclass pushes that theme itself, so ``PanelSpec().build(...)`` prints
+    correctly outside :class:`DefaultFormatter`. Built lazily to keep Rich imports
+    out of module load.
+    """
+
+    def rich_console(self, console: "Console", options: "ConsoleOptions") -> "RenderResult":
+        with console.use_theme(default_styles_theme(console)):
+            yield from cls.__rich_console__(self, console, options)
+
+    return type(cls.__name__, (cls,), {"__rich_console__": rich_console, "__module__": cls.__module__})
 
 
 class DefaultStyled:
@@ -757,7 +776,7 @@ class TableSpec:
 
         from rich.table import Table
 
-        table = Table(**opts)
+        table = _default_styled(Table)(**opts)
 
         for column in columns:
             col_opts = {
@@ -917,7 +936,7 @@ class PanelSpec:
 
         from rich.panel import Panel
 
-        return Panel(renderable, **opts)
+        return _default_styled(Panel)(renderable, **opts)
 
     def copy(self, **kwargs: Any) -> Self:
         return evolve(self, **kwargs)

--- a/tests/test_help_customization.py
+++ b/tests/test_help_customization.py
@@ -1876,3 +1876,17 @@ def test_help_group_theme_end_to_end():
     assert "\x1b[32m╭" in safe_border  # border -> green (Theme form)
     # Safe Zone only overrode its border; its names fall back to the base cyan.
     assert "\x1b[36mkeep" in safe_row
+
+
+def test_specs_render_outside_default_formatter():
+    """PanelSpec/TableSpec defaults are bare cyclopts.* names; they must still resolve on a plain console."""
+    from rich.text import Text
+
+    console = Console(width=40, force_terminal=True, color_system="truecolor", legacy_windows=False, highlight=False)
+    entries = [HelpEntry(positive_names=("--alpha",), description="A")]
+    with console.capture() as capture:
+        console.print(PanelSpec().build(Text("x")))
+        console.print(TableSpec().build((NameColumn, DescriptionColumn), entries))
+    output = capture.get()
+    assert "╭" in output
+    assert "\x1b[36m--alpha" in output  # cyclopts.name -> cyan


### PR DESCRIPTION
## Make `PanelSpec`/`TableSpec` output render outside `DefaultFormatter`

v5 changed the exported specs' style defaults to bare `cyclopts.*` names so they are themeable. Rich can only resolve those names while the default theme is active, which today happens only inside `DefaultFormatter`'s private `DefaultStyled` wrapper. Printing a built spec directly, as a v4-era custom formatter would, raises `MissingStyle`:

```python
Console().print(PanelSpec().build(Text("x")))  # MissingStyle: cyclopts.border
```

`build()` now returns a lazily created subclass of `Panel`/`Table` that pushes the default theme in its own `__rich_console__`. Return types and `isinstance` checks are unchanged, Rich stays a lazy import, and user theme keys still win because `default_styles_theme` only fills the names the console lacks. The existing `DefaultStyled` wrapper stays for the usage line and for layering `Group.theme` on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
