### PR TITLE
fix(help): show CHOICE metavar for choice parameters and collapse variadic-collection metavars to X...

### DIFF
--- a/cyclopts/_convert.py
+++ b/cyclopts/_convert.py
@@ -70,7 +70,6 @@ _abstract_to_concrete_type_mapping: dict[type, type] = {
     collections.abc.MutableSet: set,
     collections.abc.MutableSequence: list,
     collections.abc.Collection: list,
-    collections.abc.Container: list,
     collections.abc.Reversible: list,
     collections.abc.Mapping: dict,
     collections.abc.MutableMapping: dict,

--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -355,7 +355,7 @@ def get_choices_from_hint(type_: Any, name_transform: Callable[[str], str]) -> l
                 choices.extend(x)
     elif _origin is Literal:
         choices.extend(str(x) for x in get_args(type_))
-    elif _origin in ITERABLE_TYPES:
+    elif _origin in ITERABLE_TYPES or _origin in VARIADIC_COLLECTION_TYPES:
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):
             choices.extend(get_choices(args[0]))

--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -1,7 +1,17 @@
 import inspect
 import sys
 import typing
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import (
+    Callable,
+    Collection,
+    Container,
+    Iterable,
+    MutableSequence,
+    MutableSet,
+    Reversible,
+    Sequence,
+    Set,
+)
 from enum import Enum, Flag
 from functools import partial
 from types import UnionType
@@ -27,6 +37,23 @@ ITERABLE_TYPES = {
     list,
     set,
     tuple,
+}
+
+# Single-element iterables that consume one value per CLI token, so they share ``tuple[X, ...]``'s
+# ``X...`` metavar. Excludes ``tuple`` (fixed arity / explicit ``...``) and mappings (key/value pairs).
+VARIADIC_COLLECTION_TYPES = {
+    Iterable,
+    typing.Sequence,
+    Sequence,
+    Collection,
+    Container,
+    Reversible,
+    MutableSequence,
+    Set,
+    MutableSet,
+    frozenset,
+    list,
+    set,
 }
 
 

--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -353,7 +353,7 @@ def get_choices_from_hint(type_: Any, name_transform: Callable[[str], str]) -> l
                 choices.extend(x)
     elif _origin is Literal:
         choices.extend(str(x) for x in get_args(type_))
-    elif is_class_and_subclass(_origin, tuple(ITERABLE_TYPES)):
+    elif is_iterable_type(type_):
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):
             choices.extend(get_choices(args[0]))

--- a/cyclopts/annotations.py
+++ b/cyclopts/annotations.py
@@ -4,7 +4,6 @@ import typing
 from collections.abc import (
     Callable,
     Collection,
-    Container,
     Iterable,
     MutableSequence,
     MutableSet,
@@ -46,7 +45,6 @@ VARIADIC_COLLECTION_TYPES = {
     typing.Sequence,
     Sequence,
     Collection,
-    Container,
     Reversible,
     MutableSequence,
     Set,
@@ -355,7 +353,7 @@ def get_choices_from_hint(type_: Any, name_transform: Callable[[str], str]) -> l
                 choices.extend(x)
     elif _origin is Literal:
         choices.extend(str(x) for x in get_args(type_))
-    elif _origin in ITERABLE_TYPES or _origin in VARIADIC_COLLECTION_TYPES:
+    elif is_class_and_subclass(_origin, tuple(ITERABLE_TYPES)):
         args = get_args(type_)
         if len(args) == 1 or (_origin is tuple and len(args) == 2 and args[1] is Ellipsis):
             choices.extend(get_choices(args[0]))

--- a/cyclopts/completion/_base.py
+++ b/cyclopts/completion/_base.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 from attrs import field
 
-from cyclopts.annotations import ITERABLE_TYPES, is_annotated, is_union
+from cyclopts.annotations import ITERABLE_TYPES, VARIADIC_COLLECTION_TYPES, is_annotated, is_union
 from cyclopts.argument import ArgumentCollection
 from cyclopts.exceptions import CycloptsError
 from cyclopts.field_info import VAR_KEYWORD
@@ -180,7 +180,7 @@ def get_completion_action(type_hint: Any) -> CompletionAction:
     origin = get_origin(type_hint)
 
     # For collection types, unwrap to get element type
-    if is_class_and_subclass(origin, tuple(ITERABLE_TYPES)):
+    if is_class_and_subclass(origin, tuple(ITERABLE_TYPES)) or origin in VARIADIC_COLLECTION_TYPES:
         args = get_args(type_hint)
         if args and len(args) >= 1:
             # list[Path], set[Path], tuple[Path, ...] -> check first arg

--- a/cyclopts/completion/_base.py
+++ b/cyclopts/completion/_base.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 from attrs import field
 
-from cyclopts.annotations import ITERABLE_TYPES, VARIADIC_COLLECTION_TYPES, is_annotated, is_union
+from cyclopts.annotations import ITERABLE_TYPES, is_annotated, is_union
 from cyclopts.argument import ArgumentCollection
 from cyclopts.exceptions import CycloptsError
 from cyclopts.field_info import VAR_KEYWORD
@@ -180,7 +180,7 @@ def get_completion_action(type_hint: Any) -> CompletionAction:
     origin = get_origin(type_hint)
 
     # For collection types, unwrap to get element type
-    if is_class_and_subclass(origin, tuple(ITERABLE_TYPES)) or origin in VARIADIC_COLLECTION_TYPES:
+    if is_class_and_subclass(origin, tuple(ITERABLE_TYPES)):
         args = get_args(type_hint)
         if args and len(args) >= 1:
             # list[Path], set[Path], tuple[Path, ...] -> check first arg

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -107,8 +107,8 @@ class HelpEntry:
     ``Literal``/``Enum`` → ``CHOICE``) and can be overridden with
     :attr:`Parameter.metavar <cyclopts.Parameter.metavar>`. :obj:`None` for entries that do not
     consume a value (boolean flags, counting parameters, dict/structured parameters populated via
-    dotted keys, commands), even with an explicit ``Parameter.metavar``, and for entries whose
-    ``[choices]`` list is displayed unless an explicit ``Parameter.metavar`` is set.
+    dotted keys, commands), even with an explicit ``Parameter.metavar``. Entries whose ``[choices]``
+    list is displayed still carry a ``CHOICE`` metavar (both are shown).
 
     This is *not* how a positional parameter is displayed — that is its :attr:`positional_label`,
     derived from the parameter's name. ``metavar`` never affects the identifier.
@@ -609,13 +609,15 @@ def _resolve_metavar(argument: "Argument") -> str | None:
     ):
         return None
     # An explicit ``Parameter.choices`` describes the leaf value exactly like a
-    # ``Literal``/``Enum`` hint does, so the leaf renders as ``CHOICE`` (``LIST[CHOICE]``),
-    # never as the underlying type name.
+    # ``Literal``/``Enum`` hint does, so the leaf renders as ``CHOICE`` (``CHOICE...`` for a
+    # single-token collection, ``LIST[CHOICE]`` for a multi-token one), never the type name.
     leaf = "CHOICE" if argument._explicit_choices() else None
     metavar = _type_metavar(hint, leaf=leaf)
     n_tokens = argument.parameter.n_tokens
     if metavar and n_tokens and get_origin(resolved) is not tuple:
-        if is_iterable_type(resolved) and (args := get_args(resolved)):
+        if (is_iterable_type(resolved) or get_origin(resolved) in VARIADIC_COLLECTION_TYPES) and (
+            args := get_args(resolved)
+        ):
             # Each consumed token is one element, not one whole container.
             metavar = _type_metavar(args[0], leaf=leaf)
         metavar = f"{metavar}..." if n_tokens == -1 else " ".join([metavar] * n_tokens)

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -18,6 +18,7 @@ from typing import (
 from attrs import define, evolve, field
 
 from cyclopts.annotations import (
+    VARIADIC_COLLECTION_TYPES,
     get_hint_name,
     is_enum,
     is_iterable_type,
@@ -636,9 +637,13 @@ def _type_metavar(hint, *, leaf: str | None = None) -> str:
 
     Tuples render argparse-style, one placeholder per token the user types
     (``tuple[int, int]`` -> ``INT INT``, ``tuple[int, ...]`` -> ``INT...``), with nested
-    tuples flattened. Other generics are the uppercased type name over their arguments
-    (``LIST[STR]``, ``LIST[INT INT]``); a multi-token member is parenthesized when it has
-    siblings (``(INT INT)|STR``, ``DICT[STR, (INT INT)]``) so the grouping stays unambiguous.
+    tuples flattened. Other variadic collections (``list``, ``set``, ``Sequence``, ...) consume
+    one element per token, so a single-token element renders like ``tuple[X, ...]``
+    (``list[str]`` -> ``STR...``); a multi-token element keeps the container form so its grouping
+    stays unambiguous (``list[tuple[int, str]]`` -> ``LIST[INT STR]``).
+    Remaining generics (e.g. ``dict``) are the uppercased type name over their arguments
+    (``DICT[STR, INT]``); a multi-token member is parenthesized when it has siblings
+    (``(INT INT)|STR``, ``DICT[STR, (INT INT)]``) so the grouping stays unambiguous.
     ``Literal``/``Enum`` render as ``CHOICE``; ``leaf`` replaces every non-generic leaf name
     (explicit ``Parameter.choices``).
     """
@@ -661,6 +666,13 @@ def _type_metavar(hint, *, leaf: str | None = None) -> str:
             element = recurse(args[0])
             return f"{element}..." if element else ""
         return " ".join(m for arg in args if (m := recurse(arg)))
+    if origin in VARIADIC_COLLECTION_TYPES and args:
+        # Consumes one element per token, like ``tuple[X, ...]``. Only a single-token element
+        # collapses to ``X...``; a multi-token element keeps the ``LIST[...]`` form below so its
+        # grouping stays unambiguous (``LIST[INT STR]``, not ``INT STR...``).
+        element = recurse(args[0])
+        if element and " " not in element and "..." not in element:
+            return f"{element}..."
     if origin and args:
         names = [recurse(arg) for arg in args]
         if not all(names):

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -398,7 +398,7 @@ def format_usage(
     for argument in required_keyword_params:
         # Keyword parameters show the value placeholder (``--foo STR``); positionals
         # below show their name-derived label instead.
-        metavar = _resolve_metavar(argument, in_usage=True) if shows_metavar(argument) else None
+        metavar = _resolve_metavar(argument) if shows_metavar(argument) else None
         usage.append(f"{argument.name} {metavar}" if metavar else argument.name)
 
     if optional_keyword_params:
@@ -576,7 +576,7 @@ def _expand_structured_dict_for_help(
                 yield _make_help_entry(leaf, format)
 
 
-def _resolve_metavar(argument: "Argument", *, in_usage: bool = False) -> str | None:
+def _resolve_metavar(argument: "Argument") -> str | None:
     """Resolve the value placeholder representing ``argument``'s **value** (the ``PATH`` in ``--config PATH``).
 
     Returns :obj:`None` for arguments that never consume a value on the command line
@@ -584,11 +584,8 @@ def _resolve_metavar(argument: "Argument", *, in_usage: bool = False) -> str | N
     would misrepresent the CLI. For value-consuming arguments an explicit
     :attr:`Parameter.metavar <cyclopts.Parameter.metavar>` wins (an empty string suppresses
     it); structured/dict parameters populated only through dotted sub-keys otherwise get
-    :obj:`None`. The default derives from the type hint (``STR``, ``PATH``, ``CHOICE``). In
-    panel rows a displayed ``[choices]`` list conveys the value's shape better than
-    ``CHOICE``, so the choice part is dropped there; the usage line has no such list and
-    keeps it (``in_usage``). Independent of the positional display identifier; see
-    :func:`_resolve_positional_label`.
+    :obj:`None`. The default derives from the type hint (``STR``, ``PATH``, ``CHOICE``).
+    Independent of the positional display identifier; see :func:`_resolve_positional_label`.
     """
     if argument.parameter.count:
         return None
@@ -610,17 +607,16 @@ def _resolve_metavar(argument: "Argument", *, in_usage: bool = False) -> str | N
         and (argument._accepts_arbitrary_keywords or argument.children)
     ):
         return None
-    choice = "CHOICE" if in_usage or not argument.get_choices() else ""
     # An explicit ``Parameter.choices`` describes the leaf value exactly like a
-    # ``Literal``/``Enum`` hint does, so the leaf renders as ``choice`` (``LIST[CHOICE]``),
+    # ``Literal``/``Enum`` hint does, so the leaf renders as ``CHOICE`` (``LIST[CHOICE]``),
     # never as the underlying type name.
-    leaf = choice if argument._explicit_choices() else None
-    metavar = _type_metavar(hint, choice=choice, leaf=leaf)
+    leaf = "CHOICE" if argument._explicit_choices() else None
+    metavar = _type_metavar(hint, leaf=leaf)
     n_tokens = argument.parameter.n_tokens
     if metavar and n_tokens and get_origin(resolved) is not tuple:
         if is_iterable_type(resolved) and (args := get_args(resolved)):
             # Each consumed token is one element, not one whole container.
-            metavar = _type_metavar(args[0], choice=choice, leaf=leaf)
+            metavar = _type_metavar(args[0], leaf=leaf)
         metavar = f"{metavar}..." if n_tokens == -1 else " ".join([metavar] * n_tokens)
     return metavar or None
 
@@ -635,7 +631,7 @@ def _explicit_metavar(hint) -> tuple[Any, str | None]:
     return hint, next((p.metavar for p in reversed(params) if p.metavar is not None), None)
 
 
-def _type_metavar(hint, *, choice: str = "CHOICE", leaf: str | None = None) -> str:
+def _type_metavar(hint, *, leaf: str | None = None) -> str:
     """Derive the default metavar from a type hint.
 
     Tuples render argparse-style, one placeholder per token the user types
@@ -643,7 +639,7 @@ def _type_metavar(hint, *, choice: str = "CHOICE", leaf: str | None = None) -> s
     tuples flattened. Other generics are the uppercased type name over their arguments
     (``LIST[STR]``, ``LIST[INT INT]``); a multi-token member is parenthesized when it has
     siblings (``(INT INT)|STR``, ``DICT[STR, (INT INT)]``) so the grouping stays unambiguous.
-    ``Literal``/``Enum`` render as ``choice``; ``leaf`` replaces every non-generic leaf name
+    ``Literal``/``Enum`` render as ``CHOICE``; ``leaf`` replaces every non-generic leaf name
     (explicit ``Parameter.choices``).
     """
     if hint is Ellipsis:
@@ -655,8 +651,8 @@ def _type_metavar(hint, *, choice: str = "CHOICE", leaf: str | None = None) -> s
     # parameter being optional, not by a ``NONE`` the user would type.
     hint = resolve_optional(hint)
     if get_origin(hint) is Literal or is_enum(hint):
-        return choice
-    recurse = partial(_type_metavar, choice=choice, leaf=leaf)
+        return "CHOICE"
+    recurse = partial(_type_metavar, leaf=leaf)
     if is_union(hint):
         return "|".join(_group_tokens(m) for arg in get_args(hint) if (m := recurse(arg)))
     origin, args = get_origin(hint), get_args(hint)
@@ -668,7 +664,8 @@ def _type_metavar(hint, *, choice: str = "CHOICE", leaf: str | None = None) -> s
     if origin and args:
         names = [recurse(arg) for arg in args]
         if not all(names):
-            # A suppressed ``CHOICE`` element means the ``[choices]`` list describes the value.
+            # An element suppressed via an explicit empty ``Parameter.metavar`` collapses
+            # the whole container's placeholder.
             return ""
         if len(names) > 1:
             names = [_group_tokens(n) for n in names]

--- a/cyclopts/help/help.py
+++ b/cyclopts/help/help.py
@@ -615,9 +615,7 @@ def _resolve_metavar(argument: "Argument") -> str | None:
     metavar = _type_metavar(hint, leaf=leaf)
     n_tokens = argument.parameter.n_tokens
     if metavar and n_tokens and get_origin(resolved) is not tuple:
-        if (is_iterable_type(resolved) or get_origin(resolved) in VARIADIC_COLLECTION_TYPES) and (
-            args := get_args(resolved)
-        ):
+        if is_iterable_type(resolved) and (args := get_args(resolved)):
             # Each consumed token is one element, not one whole container.
             metavar = _type_metavar(args[0], leaf=leaf)
         metavar = f"{metavar}..." if n_tokens == -1 else " ".join([metavar] * n_tokens)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1560,7 +1560,7 @@ API
          ╰────────────────────────────────────────────────────────────────╯
 
       The positional ``source`` is identified by its name (``SOURCE``); the keyword-only ``--output`` shows its metavar (``DIR``) in both the usage line and its parameter row.
-      The builtin formatters append the metavar to keyword-only parameters; positional-capable rows show their name-derived identifier instead, and rows with a ``[choices]`` list omit the type-derived ``CHOICE`` (an explicit metavar is still shown). It is also available to custom formatters as :attr:`HelpEntry.metavar <cyclopts.help.HelpEntry.metavar>`. Disable metavars (rows and usage line) with :attr:`DefaultFormatter.show_metavar <cyclopts.help.DefaultFormatter.show_metavar>` set to ``False``.
+      The builtin formatters append the metavar to keyword-only parameters; positional-capable rows show their name-derived identifier instead. It is also available to custom formatters as :attr:`HelpEntry.metavar <cyclopts.help.HelpEntry.metavar>`. Disable metavars (rows and usage line) with :attr:`DefaultFormatter.show_metavar <cyclopts.help.DefaultFormatter.show_metavar>` set to ``False``.
 
    .. attribute:: show_env_var
       :type: Optional[bool]

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -739,7 +739,8 @@ The default derives from the parameter's **type** (:class:`~pathlib.Path` → ``
 stripped, so ``Path | None`` yields ``PATH`` rather than ``PATH|NONE`` (the value you provide is always a
 :class:`~pathlib.Path`; its absence is conveyed by the parameter being optional). Tuples render one placeholder
 per token, the way the values are typed on the command line: ``tuple[int, int]`` → ``INT INT`` and
-``tuple[int, ...]`` → ``INT...``.
+``tuple[int, ...]`` → ``INT...``. Variadic collections (``list``, ``set``, ``Sequence``, ...) consume one element
+per token, so a single-element type renders the same way: ``list[str]`` → ``STR...``, ``set[int]`` → ``INT...``.
 
 This is distinct from a positional parameter's *identifier* — the ``SRC`` in ``SRC --src`` — which is its
 :attr:`HelpEntry.positional_label <cyclopts.help.HelpEntry.positional_label>`, derived from the parameter's **name** (change it via

--- a/docs/source/help_customization.rst
+++ b/docs/source/help_customization.rst
@@ -747,11 +747,8 @@ This is distinct from a positional parameter's *identifier* — the ``SRC`` in `
 
 Every builtin formatter (rich, plain, markdown, rst, html) appends the metavar to **keyword-only** parameters
 (``--config PATH``), and the usage line shows it for required keyword parameters. Positional-capable rows show
-their identifier instead (the ``CONFIG`` in ``CONFIG --config``, since it already stands in for the value). Rows
-carrying a ``[choices]`` list omit the *type-derived* ``CHOICE`` because the list conveys the value's shape better
-(the usage line, which has no such list, keeps ``CHOICE``); an explicit
-:attr:`Parameter.metavar <cyclopts.Parameter.metavar>` is shown alongside the list. Parameters that consume no
-value (boolean flags, counters) never show a metavar, explicit or not. Disable metavars entirely with
+their identifier instead (the ``CONFIG`` in ``CONFIG --config``, since it already stands in for the value).
+Parameters that consume no value (boolean flags, counters) never show a metavar, explicit or not. Disable metavars entirely with
 :attr:`DefaultFormatter.show_metavar <cyclopts.help.DefaultFormatter.show_metavar>`, which drops them from the
 usage line and clears :attr:`HelpEntry.metavar <cyclopts.help.HelpEntry.metavar>` on every entry before the
 columns render, so it also applies to custom ``column_specs``:

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_admin_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_admin_commands_markdown.md
@@ -4,7 +4,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin status
@@ -35,7 +35,7 @@ Configure database settings.
 * `--port INT`: Database server port number. *[default: 5432]*
 * `--username STR`: Authentication username. *[default: admin]*
 * `--password STR`: Authentication password (optional).
-* `--ssl-mode`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
+* `--ssl-mode CHOICE`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
 * `--pool-size INT`: Connection pool size. *[default: 10]*
 
 ### complex-cli admin users
@@ -79,7 +79,7 @@ Create a new user.
 
 **Parameters**:
 
-* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--role CHOICE`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
 * `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
 * `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
 * `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_data_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_data_commands_markdown.md
@@ -4,7 +4,7 @@ Data processing commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli data process
@@ -25,10 +25,10 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 **Parameters**:
 
 * `--batch-size INT`: Number of items to process per batch. *[default: 32]*
-* `--num-workers INT`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
-* `--quality-level INT`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
-* `--device INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--input-dir PATH`: Input data directory. *[default: data/input]*
 * `--output-dir PATH`: Output results directory. *[default: data/output]*
 * `--cache-dir PATH`: Cache directory for intermediate files.
@@ -53,10 +53,10 @@ PathConfig and ProcessingConfig).
 * `--cache-dir PATH`: Cache directory for intermediate files.
 * `--log-dir PATH`: Directory for log files. *[default: logs]*
 * `--batch-size INT`: Number of items to process per batch. *[default: 32]*
-* `--num-workers INT`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
-* `--quality-level INT`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
-* `--device INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_data_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_data_commands_markdown.md
@@ -28,7 +28,7 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 * `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
 * `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
 * `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--output-formats CHOICE..., --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--input-dir PATH`: Input data directory. *[default: data/input]*
 * `--output-dir PATH`: Output results directory. *[default: data/output]*
 * `--cache-dir PATH`: Cache directory for intermediate files.
@@ -56,7 +56,7 @@ PathConfig and ProcessingConfig).
 * `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
 * `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
 * `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--output-formats CHOICE..., --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
@@ -75,4 +75,4 @@ Validate data files against schema.
 
 * `--strict, --no-strict`: Enable strict validation mode. *[default: False]*
 * `--schema-file PATH`: Custom schema file (must exist).
-* `--ignore-patterns LIST[STR], --empty-ignore-patterns`: Patterns to ignore during validation.
+* `--ignore-patterns STR..., --empty-ignore-patterns`: Patterns to ignore during validation.

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_exclude_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_exclude_commands_markdown.md
@@ -4,7 +4,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin status
@@ -35,7 +35,7 @@ Configure database settings.
 * `--port INT`: Database server port number. *[default: 5432]*
 * `--username STR`: Authentication username. *[default: admin]*
 * `--password STR`: Authentication password (optional).
-* `--ssl-mode`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
+* `--ssl-mode CHOICE`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
 * `--pool-size INT`: Connection pool size. *[default: 10]*
 
 ### complex-cli admin users
@@ -79,7 +79,7 @@ Create a new user.
 
 **Parameters**:
 
-* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--role CHOICE`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
 * `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
 * `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
 * `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_flattened_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_flattened_commands_markdown.md
@@ -6,7 +6,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli admin users
@@ -50,7 +50,7 @@ Create a new user.
 
 **Parameters**:
 
-* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--role CHOICE`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
 * `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
 * `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
 * `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
@@ -46,7 +46,7 @@ Complex CLI application for comprehensive documentation testing.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Subcommands**:
@@ -79,7 +79,7 @@ Displays the application version and system information.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli info
@@ -99,7 +99,7 @@ Show application information.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli admin
@@ -110,7 +110,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin status
@@ -141,7 +141,7 @@ Configure database settings.
 * `--port INT`: Database server port number. *[default: 5432]*
 * `--username STR`: Authentication username. *[default: admin]*
 * `--password STR`: Authentication password (optional).
-* `--ssl-mode`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
+* `--ssl-mode CHOICE`: SSL connection mode. *[choices: disable, prefer, require, verify-full]* *[default: prefer]*
 * `--pool-size INT`: Connection pool size. *[default: 10]*
 
 ### complex-cli admin users
@@ -185,7 +185,7 @@ Create a new user.
 
 **Parameters**:
 
-* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--role CHOICE`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
 * `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
 * `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
 * `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*
@@ -309,7 +309,7 @@ Data processing commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli data process
@@ -330,10 +330,10 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 **Parameters**:
 
 * `--batch-size INT`: Number of items to process per batch. *[default: 32]*
-* `--num-workers INT`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
-* `--quality-level INT`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
-* `--device INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--input-dir PATH`: Input data directory. *[default: data/input]*
 * `--output-dir PATH`: Output results directory. *[default: data/output]*
 * `--cache-dir PATH`: Cache directory for intermediate files.
@@ -358,10 +358,10 @@ PathConfig and ProcessingConfig).
 * `--cache-dir PATH`: Cache directory for intermediate files.
 * `--log-dir PATH`: Directory for log files. *[default: logs]*
 * `--batch-size INT`: Number of items to process per batch. *[default: 32]*
-* `--num-workers INT`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
-* `--quality-level INT`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
-* `--device INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
@@ -390,7 +390,7 @@ Server management commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli server start
@@ -410,7 +410,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--server.workers INT`: Number of worker processes. *[default: 4]*
 * `--server.timeout FLOAT`: Request timeout in seconds. *[default: 30.0]*
 * `--server.debug, --server.no-debug`: Enable debug mode. *[default: False]*
-* `--auth.provider`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
+* `--auth.provider CHOICE`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
 * `--auth.token-expiry INT`: Token expiration time in seconds. *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
 * `--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
@@ -450,7 +450,7 @@ Cache management commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli cache configure
@@ -465,7 +465,7 @@ Demonstrates attrs class support for CLI parameters.
 
 **Parameters**:
 
-* `--config.backend`: Cache backend type. *[choices: memory, redis, memcached, disk]* *[default: memory]*
+* `--config.backend CHOICE`: Cache backend type. *[choices: memory, redis, memcached, disk]* *[default: memory]*
 * `--config.ttl INT`: Time-to-live in seconds. *[default: 300]*
 * `--config.max-size INT`: Maximum cache size in MB. *[default: 1024]*
 * `--config.compression, --config.no-compression`: Enable compression. *[default: False]*
@@ -520,7 +520,7 @@ documentation system needs to handle correctly.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli numpy-style
@@ -543,7 +543,7 @@ default for cyclopts.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli google-style
@@ -565,7 +565,7 @@ This command demonstrates Google docstring format.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli sphinx-style
@@ -587,7 +587,7 @@ This command demonstrates Sphinx/reST docstring format.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ## complex-cli secret-feature
@@ -608,5 +608,5 @@ This command has a hidden parameter.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_full_app_markdown.md
@@ -333,7 +333,7 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 * `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
 * `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
 * `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--output-formats CHOICE..., --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--input-dir PATH`: Input data directory. *[default: data/input]*
 * `--output-dir PATH`: Output results directory. *[default: data/output]*
 * `--cache-dir PATH`: Cache directory for intermediate files.
@@ -361,7 +361,7 @@ PathConfig and ProcessingConfig).
 * `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
 * `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
 * `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--output-formats CHOICE..., --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
@@ -380,7 +380,7 @@ Validate data files against schema.
 
 * `--strict, --no-strict`: Enable strict validation mode. *[default: False]*
 * `--schema-file PATH`: Custom schema file (must exist).
-* `--ignore-patterns LIST[STR], --empty-ignore-patterns`: Patterns to ignore during validation.
+* `--ignore-patterns STR..., --empty-ignore-patterns`: Patterns to ignore during validation.
 
 ## complex-cli server
 
@@ -413,7 +413,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--auth.provider CHOICE`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
 * `--auth.token-expiry INT`: Token expiration time in seconds. *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
-* `--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
+* `--auth.allowed-origins STR..., --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
 
 ### complex-cli server stop
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_hidden_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_hidden_commands_markdown.md
@@ -10,7 +10,7 @@ Complex CLI application for comprehensive documentation testing.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Subcommands**:

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_nested_permissions_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_nested_permissions_markdown.md
@@ -6,7 +6,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 #### complex-cli admin users

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
@@ -27,7 +27,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--auth.provider CHOICE`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
 * `--auth.token-expiry INT`: Token expiration time in seconds. *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
-* `--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
+* `--auth.allowed-origins STR..., --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
 
 ### complex-cli server stop
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_server_commands_markdown.md
@@ -4,7 +4,7 @@ Server management commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli server start
@@ -24,7 +24,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--server.workers INT`: Number of worker processes. *[default: 4]*
 * `--server.timeout FLOAT`: Request timeout in seconds. *[default: 30.0]*
 * `--server.debug, --server.no-debug`: Enable debug mode. *[default: False]*
-* `--auth.provider`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
+* `--auth.provider CHOICE`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
 * `--auth.token-expiry INT`: Token expiration time in seconds. *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
 * `--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_utilities_markdown.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMarkdownSnapshots.test_utilities_markdown.md
@@ -10,7 +10,7 @@ Complex CLI application for comprehensive documentation testing.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Utilities**:
@@ -34,7 +34,7 @@ Displays the application version and system information.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli info
@@ -54,7 +54,7 @@ Show application information.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli cache
@@ -65,7 +65,7 @@ Cache management commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 #### complex-cli cache configure
@@ -80,7 +80,7 @@ Demonstrates attrs class support for CLI parameters.
 
 **Parameters**:
 
-* `--config.backend`: Cache backend type. *[choices: memory, redis, memcached, disk]* *[default: memory]*
+* `--config.backend CHOICE`: Cache backend type. *[choices: memory, redis, memcached, disk]* *[default: memory]*
 * `--config.ttl INT`: Time-to-live in seconds. *[default: 300]*
 * `--config.max-size INT`: Maximum cache size in MB. *[default: 1024]*
 * `--config.compression, --config.no-compression`: Enable compression. *[default: False]*
@@ -135,5 +135,5 @@ documentation system needs to handle correctly.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_filtered_directive_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_filtered_directive_output.md
@@ -8,7 +8,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli admin users
@@ -52,7 +52,7 @@ Create a new user.
 
 **Parameters**:
 
-* `--role`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
+* `--role CHOICE`: User role assignment. *[choices: admin, user, guest]* *[default: user]*
 * `--permissions.none, --permissions.no-none`: Initial permission flags. *[default: False]*
 * `--permissions.read, --permissions.no-read`: Initial permission flags. *[default: False]*
 * `--permissions.write, --permissions.no-write`: Initial permission flags. *[default: False]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
@@ -32,7 +32,7 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 * `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
 * `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
 * `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--output-formats CHOICE..., --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--input-dir PATH`: Input data directory. *[default: data/input]*
 * `--output-dir PATH`: Output results directory. *[default: data/output]*
 * `--cache-dir PATH`: Cache directory for intermediate files.
@@ -60,7 +60,7 @@ PathConfig and ProcessingConfig).
 * `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
 * `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
 * `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--output-formats CHOICE..., --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
@@ -79,7 +79,7 @@ Validate data files against schema.
 
 * `--strict, --no-strict`: Enable strict validation mode. *[default: False]*
 * `--schema-file PATH`: Custom schema file (must exist).
-* `--ignore-patterns LIST[STR], --empty-ignore-patterns`: Patterns to ignore during validation.
+* `--ignore-patterns STR..., --empty-ignore-patterns`: Patterns to ignore during validation.
 
 ## Server Commands
 
@@ -112,7 +112,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--auth.provider CHOICE`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
 * `--auth.token-expiry INT`: Token expiration time in seconds. *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
-* `--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
+* `--auth.allowed-origins STR..., --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*
 
 ### complex-cli server stop
 

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_multiple_directives_output.md
@@ -8,7 +8,7 @@ Data processing commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli data process
@@ -29,10 +29,10 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 **Parameters**:
 
 * `--batch-size INT`: Number of items to process per batch. *[default: 32]*
-* `--num-workers INT`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
-* `--quality-level INT`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
-* `--device INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--input-dir PATH`: Input data directory. *[default: data/input]*
 * `--output-dir PATH`: Output results directory. *[default: data/output]*
 * `--cache-dir PATH`: Cache directory for intermediate files.
@@ -57,10 +57,10 @@ PathConfig and ProcessingConfig).
 * `--cache-dir PATH`: Cache directory for intermediate files.
 * `--log-dir PATH`: Directory for log files. *[default: logs]*
 * `--batch-size INT`: Number of items to process per batch. *[default: 32]*
-* `--num-workers INT`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
-* `--quality-level INT`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
-* `--device INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
-* `--output-formats, --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
+* `--num-workers INT|CHOICE`: Number of parallel workers. Use "auto" for automatic detection. *[choices: auto]* *[default: auto]*
+* `--quality-level INT|CHOICE`: Processing quality level. Higher values mean better quality but slower. *[choices: high, medium, low]* *[default: high]*
+* `--device CHOICE|INT`: Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. *[choices: cuda, cpu, auto]* *[default: auto]*
+* `--output-formats LIST[CHOICE], --empty-output-formats`: List of output formats to generate. *[choices: json, yaml, table, csv]* *[default: [json]]*
 * `--dry-run, --no-dry-run`: If True, simulate execution without making changes. *[default: False]*
 
 ### complex-cli data validate
@@ -89,7 +89,7 @@ Server management commands.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 ### complex-cli server start
@@ -109,7 +109,7 @@ Demonstrates Pydantic model support for CLI parameters.
 * `--server.workers INT`: Number of worker processes. *[default: 4]*
 * `--server.timeout FLOAT`: Request timeout in seconds. *[default: 30.0]*
 * `--server.debug, --server.no-debug`: Enable debug mode. *[default: False]*
-* `--auth.provider`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
+* `--auth.provider CHOICE`: Authentication provider type. *[choices: oauth2, jwt, basic, none]* *[default: jwt]*
 * `--auth.token-expiry INT`: Token expiration time in seconds. *[default: 3600]*
 * `--auth.refresh-enabled, --auth.no-refresh-enabled`: Enable token refresh. *[default: True]*
 * `--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins`: List of allowed CORS origins. *[default: ['*']]*

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_nested_directive_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_nested_directive_output.md
@@ -8,7 +8,7 @@ Administrative commands for system management.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 #### complex-cli admin users

--- a/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_simple_directive_output.md
+++ b/tests/__snapshots__/test_docs_snapshots/TestMkDocsDirectiveSnapshots.test_simple_directive_output.md
@@ -10,7 +10,7 @@ Complex CLI application for comprehensive documentation testing.
 
 * `--verbose, -v`: Verbosity level (-v, -vv, -vvv). *[default: 0]*
 * `--quiet, -q, --no-quiet`: Suppress non-essential output. *[default: False]*
-* `--log-level`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
+* `--log-level CHOICE`: Logging level. *[choices: debug, info, warning, error, critical]* *[default: info]*
 * `--no-color, --no-no-color`: Disable colored output *[default: False]*
 
 **Subcommands**:

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_admin_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_admin_commands_rst.rst
@@ -21,7 +21,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -97,7 +97,7 @@ Configure database settings.
 ``--password STR``
     Authentication password (optional).
 
-``--ssl-mode``
+``--ssl-mode CHOICE``
     SSL connection mode. [Choices: ``disable``, ``prefer``, ``require``, ``verify-full``, Default: ``prefer``]
 
 ``--pool-size INT``
@@ -170,7 +170,7 @@ Create a new user.
 
 **Parameters:**
 
-``--role``
+``--role CHOICE``
     User role assignment. [Choices: ``admin``, ``user``, ``guest``, Default: ``user``]
 
 ``--permissions.none, --permissions.no-none``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_data_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_data_commands_rst.rst
@@ -21,7 +21,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -74,16 +74,16 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 ``--batch-size INT``
     Number of items to process per batch. [Default: ``32``]
 
-``--num-workers INT``
+``--num-workers INT|CHOICE``
     Number of parallel workers. Use "auto" for automatic detection. [Choices: ``auto``, Default: ``auto``]
 
-``--quality-level INT``
+``--quality-level INT|CHOICE``
     Processing quality level. Higher values mean better quality but slower. [Choices: ``high``, ``medium``, ``low``, Default: ``high``]
 
-``--device INT``
+``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats, --empty-output-formats``
+``--output-formats LIST[CHOICE], --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--input-dir PATH``
@@ -132,16 +132,16 @@ PathConfig and ProcessingConfig).
 ``--batch-size INT``
     Number of items to process per batch. [Default: ``32``]
 
-``--num-workers INT``
+``--num-workers INT|CHOICE``
     Number of parallel workers. Use "auto" for automatic detection. [Choices: ``auto``, Default: ``auto``]
 
-``--quality-level INT``
+``--quality-level INT|CHOICE``
     Processing quality level. Higher values mean better quality but slower. [Choices: ``high``, ``medium``, ``low``, Default: ``high``]
 
-``--device INT``
+``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats, --empty-output-formats``
+``--output-formats LIST[CHOICE], --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--dry-run, --no-dry-run``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_data_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_data_commands_rst.rst
@@ -83,7 +83,7 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 ``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats LIST[CHOICE], --empty-output-formats``
+``--output-formats CHOICE..., --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--input-dir PATH``
@@ -141,7 +141,7 @@ PathConfig and ProcessingConfig).
 ``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats LIST[CHOICE], --empty-output-formats``
+``--output-formats CHOICE..., --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--dry-run, --no-dry-run``
@@ -171,5 +171,5 @@ Validate data files against schema.
 ``--schema-file PATH``
     Custom schema file (must exist).
 
-``--ignore-patterns LIST[STR], --empty-ignore-patterns``
+``--ignore-patterns STR..., --empty-ignore-patterns``
     Patterns to ignore during validation.

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_flattened_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_flattened_commands_rst.rst
@@ -21,7 +21,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -111,7 +111,7 @@ Create a new user.
 
 **Parameters:**
 
-``--role``
+``--role CHOICE``
     User role assignment. [Choices: ``admin``, ``user``, ``guest``, Default: ``user``]
 
 ``--permissions.none, --permissions.no-none``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_full_app_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_full_app_rst.rst
@@ -22,7 +22,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -159,7 +159,7 @@ Configure database settings.
 ``--password STR``
     Authentication password (optional).
 
-``--ssl-mode``
+``--ssl-mode CHOICE``
     SSL connection mode. [Choices: ``disable``, ``prefer``, ``require``, ``verify-full``, Default: ``prefer``]
 
 ``--pool-size INT``
@@ -232,7 +232,7 @@ Create a new user.
 
 **Parameters:**
 
-``--role``
+``--role CHOICE``
     User role assignment. [Choices: ``admin``, ``user``, ``guest``, Default: ``user``]
 
 ``--permissions.none, --permissions.no-none``
@@ -475,16 +475,16 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 ``--batch-size INT``
     Number of items to process per batch. [Default: ``32``]
 
-``--num-workers INT``
+``--num-workers INT|CHOICE``
     Number of parallel workers. Use "auto" for automatic detection. [Choices: ``auto``, Default: ``auto``]
 
-``--quality-level INT``
+``--quality-level INT|CHOICE``
     Processing quality level. Higher values mean better quality but slower. [Choices: ``high``, ``medium``, ``low``, Default: ``high``]
 
-``--device INT``
+``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats, --empty-output-formats``
+``--output-formats LIST[CHOICE], --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--input-dir PATH``
@@ -533,16 +533,16 @@ PathConfig and ProcessingConfig).
 ``--batch-size INT``
     Number of items to process per batch. [Default: ``32``]
 
-``--num-workers INT``
+``--num-workers INT|CHOICE``
     Number of parallel workers. Use "auto" for automatic detection. [Choices: ``auto``, Default: ``auto``]
 
-``--quality-level INT``
+``--quality-level INT|CHOICE``
     Processing quality level. Higher values mean better quality but slower. [Choices: ``high``, ``medium``, ``low``, Default: ``high``]
 
-``--device INT``
+``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats, --empty-output-formats``
+``--output-formats LIST[CHOICE], --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--dry-run, --no-dry-run``
@@ -623,7 +623,7 @@ Demonstrates Pydantic model support for CLI parameters.
 ``--server.debug, --server.no-debug``
     Enable debug mode. [Default: ``False``]
 
-``--auth.provider``
+``--auth.provider CHOICE``
     Authentication provider type. [Choices: ``oauth2``, ``jwt``, ``basic``, ``none``, Default: ``jwt``]
 
 ``--auth.token-expiry INT``
@@ -709,7 +709,7 @@ Demonstrates attrs class support for CLI parameters.
 
 **Parameters:**
 
-``--config.backend``
+``--config.backend CHOICE``
     Cache backend type. [Choices: ``memory``, ``redis``, ``memcached``, ``disk``, Default: ``memory``]
 
 ``--config.ttl INT``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_full_app_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_full_app_rst.rst
@@ -484,7 +484,7 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 ``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats LIST[CHOICE], --empty-output-formats``
+``--output-formats CHOICE..., --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--input-dir PATH``
@@ -542,7 +542,7 @@ PathConfig and ProcessingConfig).
 ``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats LIST[CHOICE], --empty-output-formats``
+``--output-formats CHOICE..., --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--dry-run, --no-dry-run``
@@ -572,7 +572,7 @@ Validate data files against schema.
 ``--schema-file PATH``
     Custom schema file (must exist).
 
-``--ignore-patterns LIST[STR], --empty-ignore-patterns``
+``--ignore-patterns STR..., --empty-ignore-patterns``
     Patterns to ignore during validation.
 
 .. _cyclopts-complex-cli-server:
@@ -632,7 +632,7 @@ Demonstrates Pydantic model support for CLI parameters.
 ``--auth.refresh-enabled, --auth.no-refresh-enabled``
     Enable token refresh. [Default: ``True``]
 
-``--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins``
+``--auth.allowed-origins STR..., --auth.empty-allowed-origins``
     List of allowed CORS origins. [Default: ``['*']``]
 
 .. _cyclopts-complex-cli-server-stop:

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_hidden_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_hidden_commands_rst.rst
@@ -21,7 +21,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_nested_permissions_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_nested_permissions_rst.rst
@@ -21,7 +21,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_server_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_server_commands_rst.rst
@@ -21,7 +21,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -80,7 +80,7 @@ Demonstrates Pydantic model support for CLI parameters.
 ``--server.debug, --server.no-debug``
     Enable debug mode. [Default: ``False``]
 
-``--auth.provider``
+``--auth.provider CHOICE``
     Authentication provider type. [Choices: ``oauth2``, ``jwt``, ``basic``, ``none``, Default: ``jwt``]
 
 ``--auth.token-expiry INT``

--- a/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_server_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestRstSnapshots.test_server_commands_rst.rst
@@ -89,7 +89,7 @@ Demonstrates Pydantic model support for CLI parameters.
 ``--auth.refresh-enabled, --auth.no-refresh-enabled``
     Enable token refresh. [Default: ``True``]
 
-``--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins``
+``--auth.allowed-origins STR..., --auth.empty-allowed-origins``
     List of allowed CORS origins. [Default: ``['*']``]
 
 .. _cyclopts-complex-cli-server-stop:

--- a/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_filtered_directive_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_filtered_directive_rst.rst
@@ -8,7 +8,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -91,7 +91,7 @@ Create a new user.
 
 **Parameters:**
 
-``--role``
+``--role CHOICE``
     User role assignment. [Choices: ``admin``, ``user``, ``guest``, Default: ``user``]
 
 ``--permissions.none, --permissions.no-none``

--- a/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_flattened_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_flattened_commands_rst.rst
@@ -8,7 +8,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -85,7 +85,7 @@ Create a new user.
 
 **Parameters:**
 
-``--role``
+``--role CHOICE``
     User role assignment. [Choices: ``admin``, ``user``, ``guest``, Default: ``user``]
 
 ``--permissions.none, --permissions.no-none``

--- a/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_nested_commands_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_nested_commands_rst.rst
@@ -8,7 +8,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``

--- a/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_simple_directive_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_simple_directive_rst.rst
@@ -8,7 +8,7 @@ Complex CLI application for comprehensive documentation testing.
 ``--quiet, -q, --no-quiet``
     Suppress non-essential output. [Default: ``False``]
 
-``--log-level``
+``--log-level CHOICE``
     Logging level. [Choices: ``debug``, ``info``, ``warning``, ``error``, ``critical``, Default: ``info``]
 
 ``--no-color, --no-no-color``
@@ -105,7 +105,7 @@ Configure database settings.
 ``--password STR``
     Authentication password (optional).
 
-``--ssl-mode``
+``--ssl-mode CHOICE``
     SSL connection mode. [Choices: ``disable``, ``prefer``, ``require``, ``verify-full``, Default: ``prefer``]
 
 ``--pool-size INT``
@@ -178,7 +178,7 @@ Create a new user.
 
 **Parameters:**
 
-``--role``
+``--role CHOICE``
     User role assignment. [Choices: ``admin``, ``user``, ``guest``, Default: ``user``]
 
 ``--permissions.none, --permissions.no-none``
@@ -419,16 +419,16 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 ``--batch-size INT``
     Number of items to process per batch. [Default: ``32``]
 
-``--num-workers INT``
+``--num-workers INT|CHOICE``
     Number of parallel workers. Use "auto" for automatic detection. [Choices: ``auto``, Default: ``auto``]
 
-``--quality-level INT``
+``--quality-level INT|CHOICE``
     Processing quality level. Higher values mean better quality but slower. [Choices: ``high``, ``medium``, ``low``, Default: ``high``]
 
-``--device INT``
+``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats, --empty-output-formats``
+``--output-formats LIST[CHOICE], --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--input-dir PATH``
@@ -477,16 +477,16 @@ PathConfig and ProcessingConfig).
 ``--batch-size INT``
     Number of items to process per batch. [Default: ``32``]
 
-``--num-workers INT``
+``--num-workers INT|CHOICE``
     Number of parallel workers. Use "auto" for automatic detection. [Choices: ``auto``, Default: ``auto``]
 
-``--quality-level INT``
+``--quality-level INT|CHOICE``
     Processing quality level. Higher values mean better quality but slower. [Choices: ``high``, ``medium``, ``low``, Default: ``high``]
 
-``--device INT``
+``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats, --empty-output-formats``
+``--output-formats LIST[CHOICE], --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--dry-run, --no-dry-run``
@@ -565,7 +565,7 @@ Demonstrates Pydantic model support for CLI parameters.
 ``--server.debug, --server.no-debug``
     Enable debug mode. [Default: ``False``]
 
-``--auth.provider``
+``--auth.provider CHOICE``
     Authentication provider type. [Choices: ``oauth2``, ``jwt``, ``basic``, ``none``, Default: ``jwt``]
 
 ``--auth.token-expiry INT``
@@ -649,7 +649,7 @@ Demonstrates attrs class support for CLI parameters.
 
 **Parameters:**
 
-``--config.backend``
+``--config.backend CHOICE``
     Cache backend type. [Choices: ``memory``, ``redis``, ``memcached``, ``disk``, Default: ``memory``]
 
 ``--config.ttl INT``

--- a/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_simple_directive_rst.rst
+++ b/tests/__snapshots__/test_docs_snapshots/TestSphinxDirectiveSnapshots.test_simple_directive_rst.rst
@@ -428,7 +428,7 @@ all fields from ProcessingConfig and PathConfig become CLI options.
 ``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats LIST[CHOICE], --empty-output-formats``
+``--output-formats CHOICE..., --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--input-dir PATH``
@@ -486,7 +486,7 @@ PathConfig and ProcessingConfig).
 ``--device CHOICE|INT``
     Computing device to use. Can be "cuda", "cpu", "auto", or a GPU index. [Choices: ``cuda``, ``cpu``, ``auto``, Default: ``auto``]
 
-``--output-formats LIST[CHOICE], --empty-output-formats``
+``--output-formats CHOICE..., --empty-output-formats``
     List of output formats to generate. [Choices: ``json``, ``yaml``, ``table``, ``csv``, Default: ``[json]``]
 
 ``--dry-run, --no-dry-run``
@@ -516,7 +516,7 @@ Validate data files against schema.
 ``--schema-file PATH``
     Custom schema file (must exist).
 
-``--ignore-patterns LIST[STR], --empty-ignore-patterns``
+``--ignore-patterns STR..., --empty-ignore-patterns``
     Patterns to ignore during validation.
 
 .. _cyclopts-complex-cli-server:
@@ -574,7 +574,7 @@ Demonstrates Pydantic model support for CLI parameters.
 ``--auth.refresh-enabled, --auth.no-refresh-enabled``
     Enable token refresh. [Default: ``True``]
 
-``--auth.allowed-origins LIST[STR], --auth.empty-allowed-origins``
+``--auth.allowed-origins STR..., --auth.empty-allowed-origins``
     List of allowed CORS origins. [Default: ``['*']``]
 
 .. _cyclopts-complex-cli-server-stop:

--- a/tests/apps/test_burgery.py
+++ b/tests/apps/test_burgery.py
@@ -70,7 +70,7 @@ def test_create_burger_help(console):
         │ --mustard --no-mustard  Add mustard. [default: True]               │
         │ --ketchup --no-ketchup  Add ketchup. [default: True]               │
         │ --mayo --no-mayo        [default: True]                            │
-        │ --custom LIST[STR]                                                 │
+        │ --custom STR...                                                    │
         │   --empty-custom                                                   │
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Toppings ─────────────────────────────────────────────────────────╮

--- a/tests/completion/test_behavior.py
+++ b/tests/completion/test_behavior.py
@@ -293,3 +293,27 @@ def test_behavior(
     assert not leaked, (
         f"[{scenario_id}] completions {leaked} should NOT have been offered. partial={partial!r} got={results!r}"
     )
+
+
+def test_get_completion_action_abstract_collections():
+    """Path elements inside abstract collections still resolve to FILES completion.
+
+    ``Container`` is the one collection origin that is not an ``Iterable`` subclass, so a
+    subclass-only check left ``Container[Path]`` at ``NONE`` instead of unwrapping to ``Path``.
+    """
+    from collections.abc import Collection, Container, MutableSequence, MutableSet, Set
+    from pathlib import Path
+
+    from cyclopts.completion._base import CompletionAction, get_completion_action
+
+    hints = [
+        list[Path],
+        set[Path],
+        Collection[Path],
+        MutableSequence[Path],
+        Set[Path],
+        MutableSet[Path],
+        Container[Path],
+    ]
+    for hint in hints:
+        assert get_completion_action(hint) == CompletionAction.FILES, hint

--- a/tests/completion/test_behavior.py
+++ b/tests/completion/test_behavior.py
@@ -296,12 +296,8 @@ def test_behavior(
 
 
 def test_get_completion_action_abstract_collections():
-    """Path elements inside abstract collections still resolve to FILES completion.
-
-    ``Container`` is the one collection origin that is not an ``Iterable`` subclass, so a
-    subclass-only check left ``Container[Path]`` at ``NONE`` instead of unwrapping to ``Path``.
-    """
-    from collections.abc import Collection, Container, MutableSequence, MutableSet, Set
+    """Path elements inside abstract collections still resolve to FILES completion."""
+    from collections.abc import Collection, MutableSequence, MutableSet, Set
     from pathlib import Path
 
     from cyclopts.completion._base import CompletionAction, get_completion_action
@@ -313,7 +309,6 @@ def test_get_completion_action_abstract_collections():
         MutableSequence[Path],
         Set[Path],
         MutableSet[Path],
-        Container[Path],
     ]
     for hint in hints:
         assert get_completion_action(hint) == CompletionAction.FILES, hint

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Literal, Optional, Union
 
 import pytest
 
-from cyclopts.annotations import contains_hint, get_hint_name, is_iterable_type, resolve
+from cyclopts.annotations import contains_hint, get_choices_from_hint, get_hint_name, is_iterable_type, resolve
 
 
 def test_resolve_annotated():
@@ -138,3 +138,25 @@ def test_get_annotated_discriminator_positive():
     from cyclopts.annotations import get_annotated_discriminator
 
     assert get_annotated_discriminator(Annotated[int, SimpleNamespace(discriminator="type")]) == "type"
+
+
+def test_get_choices_from_hint_abstract_collections():
+    """Abstract collections normalize to concrete containers, so their ``Literal`` element's choices must survive.
+
+    ``Container`` in particular is not an ``Iterable`` subclass, so it slips past subclass-based
+    iterable checks; membership in ``VARIADIC_COLLECTION_TYPES`` is what recognizes it here.
+    """
+    from collections.abc import Collection, Container, MutableSequence, MutableSet, Set
+
+    choice = Literal["fizz", "buzz"]
+    hints = [
+        list[choice],
+        set[choice],
+        Collection[choice],
+        MutableSequence[choice],
+        Set[choice],
+        MutableSet[choice],
+        Container[choice],
+    ]
+    for hint in hints:
+        assert get_choices_from_hint(hint, name_transform=lambda x: x) == ["fizz", "buzz"], hint

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -141,12 +141,8 @@ def test_get_annotated_discriminator_positive():
 
 
 def test_get_choices_from_hint_abstract_collections():
-    """Abstract collections normalize to concrete containers, so their ``Literal`` element's choices must survive.
-
-    ``Container`` in particular is not an ``Iterable`` subclass, so it slips past subclass-based
-    iterable checks; membership in ``VARIADIC_COLLECTION_TYPES`` is what recognizes it here.
-    """
-    from collections.abc import Collection, Container, MutableSequence, MutableSet, Set
+    """Abstract collections normalize to concrete containers, so their ``Literal`` element's choices must survive."""
+    from collections.abc import Collection, MutableSequence, MutableSet, Set
 
     choice = Literal["fizz", "buzz"]
     hints = [
@@ -156,7 +152,6 @@ def test_get_choices_from_hint_abstract_collections():
         MutableSequence[choice],
         Set[choice],
         MutableSet[choice],
-        Container[choice],
     ]
     for hint in hints:
         assert get_choices_from_hint(hint, name_transform=lambda x: x) == ["fizz", "buzz"], hint

--- a/tests/test_bind_empty_iterable.py
+++ b/tests/test_bind_empty_iterable.py
@@ -103,7 +103,6 @@ def test_abstract_iterable_consume_multiple_empty(app, hint, expected, assert_pa
         (collections.abc.Sequence[int], []),
         (collections.abc.MutableSequence[int], []),
         (collections.abc.Collection[int], []),
-        (collections.abc.Container[int], []),
         (collections.abc.Reversible[int], []),
         (collections.abc.Set[int], set()),
         (collections.abc.MutableSet[int], set()),

--- a/tests/test_bind_generic_class.py
+++ b/tests/test_bind_generic_class.py
@@ -160,10 +160,11 @@ def test_bind_generic_class_accepts_default_multiple_args(
         PRIORITY
 
         ╭─ Parameters ───────────────────────────────────────────────────────╮
-        │ *  COORDS.X --coords.x  [required]                                 │
-        │ *  COORDS.Y --coords.y  [required]                                 │
-        │ *  PRIORITY --priority  [required]                                 │
-        │    --coords.color       [choices: red, green, blue] [default: red] │
+        │ *  COORDS.X --coords.x    [required]                               │
+        │ *  COORDS.Y --coords.y    [required]                               │
+        │ *  PRIORITY --priority    [required]                               │
+        │    --coords.color CHOICE  [choices: red, green, blue] [default:    │
+        │                           red]                                     │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -358,13 +358,11 @@ def test_coerce_frozenset():
         (AbcMutableSet[str], {"123", "456"}),
         (AbcMutableSequence[str], ["123", "456"]),
         (AbcCollection[str], ["123", "456"]),
-        (AbcContainer[str], ["123", "456"]),
         (AbcReversible[str], ["123", "456"]),
         (AbcSet, {"123", "456"}),
         (AbcMutableSet, {"123", "456"}),
         (AbcMutableSequence, ["123", "456"]),
         (AbcCollection, ["123", "456"]),
-        (AbcContainer, ["123", "456"]),
         (AbcReversible, ["123", "456"]),
     ],
 )
@@ -376,6 +374,17 @@ def test_coerce_abstract_collection_types(hint, expected):
     """
     result = convert(hint, ["123", "456"])
     assert expected == result
+
+
+@pytest.mark.parametrize("hint", [AbcContainer[str], AbcContainer])
+def test_coerce_container_unsupported(hint):
+    """``Container`` only promises ``__contains__``, not iteration, so it is not a supported CLI collection type.
+
+    It falls through to the scalar-constructor path, which raises (the bind layer surfaces this as a
+    ``CoercionError``); it must not silently coerce to a ``list`` like the iterable abstract collections do.
+    """
+    with pytest.raises((CoercionError, TypeError)):
+        convert(hint, ["123", "456"])
 
 
 def test_coerce_literal():

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -3527,7 +3527,7 @@ def test_help_pydantic_dict_literal_choices(app, console):
         ╰────────────────────────────────────────────────────────────────────╯
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --models.{NAME}.level  verbosity level [choices: low, med, high]   │
-        │                        [default: low]                              │
+        │   CHOICE               [default: low]                              │
         ╰────────────────────────────────────────────────────────────────────╯
         """
     )

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -3340,7 +3340,7 @@ def test_help_pydantic_dict_list_basemodel_is_leaf(app, console):
         ╭─ Parameters ───────────────────────────────────────────────────────╮
         │ --models.{NAME}.path STR  path to data                             │
         │ --models.{NAME}.items     list of items [default: []]              │
-        │   LIST[INNER]                                                      │
+        │   INNER...                                                         │
         │   --models.{NAME}                                                  │
         │   .empty-items                                                     │
         ╰────────────────────────────────────────────────────────────────────╯

--- a/tests/test_help_metavar.py
+++ b/tests/test_help_metavar.py
@@ -296,7 +296,7 @@ def test_metavar_strips_nested_annotated(app):
 
 
 def test_metavar_choice_for_literal_and_enum(app):
-    """``Literal``/``Enum`` derive ``CHOICE`` (Click-style); shown only when the ``[choices]`` list is hidden."""
+    """``Literal``/``Enum`` derive ``CHOICE`` (Click-style), like every other value-consuming type."""
     from enum import Enum
 
     class Color(Enum):
@@ -318,7 +318,8 @@ def test_metavar_choice_for_literal_and_enum(app):
     assert color.metavar == "CHOICE"
     assert either.metavar == "CHOICE|INT"
     assert pair.metavar == "CHOICE INT"
-    assert shown.metavar is None
+    # A displayed ``[choices]`` list no longer suppresses the placeholder.
+    assert shown.metavar == "CHOICE"
     assert shown.choices == ("x", "y")
 
 
@@ -326,8 +327,7 @@ def test_metavar_choice_for_explicit_parameter_choices(app):
     """An explicit ``Parameter.choices`` derives ``CHOICE`` like ``Literal``/``Enum``, not the underlying type name.
 
     The choice list describes the value, so a plain ``int``/``str`` carrying ``choices``
-    shows ``CHOICE`` in usage and is suppressed in the panel (where ``[choices]`` is listed),
-    exactly like a ``Literal`` hint. With ``show_choices=False`` the placeholder stays ``CHOICE``.
+    shows ``CHOICE`` instead of ``INT``/``STR``, exactly like a ``Literal`` hint.
     """
 
     @app.default
@@ -341,12 +341,11 @@ def test_metavar_choice_for_explicit_parameter_choices(app):
         pass
 
     num, color, hidden, plain = _parameter_entries(app)
-    # Panel rows: the ``[choices]`` list stands in for the placeholder.
-    assert num.metavar is None
+    assert num.metavar == "CHOICE"
     assert num.choices == ("1", "2", "3")
-    assert color.metavar is None
+    assert color.metavar == "CHOICE"
     assert color.choices == ("red", "green")
-    # ``show_choices=False`` hides the list, so the ``CHOICE`` placeholder returns.
+    # ``show_choices=False`` hides the list but the ``CHOICE`` placeholder is unchanged.
     assert hidden.metavar == "CHOICE"
     # A plain type without choices is unaffected.
     assert plain.metavar == "INT"
@@ -382,8 +381,8 @@ def test_usage_wraps_choice_in_container_for_explicit_parameter_choices(app, con
     assert "Usage: test_help_metavar --a LIST[CHOICE] --b LIST[CHOICE]" in capture.get()
 
     a, b = _parameter_entries(app)
-    assert a.metavar is None
-    assert b.metavar is None
+    assert a.metavar == "LIST[CHOICE]"
+    assert b.metavar == "LIST[CHOICE]"
 
 
 def test_explicit_metavar_shown_alongside_choices(app, console: Console):
@@ -467,11 +466,12 @@ def test_usage_keeps_choice_metavar_for_required_choice_parameters(app, console:
         app.help_print(console=console)
     actual = capture.get()
     assert "Usage: test_help_metavar --color CHOICE --mode CHOICE --n INT" in actual
-    assert "--color  [choices: red, blue]" in actual
+    assert "--color CHOICE" in actual
+    assert "[choices: red, blue]" in actual
 
 
-def test_mixed_union_keeps_free_form_metavar_when_choices_shown(app):
-    """Only the choice half is dropped in favour of the ``[choices]`` list; ``INT`` still parses and still shows."""
+def test_mixed_union_renders_both_members(app):
+    """A ``Literal | int`` union renders both members (``CHOICE|INT``) alongside the ``[choices]`` list."""
 
     @app.default
     def main(*, mixed: Literal["auto"] | int = 1):
@@ -479,7 +479,7 @@ def test_mixed_union_keeps_free_form_metavar_when_choices_shown(app):
 
     (entry,) = _parameter_entries(app)
     assert entry.choices == ("auto",)
-    assert entry.metavar == "INT"
+    assert entry.metavar == "CHOICE|INT"
 
 
 def test_metavar_for_dict_with_accepts_keys_false(app, console: Console):
@@ -581,7 +581,7 @@ def test_metavar_strips_none_from_nested_unions(app):
 
     a, b = _parameter_entries(app)
     assert a.metavar == "LIST[INT]"
-    assert b.metavar is None
+    assert b.metavar == "LIST[CHOICE]"
 
 
 def test_metavar_honors_element_metavars_in_containers(app):

--- a/tests/test_help_metavar.py
+++ b/tests/test_help_metavar.py
@@ -573,19 +573,14 @@ def test_metavar_repeats_for_n_tokens(app):
 
 
 def test_metavar_n_tokens_descends_into_abstract_collections(app):
-    """Every ``VARIADIC_COLLECTION_TYPES`` origin descends to its element under ``n_tokens``.
-
-    ``Container`` is the one such origin that is not an ``Iterable`` subclass, so it slipped
-    past the ``is_iterable_type`` gate and rendered the whole ``STR...`` container per token
-    (``STR... STR...``) instead of the element (``STR STR``).
-    """
-    from collections.abc import Container
+    """An abstract collection descends to its element under ``n_tokens``, one placeholder per token."""
+    from collections.abc import Collection
 
     @app.default
     def main(
         *,
-        x: Annotated[Container[str], Parameter(n_tokens=2)],
-        y: Annotated[Container[str], Parameter(n_tokens=-1)],
+        x: Annotated[Collection[str], Parameter(n_tokens=2)],
+        y: Annotated[Collection[str], Parameter(n_tokens=-1)],
     ):
         pass
 

--- a/tests/test_help_metavar.py
+++ b/tests/test_help_metavar.py
@@ -572,6 +572,28 @@ def test_metavar_repeats_for_n_tokens(app):
     assert w.metavar == "INT INT INT"
 
 
+def test_metavar_n_tokens_descends_into_abstract_collections(app):
+    """Every ``VARIADIC_COLLECTION_TYPES`` origin descends to its element under ``n_tokens``.
+
+    ``Container`` is the one such origin that is not an ``Iterable`` subclass, so it slipped
+    past the ``is_iterable_type`` gate and rendered the whole ``STR...`` container per token
+    (``STR... STR...``) instead of the element (``STR STR``).
+    """
+    from collections.abc import Container
+
+    @app.default
+    def main(
+        *,
+        x: Annotated[Container[str], Parameter(n_tokens=2)],
+        y: Annotated[Container[str], Parameter(n_tokens=-1)],
+    ):
+        pass
+
+    x, y = _parameter_entries(app)
+    assert x.metavar == "STR STR"
+    assert y.metavar == "STR..."
+
+
 def test_metavar_strips_none_from_nested_unions(app):
     """``None`` inside a container element is never something the user types, so it is not advertised."""
 
@@ -1001,8 +1023,9 @@ def test_metavar_default_panel_rendering_unchanged(app, console: Console):
     assert "│ *  URL  [required]" in actual
     # Optional positional-or-keyword: name-derived label precedes the option name.
     assert "DEST --dest" in actual
-    # Keyword-only with choices: option name only; ``[choices]`` suppresses the metavar.
-    assert "│ --quality " in actual
+    # Keyword-only with choices: option name plus a ``CHOICE`` metavar, alongside ``[choices]``.
+    assert "--quality CHOICE" in actual
+    assert "[choices: 144, 720]" in actual
     assert "QUALITY" not in actual
     # Keyword-only boolean flag: negatives shown, never a label.
     assert "--flag --no-flag" in actual

--- a/tests/test_help_metavar.py
+++ b/tests/test_help_metavar.py
@@ -105,7 +105,7 @@ def test_metavar_tuple_renders_one_placeholder_per_token(app):
     "hint, expected",
     [
         (tuple[int, int] | str, "(INT INT)|STR"),
-        (list[int] | tuple[int, int], "LIST[INT]|(INT INT)"),
+        (list[int] | tuple[int, int], "INT...|(INT INT)"),
         (list[tuple[int, int] | str], "LIST[(INT INT)|STR]"),
         (list[tuple[int, ...]], "LIST[INT...]"),
         (dict[str, tuple[int, int]], "DICT[STR, (INT INT)]"),
@@ -113,7 +113,7 @@ def test_metavar_tuple_renders_one_placeholder_per_token(app):
     ],
 )
 def test_type_metavar_groups_multi_token_members(hint, expected):
-    """A tuple is always its tokens; it is parenthesized only when it sits beside siblings."""
+    """A single-token element collapses to ``X...``; a multi-token element keeps the ``LIST[...]`` form."""
     from cyclopts.help.help import _type_metavar
 
     assert _type_metavar(hint) == expected
@@ -292,7 +292,7 @@ def test_metavar_strips_nested_annotated(app):
         pass
 
     (ports,) = _parameter_entries(app)
-    assert ports.metavar == "LIST[PORT]"
+    assert ports.metavar == "PORT..."
 
 
 def test_metavar_choice_for_literal_and_enum(app):
@@ -378,11 +378,11 @@ def test_usage_wraps_choice_in_container_for_explicit_parameter_choices(app, con
 
     with console.capture() as capture:
         app.help_print(console=console)
-    assert "Usage: test_help_metavar --a LIST[CHOICE] --b LIST[CHOICE]" in capture.get()
+    assert "Usage: test_help_metavar --a CHOICE... --b CHOICE..." in capture.get()
 
     a, b = _parameter_entries(app)
-    assert a.metavar == "LIST[CHOICE]"
-    assert b.metavar == "LIST[CHOICE]"
+    assert a.metavar == "CHOICE..."
+    assert b.metavar == "CHOICE..."
 
 
 def test_explicit_metavar_shown_alongside_choices(app, console: Console):
@@ -580,8 +580,8 @@ def test_metavar_strips_none_from_nested_unions(app):
         pass
 
     a, b = _parameter_entries(app)
-    assert a.metavar == "LIST[INT]"
-    assert b.metavar == "LIST[CHOICE]"
+    assert a.metavar == "INT..."
+    assert b.metavar == "CHOICE..."
 
 
 def test_metavar_honors_element_metavars_in_containers(app):
@@ -594,7 +594,7 @@ def test_metavar_honors_element_metavars_in_containers(app):
 
     ports, emails, p = _parameter_entries(app)
     assert ports.metavar == "PORT PORT"
-    assert emails.metavar == "LIST[EMAIL]"
+    assert emails.metavar == "EMAIL..."
     assert p.metavar == "PORT"
 
 


### PR DESCRIPTION
Addresses both items from Rikiub's feedback on the metavar feature in [#885](https://github.com/BrianPugh/cyclopts/issues/885#issuecomment-5643310179).

## 1. Show `CHOICE` metavar for enum / `Literal` / explicit-choices parameters

Enum, `Literal`, and explicit-`Parameter.choices` parameters previously rendered a *blank* value placeholder in help panels (relying on the adjacent `[choices: ...]` list) while every other value-consuming type showed its type name (`PATH`, `STR`, `INT`, ...). This made choice parameters look inconsistent with the rest of the panel — and with the usage line, which already showed `CHOICE`.

Panels now show `CHOICE`, consistent with the usage line and every other type:

```
│ *  --codec-req CHOICE     required keyword enum [choices: av1, vp9, h264]    │
│    --codec CHOICE         enum via | None [choices: av1, vp9, h264]          │
│    --mode CHOICE          Literal via | None [choices: fast, slow]           │
│    --pick CHOICE          explicit Parameter.choices [choices: a, b]         │
```

Since panel and usage lines now render metavars identically, the vestigial `in_usage` suppression path and the `choice` threading through `_type_metavar` are removed.

## 2. Collapse variadic-collection metavars to `X...`

`list`, `set`, `frozenset`, `Sequence`, `Iterable`, and the other single-element iterables consume one value per CLI token — exactly like `tuple[X, ...]` — but rendered as `LIST[STR]` / `SET[STR]` / `SEQUENCE[STR]` / `ITERABLE[STR]` while `tuple[str, ...]` rendered `STR...`. Rikiub flagged this inconsistency directly.

A single-token element now collapses to `X...` for every variadic collection, matching `tuple`:

| type | before | after |
| --- | --- | --- |
| `list[str]` | `LIST[STR]` | `STR...` |
| `set[int]` | `SET[INT]` | `INT...` |
| `Sequence[str]` | `SEQUENCE[STR]` | `STR...` |
| `list[Literal["a","b"]]` | `LIST[CHOICE]` | `CHOICE...` |

A **multi-token** element keeps the `LIST[...]` form so its grouping stays unambiguous — `list[tuple[int, str]]` → `LIST[INT STR]`, not the ambiguous `INT STR...`; `list[tuple[int, ...]]` → `LIST[INT...]`. `dict` is unaffected (`DICT[STR, INT]`).

## 3. Recognize abstract collections consistently

The subsystems that reason about "is this a collection" disagreed on the abstract-collection ABCs. `_convert.py` normalizes `collections.abc.Collection` / `MutableSequence` / `Set` / ... to their concrete types (via `_abstract_to_concrete_type_mapping`), but the choices extractor and the shell-completion action detector both gated on plain `ITERABLE_TYPES` membership, so those abstract hints were silently missed:

- `Collection[Literal["a", "b"]]` advertised the `CHOICE` metavar but dropped its `[choices: a, b]` list.
- `Collection[Path]` (and the other abstract collections) offered no file completion.

Both now recognize the same set of collections the converter does, so an abstract hint behaves exactly like its concrete counterpart everywhere.

## 4. Drop speculative `Container` support (breaking)

`collections.abc.Container` was in the abstract-to-concrete mapping as a completeness follow-up (never user-requested). Unlike every other mapped ABC, `Container` only promises `__contains__` — it is *not* an `Iterable` subclass — so it fit neither the "collection of values" model the parser assumes nor the `Iterable`-based checks the rest of the code relies on, and it was the sole reason those checks needed special-casing.

`Container[...]` now raises (surfaced as a `CoercionError`) instead of quietly coercing to a `list`. With it gone, every remaining collection origin is an `Iterable` subclass, so the choices, metavar, and completion sites all reduce to a single `is_iterable_type` check — no per-type special cases. This only ever shipped in the v5 pre-releases, so no released version is affected.

## Notes

- Positional-capable rows are unaffected — they still show their name-derived identifier (`CODEC --codec`), not the metavar.

## Tests & docs

- Updated assertion tests that encoded the old behavior (`test_help_metavar.py`, `test_help.py`, `test_bind_generic_class.py`, `test_burgery.py`).
- Added regression coverage for abstract-collection choices/completion (`test_annotations.py`, `test_behavior.py`) and for the deliberate `Container` exclusion (`test_coercion.py`).
- Regenerated syrupy docs snapshots — all diffs are the metavar changes above.
- Docs updated (`help_customization.rst`, `api.rst`): dropped the obsolete panel-suppression explanation and documented the variadic-collection form.

Full suite: 3431 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QecYSBdMtW2ATDcV7Ac4ep
