### PR TITLE
fix: pass the Optional-stripped type to validators

### DIFF
--- a/cyclopts/argument/_argument.py
+++ b/cyclopts/argument/_argument.py
@@ -97,7 +97,7 @@ class Argument:
     Fully resolved user-provided :class:`.Parameter`.
     """
 
-    hint: Any = field(default=str)
+    hint: Any = field(default=str, converter=partial(resolve, optional=False))
     """
     The type hint for this argument; may be different from :attr:`.FieldInfo.annotation`.
     Annotated wrappers are stripped, but Optional is preserved for none-coercion.
@@ -979,7 +979,7 @@ class Argument:
                 and self.field_info.kind is self.field_info.VAR_KEYWORD
                 and self._accepts_arbitrary_keywords
             ):
-                hint = get_args(self.hint)[1]
+                hint = resolve_optional(get_args(self.hint)[1])
                 for validator in self.parameter.validator:
                     validator = _resolve(validator, hint)
                     is_method = inspect.ismethod(validator)
@@ -990,7 +990,7 @@ class Argument:
                             validator(hint, val)
                 validate_pydantic(dict[str, self.field_info.annotation], value)
             elif self.field_info and self.field_info.kind is self.field_info.VAR_POSITIONAL:
-                hint = get_args(self.hint)[0]
+                hint = resolve_optional(get_args(self.hint)[0])
                 for validator in self.parameter.validator:
                     validator = _resolve(validator, hint)
                     is_method = inspect.ismethod(validator)
@@ -1001,12 +1001,14 @@ class Argument:
                             validator(hint, val)
                 validate_pydantic(tuple[self.field_info.annotation, ...], value)
             else:
+                # Validators, like custom converters, receive the Optional-stripped type.
+                hint = resolve_optional(self.hint)
                 for validator in self.parameter.validator:
-                    validator = _resolve(validator, self.hint)
+                    validator = _resolve(validator, hint)
                     if inspect.ismethod(validator):
                         validator(value)
                     else:
-                        validator(self.hint, value)
+                        validator(hint, value)
                 validate_pydantic(self.field_info.annotation, value)
         except (AssertionError, ValueError, TypeError) as e:
             raise ValidationError(exception_message=e.args[0] if e.args else "", argument=self) from e

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -737,7 +737,7 @@ def _make_help_entry(argument: "Argument", format: str) -> HelpEntry:
         default = argument.show_default
     elif argument.show_default:
         default_val = argument.field_info.default
-        if is_class_and_subclass(argument.hint, Enum):
+        if is_class_and_subclass(resolve_optional(argument.hint), Enum):
             default = argument.parameter.name_transform(default_val.name)
         elif isinstance(default_val, (list, tuple, set, frozenset)):
             formatted_items = []

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -32,7 +32,7 @@ from cyclopts.group import Group
 from cyclopts.help.inline_text import InlineText
 from cyclopts.help.silent import SILENT, SilentRich
 from cyclopts.parameter import ITERATIVE_BOOL_IMPLICIT_VALUE, get_parameters
-from cyclopts.utils import SortHelper, frozen, is_class_and_subclass, resolve_callables, slice_to_str
+from cyclopts.utils import SortHelper, frozen, resolve_callables, slice_to_str
 
 if TYPE_CHECKING:
     from rich.console import RenderableType
@@ -737,7 +737,7 @@ def _make_help_entry(argument: "Argument", format: str) -> HelpEntry:
         default = argument.show_default
     elif argument.show_default:
         default_val = argument.field_info.default
-        if is_class_and_subclass(resolve_optional(argument.hint), Enum):
+        if isinstance(default_val, Enum):
             default = argument.parameter.name_transform(default_val.name)
         elif isinstance(default_val, (list, tuple, set, frozenset)):
             formatted_items = []

--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -20,6 +20,11 @@ from cyclopts.utils import UNSET
 Case = namedtuple("TestCase", ["args", "expected"])
 
 
+def test_argument_hint_strips_annotated_preserves_optional():
+    assert Argument(hint=Annotated[bool, Parameter()]).hint is bool
+    assert Argument(hint=Annotated[int | None, Parameter()]).hint == int | None
+
+
 def test_argument_collection_no_annotation_no_default():
     def foo(a, b):
         pass

--- a/tests/test_bind_none.py
+++ b/tests/test_bind_none.py
@@ -638,6 +638,28 @@ def test_bind_optional_validator_receives_resolved_type(app, mocker):
     my_validator.assert_called_once_with(int, 5)
 
 
+def test_bind_optional_validator_var_positional_receives_resolved_type(app, mocker):
+    my_validator = mocker.Mock()
+
+    @app.default
+    def default(*values: Annotated[int | None, Parameter(validator=my_validator)]):
+        pass
+
+    app.parse_args(["1", "2"], exit_on_error=False)
+    assert my_validator.call_args_list == [mocker.call(int, 1), mocker.call(int, 2)]
+
+
+def test_bind_optional_validator_var_keyword_receives_resolved_type(app, mocker):
+    my_validator = mocker.Mock()
+
+    @app.default
+    def default(**values: Annotated[int | None, Parameter(validator=my_validator)]):
+        pass
+
+    app.parse_args(["--a", "1", "--b", "2"], exit_on_error=False)
+    assert my_validator.call_args_list == [mocker.call(int, 1), mocker.call(int, 2)]
+
+
 def test_bind_validation_error_propagation_in_union(app):
     """Test that ValidationError is properly propagated during union probing.
 

--- a/tests/test_bind_none.py
+++ b/tests/test_bind_none.py
@@ -626,6 +626,18 @@ def test_bind_optional_custom_converter_receives_resolved_type(app, assert_parse
     my_converter.assert_called_once_with(int, mocker.ANY)
 
 
+def test_bind_optional_validator_receives_resolved_type(app, mocker):
+    """Validators, like custom converters, receive ``int`` rather than ``int | None``."""
+    my_validator = mocker.Mock()
+
+    @app.default
+    def default(value: Annotated[int | None, Parameter(validator=my_validator)] = None):
+        pass
+
+    app.parse_args(["5"], exit_on_error=False)
+    my_validator.assert_called_once_with(int, 5)
+
+
 def test_bind_validation_error_propagation_in_union(app):
     """Test that ValidationError is properly propagated during union probing.
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1039,6 +1039,25 @@ def test_help_format_group_parameters_choices_optional_enum_default(capture_form
     assert actual == expected
 
 
+def test_help_format_group_parameters_optional_enum_none_default_shown(capture_format_group_parameters):
+    class CompSciProblem(Enum):
+        fizz = "bleep bloop blop"
+        buzz = "blop bleep bloop"
+
+    def cmd(foo: Annotated[CompSciProblem | None, Parameter(show_default=True)] = None):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO --foo  [choices: fizz, buzz] [default: None]                   │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
 def test_help_format_group_parameters_choices_enum_list(capture_format_group_parameters):
     class CompSciProblem(Enum):
         fizz = "bleep bloop blop"

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1020,6 +1020,25 @@ def test_help_format_group_parameters_choices_enum(capture_format_group_paramete
     assert actual == expected
 
 
+def test_help_format_group_parameters_choices_optional_enum_default(capture_format_group_parameters):
+    class CompSciProblem(Enum):
+        fizz = "bleep bloop blop"
+        buzz = "blop bleep bloop"
+
+    def cmd(foo: CompSciProblem | None = CompSciProblem.fizz):
+        pass
+
+    actual = capture_format_group_parameters(cmd)
+    expected = dedent(
+        """\
+        ╭─ Parameters ───────────────────────────────────────────────────────╮
+        │ FOO --foo  [choices: fizz, buzz] [default: fizz]                   │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert actual == expected
+
+
 def test_help_format_group_parameters_choices_enum_list(capture_format_group_parameters):
     class CompSciProblem(Enum):
         fizz = "bleep bloop blop"


### PR DESCRIPTION
## Pass the Optional-stripped type to validators

In `v5-develop`, `Argument.hint` keeps `Optional` so the built-in converter can coerce `"none"`/`"null"` tokens. That leaked into the validator callback: a `Parameter(validator=v)` on `int | None` received `int | None` where v4 (and v5 custom converters) receive `int`. A validator dispatching on the type (`issubclass(type_, Path)`) would raise `TypeError` and surface as a misleading `ValidationError`.

Validators now get the stripped type at all three call sites (normal, `*args`, `**kwargs`), consistent with converters and v4, so no migration entry is needed. Validators still receive `None` as the *value* when applicable, which is where that information belongs.

Two related fallout fixes from the same hint change:

- `color: Color | None = Color.RED` rendered `[default: Color.RED]` in help; it renders `[default: red]` again.
- A bare `Argument(hint=Annotated[bool, Parameter()])` no longer stripped `Annotated`, contradicting the field's docstring; the field got back a `resolve(optional=False)` converter.
